### PR TITLE
fix: correct release increment regex quoting

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
             COMMITS=$(git log --pretty=format:"%s %b" "${LAST_TAG}..HEAD")
           fi
 
-          if echo "$COMMITS" | grep -qiE "(BREAKING CHANGE|!:)\"; then
+          if echo "$COMMITS" | grep -qiE "(BREAKING CHANGE|!:)"; then
             echo "increment=major" >> "$GITHUB_OUTPUT"
           elif echo "$COMMITS" | grep -qE "^feat(\(.+\))?[!]?:"; then
             echo "increment=minor" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
This PR fixes a malformed regex in the Determine version increment step of the release workflow. It unblocks the release workflow from syntax errors after merge.