### PR TITLE
fix: trigger CI checks on release-please PRs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,6 +14,7 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Use a PAT (or GitHub App token) so downstream CI workflows trigger on release PRs.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Summary
- switch release-please action token from `GITHUB_TOKEN` to `RELEASE_PLEASE_TOKEN`
- keep manifest-based release-please config as-is

## Why
PRs and branches created with `GITHUB_TOKEN` do not reliably trigger downstream workflows. Using a dedicated token allows required CI checks to attach automatically to release PRs.

## Required setup
- add repository secret `RELEASE_PLEASE_TOKEN` with a fine-grained PAT (repo contents + pull requests write)
