### PR TITLE
chore: enable auto-merge for Release Please version PRs

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,7 @@
     ".": {
       "release-type": "node",
       "include-component-in-tag": false,
+      "pull-request-auto-merge": true,
       "changelog-sections": [
         {
           "type": "feat",


### PR DESCRIPTION
## Summary

Automate the release workflow by enabling auto-merge for Release Please version bump PRs. This eliminates the need for manual approval on every version update.

## Changes

- Add `pull-request-auto-merge: true` to `release-please-config.json`
- Release Please will now automatically merge version bump PRs after CI passes
- The `publish.yml` workflow will be triggered automatically on tag creation

## Benefits

- Reduces friction in the release process
- Version bumps and tags are created without manual intervention  
- Keeps the workflow fully automated end-to-end
- Only applies to Release Please generated PRs, not custom PRs

## How it works

1. Commit pushed to main
2. Release Please detects conventional commits and creates a version bump PR
3. GitHub Actions runs tests on the PR
4. If tests pass, Release Please automatically merges the PR
5. The tag is created and publish workflow runs

The entire process is now automated.