### PR TITLE
chore: trigger CI for release-please branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - release-please--branches--**
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
## Summary
- run the CI workflow on pushes to `release-please--branches--**`
- keep the existing `pull_request` trigger for normal feature PRs

## Why
Release Please creates a same-repo branch and PR, but the PR can appear with no attached checks until another push hits that branch. By running CI on push for release-please branches, the required test contexts attach immediately to the release PR head SHA.

## Result
Future autorelease PRs should no longer get stuck in "pending required checks" with nothing running.
