### PR TITLE
chore: align Releases, tags, and deployments

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 concurrency:
   group: release
   cancel-in-progress: false
@@ -123,4 +126,6 @@ jobs:
           fi
 
       - name: Run release-it
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: npx release-it --ci --increment=${{ steps.increment.outputs.increment }}

--- a/.release-it.json
+++ b/.release-it.json
@@ -8,7 +8,7 @@
     "changelog": "npx auto-changelog --stdout --unreleased --commit-limit false -u --hide-credit"
   },
   "github": {
-    "release": false
+    "release": true
   },
   "npm": {
     "publish": false


### PR DESCRIPTION
## Summary
Align release surfaces so GitHub Releases, git tags, and npm deployment records stay in sync.

## Changes
- Enable GitHub Release creation in `.release-it.json` (`github.release: true`)
- Grant `contents: write` permission in release workflow
- Pass `GITHUB_TOKEN` to `release-it` for GitHub Release API calls

## Why
We observed tags/deployments advancing while the Releases page stayed on an older version. This change makes all release surfaces align for future versions.