### PR TITLE
feat: stable Scrivener identity and reorder reconciliation

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -69,6 +69,35 @@ Phase 1 continues using frontmatter as a bootstrap source when present. On the f
 
 If a scene file is deleted (in Scrivener), the sidecar is orphaned. On sync, the service detects `.meta.yaml` files with no corresponding `.md` and logs a warning. It does not auto-delete them — that is an explicit user action.
 
+### Design Decision: Stable Identity vs Mutable Order
+
+When Scrivener is the source of truth, binder order is mutable. Reordering scenes, moving a scene to another chapter, or restructuring acts should not create a new logical scene in `mcp-writing`.
+
+The service therefore needs to treat identity and position as separate concepts:
+
+- **External source identity:** a stable identifier supplied by the source tool. For Scrivener external sync, this should be the binder ID from the exported filename (the `[10]` portion of `011 Scene Sebastian [10].txt`), not the visible sequence prefix (`011`).
+- **Internal MCP identity:** a stable `scene_id` used by the index, sidecars, references, and tools.
+- **Mutable structural fields:** filename, path, `timeline_position`, `part`, `chapter`, and adjacent beat carry can all change over time without implying a new scene.
+
+This means a reorder in Scrivener should normally reconcile as an update, not an insertion:
+
+- same Scrivener binder ID
+- same internal `scene_id`
+- updated filename/path
+- updated `timeline_position`
+- possibly updated path-derived `part` / `chapter`
+
+Only ambiguous lifecycle events should require user review, for example:
+
+- a previously known external ID disappears entirely
+- an external ID remains but the prose/title changes so radically that a split/merge/replacement is plausible
+- two imported records claim the same external ID
+- a new scene appears with no known external ID match and no deterministic mapping
+
+**Design principle:** the service should reconcile simple reorder/move operations automatically, and escalate only when the source-of-truth change is ambiguous.
+
+For non-Scrivener projects, `scene_id` may still be user-authored and primary. The external/internal split is required specifically for importer-backed workflows where exported ordering is not stable.
+
 ---
 
 ## Content Structure
@@ -409,6 +438,9 @@ Passing an invalid FTS5 expression (e.g. an unmatched `"`) to `search_metadata` 
 
 **#9 — Unguarded IO errors in write tools when prose/character file has moved (resolved)**
 `update_scene_metadata`, `update_character_sheet`, and `flag_scene` previously let ENOENT and other IO errors throw as unhandled exceptions when the indexed file path was stale. All three now return a `STALE_PATH` error (with `indexed_path` detail) on ENOENT, and `IO_ERROR` for other failures, consistent with `get_scene_prose`.
+
+**#10 — Re-import after Scrivener reorder creates duplicate logical scenes (must fix)**
+The importer currently derives `scene_id` from the exported sequence prefix plus title (for example `011 Scene Sebastian [10].txt` → `sc-011-sebastian`). If the scene is later reordered in Scrivener and exported as `015 Scene Sebastian [10].txt`, the importer treats it as a new scene rather than the same scene at a new position. Re-importing into the same sync target can therefore leave both the old and new imported scenes on disk and in the index. The importer must reconcile by stable external source ID (Scrivener binder ID), not by current visible ordering.
 
 ---
 

--- a/metadata-lint.js
+++ b/metadata-lint.js
@@ -17,6 +17,8 @@ const threadLinkSchema = z.object({
 
 const sceneSchema = z.object({
   scene_id: z.string().min(1),
+  external_source: z.string().min(1).optional(),
+  external_id: z.string().min(1).optional(),
   title: z.string().min(1).optional(),
   part: z.number().int().positive().optional(),
   chapter: z.number().int().positive().optional(),

--- a/scripts/import.js
+++ b/scripts/import.js
@@ -14,12 +14,13 @@
  *   --dry-run         Show what would be created without writing anything
  *
  * What it does (Draft folder):
- *   - Walks the Draft dir in filename order (NNN prefix = binder sequence)
+ *   - Walks the Draft dir in filename order (NNN prefix = current binder sequence)
  *   - Skips empty files (non-compilation title cards) and Epigraphs
  *   - Detects Save the Cat beat markers ("-Beat Name-" empty files) and carries
  *     the beat name forward to the next prose scene's sidecar
  *   - Creates mcp-sync-dir/projects/<project>/scenes/ structure
- *   - Writes a .meta.yaml sidecar for each scene (skips files that already have one)
+ *   - Reconciles existing imports by stable Scrivener binder ID (`[123]` in the filename)
+ *   - Writes a .meta.yaml sidecar for each scene while preserving existing editorial metadata
  *
  * What it does (Notes folder):
  *   - Tracks section mode via empty top-level folder markers (Characters, Places, World...)
@@ -62,11 +63,16 @@ const placesDir = path.join(mcpSyncDir, "projects", projectId, "world", "places"
 // Helpers
 // ---------------------------------------------------------------------------
 
-// Parse "NNN Title [binder_id].txt" → { seq, rawTitle } or null
+// Parse "NNN Title [binder_id].txt" → { seq, rawTitle, binderId, ext } or null
 function parseFilename(filename) {
-  const m = filename.match(/^(\d+)\s+(.+?)\s*\[\d+\]\.(txt|md)$/);
+  const m = filename.match(/^(\d+)\s+(.+?)\s*\[(\d+)\]\.(txt|md)$/);
   if (!m) return null;
-  return { seq: parseInt(m[1], 10), rawTitle: m[2].trim() };
+  return {
+    seq: parseInt(m[1], 10),
+    rawTitle: m[2].trim(),
+    binderId: m[3],
+    ext: m[4],
+  };
 }
 
 function isBeatMarker(rawTitle) {
@@ -94,8 +100,8 @@ function slugify(str) {
     .slice(0, 50);
 }
 
-function makeSceneId(seq, title) {
-  return `sc-${String(seq).padStart(3, "0")}-${slugify(title).slice(0, 40)}`;
+function makeSceneId(binderId, title) {
+  return `sc-${String(binderId).padStart(3, "0")}-${slugify(title).slice(0, 40)}`;
 }
 
 function makeCharacterId(rawTitle) {
@@ -137,6 +143,51 @@ function walkSorted(dir) {
   return files.sort((a, b) => path.basename(a).localeCompare(path.basename(b)));
 }
 
+function loadYamlFile(filePath) {
+  try {
+    return yaml.load(fs.readFileSync(filePath, "utf8")) ?? {};
+  } catch {
+    return {};
+  }
+}
+
+function buildExistingSceneIndex(dir) {
+  const byBinderId = new Map();
+  if (!fs.existsSync(dir)) return byBinderId;
+
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (!entry.isFile() || !entry.name.endsWith(".meta.yaml")) continue;
+
+    const sidecarPath = path.join(dir, entry.name);
+    const proseCandidates = [
+      sidecarPath.replace(/\.meta\.yaml$/, ".txt"),
+      sidecarPath.replace(/\.meta\.yaml$/, ".md"),
+    ];
+    const prosePath = proseCandidates.find(candidate => fs.existsSync(candidate)) ?? null;
+    const proseName = prosePath ? path.basename(prosePath) : entry.name.replace(/\.meta\.yaml$/, ".txt");
+    const parsedName = parseFilename(proseName);
+    const meta = loadYamlFile(sidecarPath);
+    const binderId = meta.external_source === "scrivener" && meta.external_id
+      ? String(meta.external_id)
+      : parsedName?.binderId ?? null;
+
+    if (!binderId) continue;
+
+    byBinderId.set(String(binderId), {
+      binderId: String(binderId),
+      prosePath,
+      sidecarPath,
+      meta,
+    });
+  }
+
+  return byBinderId;
+}
+
+function removeIfExists(filePath) {
+  if (filePath && fs.existsSync(filePath)) fs.unlinkSync(filePath);
+}
+
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
@@ -149,6 +200,7 @@ const hasNotes = fs.existsSync(notesDir);
 const draftRoot = hasDraft ? draftDir : scrivenerDir;
 
 const files = walkSorted(draftRoot);
+const existingScenes = buildExistingSceneIndex(scenesDir);
 let created = 0;
 let skipped = 0;
 let alreadyDone = 0;
@@ -172,7 +224,7 @@ for (const file of files) {
     continue;
   }
 
-  const { seq, rawTitle } = parsed;
+  const { seq, rawTitle, binderId, ext } = parsed;
   const isEmpty = fs.statSync(file).size === 0;
 
   // Beat markers: always empty, carry beat name forward
@@ -197,20 +249,17 @@ for (const file of files) {
   }
 
   // Scene file — create sidecar
-  const title    = cleanTitle(rawTitle);
-  const sceneId  = makeSceneId(seq, title);
-  const destFile = path.join(scenesDir, filename);
-  const sidecar  = destFile.replace(/\.(txt|md)$/, ".meta.yaml");
-
-  if (fs.existsSync(sidecar)) {
-    console.log(`  SKIP  (sidecar exists) ${filename}`);
-    alreadyDone++;
-    beatCarry = null; // beat was consumed by an existing scene
-    continue;
-  }
+  const title = cleanTitle(rawTitle);
+  const existing = existingScenes.get(String(binderId)) ?? null;
+  const sceneId = existing?.meta?.scene_id ?? makeSceneId(binderId, title);
+  const destFile = path.join(scenesDir, `${seq.toString().padStart(3, "0")} ${rawTitle} [${binderId}].${ext}`);
+  const sidecar = destFile.replace(/\.(txt|md)$/, ".meta.yaml");
 
   const meta = {
+    ...(existing?.meta ?? {}),
     scene_id: sceneId,
+    external_source: "scrivener",
+    external_id: String(binderId),
     title,
     timeline_position: seq,
     ...(beatCarry ? { save_the_cat_beat: beatCarry } : {}),
@@ -224,20 +273,34 @@ for (const file of files) {
     // tags: [],
   };
 
+  if (!beatCarry && existing?.meta && Object.hasOwn(existing.meta, "save_the_cat_beat")) {
+    delete meta.save_the_cat_beat;
+  }
+
   if (dryRun) {
     console.log(`  DRY   ${path.basename(sidecar)}`);
+    if (existing) {
+      console.log(`        reconcile: binder ${binderId} -> existing scene_id ${sceneId}`);
+    }
     console.log(`        scene_id: ${sceneId}, beat: ${beatCarry ?? "(none)"}`);
   } else {
-    // Copy prose file into mcp-sync-dir scenes folder
-    if (!fs.existsSync(destFile)) {
-      fs.copyFileSync(file, destFile);
-    }
+    // Copy/update prose file in mcp-sync-dir scenes folder
+    fs.copyFileSync(file, destFile);
     fs.writeFileSync(sidecar, yaml.dump(meta, { lineWidth: 120 }), "utf8");
-    console.log(`  OK    ${path.basename(sidecar)}  [beat: ${beatCarry ?? "—"}]`);
+
+    if (existing) {
+      if (existing.prosePath && existing.prosePath !== destFile) removeIfExists(existing.prosePath);
+      if (existing.sidecarPath && existing.sidecarPath !== sidecar) removeIfExists(existing.sidecarPath);
+      console.log(`  OK    ${path.basename(sidecar)}  [reconciled binder ${binderId}, beat: ${beatCarry ?? "—"}]`);
+    } else {
+      console.log(`  OK    ${path.basename(sidecar)}  [beat: ${beatCarry ?? "—"}]`);
+    }
+    existingScenes.set(String(binderId), { binderId: String(binderId), prosePath: destFile, sidecarPath: sidecar, meta });
   }
 
   beatCarry = null; // consumed
-  created++;
+  if (existing) alreadyDone++;
+  else created++;
 }
 
 console.log(`\n${"─".repeat(50)}`);

--- a/test/unit.test.mjs
+++ b/test/unit.test.mjs
@@ -3,6 +3,8 @@ import assert from "node:assert/strict";
 import os from "node:os";
 import fs from "node:fs";
 import path from "node:path";
+import { spawnSync } from "node:child_process";
+import yaml from "js-yaml";
 import { checksumProse, walkFiles, walkSidecars, sidecarPath, inferProjectAndUniverse, inferScenePositionFromPath, isWorldFile, readMeta, isSyncDirWritable, syncAll } from "../sync.js";
 import { lintMetadataInSyncDir, validateMetadataObject } from "../metadata-lint.js";
 import { openDb } from "../db.js";
@@ -502,12 +504,103 @@ describe("syncAll", () => {
 });
 
 // ---------------------------------------------------------------------------
+// scripts/import.js
+// ---------------------------------------------------------------------------
+describe("Scrivener importer", () => {
+  function makeScrivenerExport() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "scrivener-export-"));
+    fs.mkdirSync(path.join(dir, "Draft"), { recursive: true });
+    fs.mkdirSync(path.join(dir, "Notes"), { recursive: true });
+    return dir;
+  }
+
+  function writeDraftFile(dir, filename, content = "Scene prose.") {
+    fs.writeFileSync(path.join(dir, "Draft", filename), content);
+  }
+
+  function runImporter(scrivenerDir, targetDir) {
+    const result = spawnSync(
+      process.execPath,
+      [path.join(process.cwd(), "scripts", "import.js"), scrivenerDir, targetDir, "--project", "test-import"],
+      { encoding: "utf8" }
+    );
+
+    if (result.status !== 0) {
+      throw new Error(`Importer failed: ${result.stderr || result.stdout}`);
+    }
+
+    return result.stdout;
+  }
+
+  test("writes stable external identity fields for imported scenes", () => {
+    const scrivenerDir = makeScrivenerExport();
+    const targetDir = fs.mkdtempSync(path.join(os.tmpdir(), "mcp-import-"));
+
+    writeDraftFile(scrivenerDir, "011 Scene Sebastian [10].txt", "Sebastian scene prose.");
+    runImporter(scrivenerDir, targetDir);
+
+    const sidecarPath = path.join(
+      targetDir,
+      "projects",
+      "test-import",
+      "scenes",
+      "011 Scene Sebastian [10].meta.yaml"
+    );
+    const meta = yaml.load(fs.readFileSync(sidecarPath, "utf8"));
+
+    assert.equal(meta.scene_id, "sc-010-sebastian");
+    assert.equal(meta.external_source, "scrivener");
+    assert.equal(meta.external_id, "10");
+    assert.equal(meta.timeline_position, 11);
+
+    fs.rmSync(scrivenerDir, { recursive: true, force: true });
+    fs.rmSync(targetDir, { recursive: true, force: true });
+  });
+
+  test("re-import after Scrivener reorder preserves scene identity and editorial metadata", () => {
+    const scrivenerDir = makeScrivenerExport();
+    const targetDir = fs.mkdtempSync(path.join(os.tmpdir(), "mcp-import-"));
+
+    writeDraftFile(scrivenerDir, "011 Scene Sebastian [10].txt", "First export prose.");
+    runImporter(scrivenerDir, targetDir);
+
+    const scenesDir = path.join(targetDir, "projects", "test-import", "scenes");
+    const originalSidecar = path.join(scenesDir, "011 Scene Sebastian [10].meta.yaml");
+    const originalMeta = yaml.load(fs.readFileSync(originalSidecar, "utf8"));
+    originalMeta.synopsis = "Keep this editorial synopsis.";
+    fs.writeFileSync(originalSidecar, yaml.dump(originalMeta, { lineWidth: 120 }), "utf8");
+
+    fs.rmSync(path.join(scrivenerDir, "Draft", "011 Scene Sebastian [10].txt"));
+    writeDraftFile(scrivenerDir, "015 Scene Sebastian [10].txt", "Reordered export prose.");
+
+    runImporter(scrivenerDir, targetDir);
+
+    const sceneFiles = fs.readdirSync(scenesDir).sort();
+    assert.deepEqual(sceneFiles, ["015 Scene Sebastian [10].meta.yaml", "015 Scene Sebastian [10].txt"]);
+
+    const reconciledMeta = yaml.load(
+      fs.readFileSync(path.join(scenesDir, "015 Scene Sebastian [10].meta.yaml"), "utf8")
+    );
+    assert.equal(reconciledMeta.scene_id, "sc-010-sebastian");
+    assert.equal(reconciledMeta.external_source, "scrivener");
+    assert.equal(reconciledMeta.external_id, "10");
+    assert.equal(reconciledMeta.timeline_position, 15);
+    assert.equal(reconciledMeta.synopsis, "Keep this editorial synopsis.");
+
+    fs.rmSync(scrivenerDir, { recursive: true, force: true });
+    fs.rmSync(targetDir, { recursive: true, force: true });
+  });
+});
+
+// ---------------------------------------------------------------------------
 // metadata-lint
 // ---------------------------------------------------------------------------
 describe("metadata lint", () => {
   test("validates scene metadata object schema", () => {
     const result = validateMetadataObject({
       scene_id: "sc-001",
+      external_source: "scrivener",
+      external_id: "10",
       title: "Arrival",
       part: 1,
       chapter: 1,


### PR DESCRIPTION
## Summary
- Add stable external scene identity for Scrivener imports (`external_source`, `external_id`)
- Reconcile re-imports by binder ID (`[n]`) so reordered scenes keep the same internal `scene_id`
- Preserve existing editorial metadata when a scene is reordered and re-imported
- Update metadata lint schema to allow external identity fields
- Add importer unit tests for identity stability and reorder reconciliation
- Document design plus edge case in PRD

## Why
Scrivener reorders renumber export prefixes (for example `011` to `015`) but should not create a new logical scene in mcp-writing.

## Validation
- `npm run lint`
- `npm test`
