### PR TITLE
fix: prevent stale release reruns from republishing tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
           # Use SSH deploy key so branch-rule bypass is scoped to deploy key actor.
           ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
           ssh-known-hosts: ${{ secrets.RELEASE_DEPLOY_KNOWN_HOSTS }}
@@ -70,6 +71,38 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Validate package version against latest tag
+        run: |
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          if [ -z "$LAST_TAG" ]; then
+            exit 0
+          fi
+
+          PACKAGE_VERSION=$(node -p "JSON.parse(require('fs').readFileSync('package.json', 'utf8')).version")
+          TAG_VERSION="${LAST_TAG#v}"
+
+          node <<'NODE' "$PACKAGE_VERSION" "$TAG_VERSION"
+          const [pkg, tag] = process.argv.slice(1);
+
+          function compareSemver(left, right) {
+            const leftParts = left.split('.').map(Number);
+            const rightParts = right.split('.').map(Number);
+            for (let index = 0; index < 3; index += 1) {
+              const delta = (leftParts[index] ?? 0) - (rightParts[index] ?? 0);
+              if (delta !== 0) return Math.sign(delta);
+            }
+            return 0;
+          }
+
+          const comparison = compareSemver(pkg, tag);
+          if (comparison < 0) {
+            console.error(`package.json version ${pkg} is behind latest tag ${tag}.`);
+            console.error('This usually means a stale workflow rerun after a tag was already published.');
+            console.error('Do not rerun the old release job; trigger release from current main instead.');
+            process.exit(1);
+          }
+          NODE
 
       - name: Determine version increment
         id: increment

--- a/README.md
+++ b/README.md
@@ -453,7 +453,7 @@ How it works:
 
 1. A PR is merged into `main`.
 2. `.github/workflows/release.yml` runs on that push.
-3. The workflow infers version bump type from commits since last tag:
+3. The workflow fetches tags and infers version bump type from commits since last tag:
   - `BREAKING CHANGE` or `!:` -> major
   - `feat:` -> minor
   - everything else -> patch
@@ -472,6 +472,12 @@ Local dry-run (optional):
 ```sh
 npm run release -- --ci --dry-run
 ```
+
+Operational note:
+
+- If a release job partially succeeds by pushing a tag before failing later, do not rerun that old workflow run.
+- The workflow now fails fast when `package.json` is behind the latest tag, which indicates a stale rerun.
+- In that case, trigger the next release from current `main` instead of retrying the old run.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
Harden the release workflow against stale reruns that try to publish an already-published version.

## Changes
- Fetch tags explicitly during release checkout
- Fail fast when package.json version is behind the latest tag
- Document the correct operator behavior in README

## Why
A previous release partially succeeded (tag/npm publish) and a rerun of the old workflow tried to publish the same version again. This change makes that failure mode explicit and prevents accidental duplicate publish attempts.
