### PR TITLE
fix: support legacy release token secret name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,11 +38,18 @@ jobs:
     if: "!startsWith(github.event.head_commit.message, 'Release ')"
 
     steps:
+      - name: Validate release token
+        run: |
+          if [ -z "${{ secrets.RELEASE_TOKEN }}" ] && [ -z "${{ secrets.RELEASE_PLEASE_TOKEN }}" ]; then
+            echo "Error: Neither RELEASE_TOKEN nor RELEASE_PLEASE_TOKEN is set."
+            exit 1
+          fi
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           # Use PAT so the push of the version bump commit/tag is allowed.
-          token: ${{ secrets.RELEASE_TOKEN }}
+          token: ${{ secrets.RELEASE_TOKEN || secrets.RELEASE_PLEASE_TOKEN }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -68,7 +75,7 @@ jobs:
             COMMITS=$(git log --pretty=format:"%s %b" "${LAST_TAG}..HEAD")
           fi
 
-          if echo "$COMMITS" | grep -qiE "(BREAKING CHANGE|!:)"; then
+          if echo "$COMMITS" | grep -qiE "(BREAKING CHANGE|!:)\"; then
             echo "increment=major" >> "$GITHUB_OUTPUT"
           elif echo "$COMMITS" | grep -qE "^feat(\(.+\))?[!]?:"; then
             echo "increment=minor" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
This PR adds support for both `RELEASE_TOKEN` and `RELEASE_PLEASE_TOKEN` secrets in the release workflow. It also adds a validation step to ensure at least one of these tokens is present.