### PR TITLE
docs: add status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,6 @@
 # mcp-writing
 
-[![CI](https://github.com/hannasdev/mcp-writing/actions/workflows/ci.yml/badge.svg)](https://github.com/hannasdev/mcp-writing/actions/workflows/ci.yml)
-[![Publish to npm](https://github.com/hannasdev/mcp-writing/actions/workflows/publish.yml/badge.svg)](https://github.com/hannasdev/mcp-writing/actions/workflows/publish.yml)
-[![GitHub release](https://img.shields.io/github/v/release/hannasdev/mcp-writing)](https://github.com/hannasdev/mcp-writing/releases)
-[![npm version](https://img.shields.io/npm/v/%40hanna84%2Fmcp-writing)](https://www.npmjs.com/package/@hanna84/mcp-writing)
-[![npm downloads](https://img.shields.io/npm/dm/%40hanna84%2Fmcp-writing)](https://www.npmjs.com/package/@hanna84/mcp-writing)
-[![Node.js](https://img.shields.io/badge/node-%3E%3D22.6.0-339933?logo=node.js&logoColor=white)](https://nodejs.org/)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![CI](https://github.com/hannasdev/mcp-writing/actions/workflows/ci.yml/badge.svg)](https://github.com/hannasdev/mcp-writing/actions/workflows/ci.yml) [![Publish to npm](https://github.com/hannasdev/mcp-writing/actions/workflows/publish.yml/badge.svg)](https://github.com/hannasdev/mcp-writing/actions/workflows/publish.yml) [![GitHub release](https://img.shields.io/github/v/release/hannasdev/mcp-writing)](https://github.com/hannasdev/mcp-writing/releases) [![npm version](https://img.shields.io/npm/v/%40hanna84%2Fmcp-writing)](https://www.npmjs.com/package/@hanna84/mcp-writing) [![npm downloads](https://img.shields.io/npm/dm/%40hanna84%2Fmcp-writing)](https://www.npmjs.com/package/@hanna84/mcp-writing) [![Node.js](https://img.shields.io/badge/node-%3E%3D22.6.0-339933?logo=node.js&logoColor=white)](https://nodejs.org/) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 An MCP service for AI-assisted reasoning and editing on long-form fiction projects.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # mcp-writing
 
+[![CI](https://github.com/hannasdev/mcp-writing/actions/workflows/ci.yml/badge.svg)](https://github.com/hannasdev/mcp-writing/actions/workflows/ci.yml)
+[![Publish to npm](https://github.com/hannasdev/mcp-writing/actions/workflows/publish.yml/badge.svg)](https://github.com/hannasdev/mcp-writing/actions/workflows/publish.yml)
+[![GitHub release](https://img.shields.io/github/v/release/hannasdev/mcp-writing)](https://github.com/hannasdev/mcp-writing/releases)
+[![npm version](https://img.shields.io/npm/v/%40hanna84%2Fmcp-writing)](https://www.npmjs.com/package/@hanna84/mcp-writing)
+[![npm](https://img.shields.io/npm/dm/%40hanna84%2Fmcp-writing)](https://www.npmjs.com/package/@hanna84/mcp-writing)
+[![Node.js](https://img.shields.io/badge/node-%3E%3D22.6.0-339933?logo=node.js&logoColor=white)](https://nodejs.org/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
 An MCP service for AI-assisted reasoning and editing on long-form fiction projects.
 
 Designed to work with [OpenClaw](https://github.com/openclaw/openclaw) but compatible with any MCP-capable AI gateway.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Publish to npm](https://github.com/hannasdev/mcp-writing/actions/workflows/publish.yml/badge.svg)](https://github.com/hannasdev/mcp-writing/actions/workflows/publish.yml)
 [![GitHub release](https://img.shields.io/github/v/release/hannasdev/mcp-writing)](https://github.com/hannasdev/mcp-writing/releases)
 [![npm version](https://img.shields.io/npm/v/%40hanna84%2Fmcp-writing)](https://www.npmjs.com/package/@hanna84/mcp-writing)
-[![npm](https://img.shields.io/npm/dm/%40hanna84%2Fmcp-writing)](https://www.npmjs.com/package/@hanna84/mcp-writing)
+[![npm downloads](https://img.shields.io/npm/dm/%40hanna84%2Fmcp-writing)](https://www.npmjs.com/package/@hanna84/mcp-writing)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D22.6.0-339933?logo=node.js&logoColor=white)](https://nodejs.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 


### PR DESCRIPTION
## Summary
Add a status badge strip to README for quick project health visibility.

## Added badges
- CI workflow status
- Publish to npm workflow status
- Latest GitHub release
- npm version
- npm downloads
- Node.js version support
- MIT license
