### PR TITLE
fix: correct node argument handling in release version guard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,8 +82,8 @@ jobs:
           PACKAGE_VERSION=$(node -p "JSON.parse(require('fs').readFileSync('package.json', 'utf8')).version")
           TAG_VERSION="${LAST_TAG#v}"
 
-          node <<'NODE' "$PACKAGE_VERSION" "$TAG_VERSION"
-          const [pkg, tag] = process.argv.slice(1);
+          node - "$PACKAGE_VERSION" "$TAG_VERSION" <<'NODE'
+          const [pkg, tag] = process.argv.slice(2);
 
           function compareSemver(left, right) {
             const leftParts = left.split('.').map(Number);


### PR DESCRIPTION
This PR fixes the node argument handling in the release version guard step of the release workflow.