### PR TITLE
chore: show npm releases in Deployments

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,11 +8,15 @@ on:
 permissions:
   contents: read
   id-token: write
+  deployments: write
 
 jobs:
   publish:
     name: npm publish
     runs-on: ubuntu-latest
+    environment:
+      name: npm
+      url: https://www.npmjs.com/package/@hanna84/mcp-writing
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,15 +5,14 @@ on:
     tags:
       - 'v*.*.*'
 
-permissions:
-  contents: read
-  id-token: write
-  deployments: write
-
 jobs:
   publish:
     name: npm publish
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      deployments: write
     environment:
       name: npm
       url: https://www.npmjs.com/package/@hanna84/mcp-writing


### PR DESCRIPTION
## Summary
Attach npm publish runs to the `npm` GitHub Environment so releases appear in the Deployments UI.

## Changes
- Add `deployments: write` permission in publish workflow
- Configure publish job environment:
  - `name: npm`
  - `url: https://www.npmjs.com/package/@hanna84/mcp-writing`

## Notes
- Affects future publishes only (no historical backfill).
