### PR TITLE
fix: avoid nested scenes/projects paths on import

### DIFF
--- a/importer.js
+++ b/importer.js
@@ -129,6 +129,41 @@ function removeIfExists(filePath) {
   if (filePath && fs.existsSync(filePath)) fs.unlinkSync(filePath);
 }
 
+function detectScopedSyncDir(syncDirAbs) {
+  const normalized = syncDirAbs.split(path.sep).join("/");
+
+  const universeMatch = normalized.match(/^(.*)\/universes\/([^/]+)\/([^/]+)(?:\/scenes)?$/);
+  if (universeMatch) {
+    const prefix = universeMatch[1] || path.parse(syncDirAbs).root;
+    const universeId = universeMatch[2];
+    const projectSlug = universeMatch[3];
+    const syncRoot = path.resolve(prefix || path.parse(syncDirAbs).root);
+    const projectRoot = path.join(syncRoot, "universes", universeId, projectSlug);
+    return {
+      projectId: `${universeId}/${projectSlug}`,
+      scope: "universe",
+      syncRoot,
+      projectRoot,
+    };
+  }
+
+  const projectMatch = normalized.match(/^(.*)\/projects\/([^/]+)(?:\/scenes)?$/);
+  if (projectMatch) {
+    const prefix = projectMatch[1] || path.parse(syncDirAbs).root;
+    const projectSlug = projectMatch[2];
+    const syncRoot = path.resolve(prefix || path.parse(syncDirAbs).root);
+    const projectRoot = path.join(syncRoot, "projects", projectSlug);
+    return {
+      projectId: projectSlug,
+      scope: "project",
+      syncRoot,
+      projectRoot,
+    };
+  }
+
+  return null;
+}
+
 export function importScrivenerSync({
   scrivenerDir,
   mcpSyncDir,
@@ -138,31 +173,48 @@ export function importScrivenerSync({
 }) {
   const scrivenerDirAbs = path.resolve(scrivenerDir);
   const mcpSyncDirAbs = path.resolve(mcpSyncDir);
+  const scopedSyncDir = detectScopedSyncDir(mcpSyncDirAbs);
+  const fallbackProjectId = path.basename(mcpSyncDirAbs).replace(/[^a-z0-9-]/gi, "-").toLowerCase();
   const resolvedProjectId = projectId
     ? projectId
-    : path.basename(mcpSyncDirAbs).replace(/[^a-z0-9-]/gi, "-").toLowerCase();
+    : scopedSyncDir?.projectId ?? fallbackProjectId;
 
   const projectIdCheck = validateProjectId(resolvedProjectId);
   if (!projectIdCheck.ok) {
     throw new Error(`Invalid project_id '${resolvedProjectId}': ${projectIdCheck.reason}`);
   }
 
+  if (scopedSyncDir && projectId && projectId !== scopedSyncDir.projectId) {
+    throw new Error(
+      `project_id '${projectId}' does not match WRITING_SYNC_DIR scope '${scopedSyncDir.projectId}'. `
+      + "Set WRITING_SYNC_DIR to the sync root or use the matching project_id."
+    );
+  }
+
   if (!fs.existsSync(scrivenerDirAbs)) {
     throw new Error(`Scrivener sync dir not found: ${scrivenerDirAbs}`);
   }
 
-  // Route universe/project IDs to universes/<universe>/<project>/scenes,
-  // matching the convention used by inferProjectAndUniverse in sync.js.
-  const segments = resolvedProjectId.split("/");
   let scenesDir;
   let scenesBoundaryRoot;
-  if (segments.length === 2) {
-    const [universeId, projectSlug] = segments;
-    scenesBoundaryRoot = path.join(mcpSyncDirAbs, "universes");
-    scenesDir = path.resolve(scenesBoundaryRoot, universeId, projectSlug, "scenes");
+  if (scopedSyncDir) {
+    scenesBoundaryRoot = path.join(
+      scopedSyncDir.syncRoot,
+      scopedSyncDir.scope === "universe" ? "universes" : "projects"
+    );
+    scenesDir = path.join(scopedSyncDir.projectRoot, "scenes");
   } else {
-    scenesBoundaryRoot = path.join(mcpSyncDirAbs, "projects");
-    scenesDir = path.resolve(scenesBoundaryRoot, resolvedProjectId, "scenes");
+    // Route universe/project IDs to universes/<universe>/<project>/scenes,
+    // matching the convention used by inferProjectAndUniverse in sync.js.
+    const segments = resolvedProjectId.split("/");
+    if (segments.length === 2) {
+      const [universeId, projectSlug] = segments;
+      scenesBoundaryRoot = path.join(mcpSyncDirAbs, "universes");
+      scenesDir = path.resolve(scenesBoundaryRoot, universeId, projectSlug, "scenes");
+    } else {
+      scenesBoundaryRoot = path.join(mcpSyncDirAbs, "projects");
+      scenesDir = path.resolve(scenesBoundaryRoot, resolvedProjectId, "scenes");
+    }
   }
 
   const relFromBoundary = path.relative(scenesBoundaryRoot, scenesDir);

--- a/importer.js
+++ b/importer.js
@@ -129,15 +129,31 @@ function removeIfExists(filePath) {
   if (filePath && fs.existsSync(filePath)) fs.unlinkSync(filePath);
 }
 
+function resolveSyncRootFromPrefix(prefix, syncDirAbs) {
+  const parsedRoot = path.parse(syncDirAbs).root;
+
+  if (!prefix) {
+    return parsedRoot ? path.resolve(parsedRoot) : path.resolve(syncDirAbs);
+  }
+
+  // On Windows, a regex prefix like "C:" would resolve relative to cwd on drive C.
+  // Use the true drive root instead (e.g., "C:\\").
+  if (/^[a-zA-Z]:$/.test(prefix)) {
+    return parsedRoot || `${prefix}${path.sep}`;
+  }
+
+  return path.resolve(prefix);
+}
+
 function detectScopedSyncDir(syncDirAbs) {
   const normalized = syncDirAbs.split(path.sep).join("/");
 
   const universeMatch = normalized.match(/^(.*)\/universes\/([^/]+)\/([^/]+)(?:\/scenes)?$/);
   if (universeMatch) {
-    const prefix = universeMatch[1] || path.parse(syncDirAbs).root;
+    const prefix = universeMatch[1];
     const universeId = universeMatch[2];
     const projectSlug = universeMatch[3];
-    const syncRoot = path.resolve(prefix || path.parse(syncDirAbs).root);
+    const syncRoot = resolveSyncRootFromPrefix(prefix, syncDirAbs);
     const projectRoot = path.join(syncRoot, "universes", universeId, projectSlug);
     return {
       projectId: `${universeId}/${projectSlug}`,
@@ -149,9 +165,9 @@ function detectScopedSyncDir(syncDirAbs) {
 
   const projectMatch = normalized.match(/^(.*)\/projects\/([^/]+)(?:\/scenes)?$/);
   if (projectMatch) {
-    const prefix = projectMatch[1] || path.parse(syncDirAbs).root;
+    const prefix = projectMatch[1];
     const projectSlug = projectMatch[2];
-    const syncRoot = path.resolve(prefix || path.parse(syncDirAbs).root);
+    const syncRoot = resolveSyncRootFromPrefix(prefix, syncDirAbs);
     const projectRoot = path.join(syncRoot, "projects", projectSlug);
     return {
       projectId: projectSlug,

--- a/test/unit.test.mjs
+++ b/test/unit.test.mjs
@@ -22,6 +22,7 @@ import {
 } from "../sync.js";
 import { lintMetadataInSyncDir, validateMetadataObject } from "../metadata-lint.js";
 import { openDb } from "../db.js";
+import { importScrivenerSync } from "../importer.js";
 
 // ---------------------------------------------------------------------------
 // checksumProse
@@ -558,6 +559,82 @@ describe("syncAll", () => {
 
     db.close();
     fs.rmSync(dir, { recursive: true });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// importer path resolution
+// ---------------------------------------------------------------------------
+describe("importScrivenerSync", () => {
+  function createScrivenerDraftFixture() {
+    const scrivDir = fs.mkdtempSync(path.join(os.tmpdir(), "scriv-import-"));
+    fs.mkdirSync(path.join(scrivDir, "Draft"), { recursive: true });
+    fs.writeFileSync(
+      path.join(scrivDir, "Draft", "001 Scene The Arrival [1].txt"),
+      "Elena steps out into the rain.",
+      "utf8"
+    );
+    return scrivDir;
+  }
+
+  test("writes into existing universe project scenes path when WRITING_SYNC_DIR points there", () => {
+    const syncRoot = fs.mkdtempSync(path.join(os.tmpdir(), "sync-root-"));
+    const scopedSyncDir = path.join(syncRoot, "universes", "universe-1", "book-1-the-lamb", "scenes");
+    const scrivDir = createScrivenerDraftFixture();
+
+    const result = importScrivenerSync({
+      scrivenerDir: scrivDir,
+      mcpSyncDir: scopedSyncDir,
+      projectId: "universe-1/book-1-the-lamb",
+      dryRun: false,
+    });
+
+    assert.equal(result.projectId, "universe-1/book-1-the-lamb");
+    assert.equal(result.scenesDir, scopedSyncDir);
+    assert.ok(fs.existsSync(path.join(scopedSyncDir, "001 Scene The Arrival [1].meta.yaml")));
+
+    // Regression guard: ensure no nested projects/<id>/scenes path is created inside scenes/
+    assert.equal(fs.existsSync(path.join(scopedSyncDir, "projects", "universe-1", "scenes")), false);
+
+    fs.rmSync(syncRoot, { recursive: true, force: true });
+    fs.rmSync(scrivDir, { recursive: true, force: true });
+  });
+
+  test("infers scoped project_id from WRITING_SYNC_DIR when omitted", () => {
+    const syncRoot = fs.mkdtempSync(path.join(os.tmpdir(), "sync-root-"));
+    const scopedProjectDir = path.join(syncRoot, "universes", "universe-1", "book-1-the-lamb");
+    const scrivDir = createScrivenerDraftFixture();
+
+    const result = importScrivenerSync({
+      scrivenerDir: scrivDir,
+      mcpSyncDir: scopedProjectDir,
+      dryRun: true,
+    });
+
+    assert.equal(result.projectId, "universe-1/book-1-the-lamb");
+    assert.equal(result.scenesDir, path.join(scopedProjectDir, "scenes"));
+
+    fs.rmSync(syncRoot, { recursive: true, force: true });
+    fs.rmSync(scrivDir, { recursive: true, force: true });
+  });
+
+  test("fails when provided project_id conflicts with scoped WRITING_SYNC_DIR", () => {
+    const syncRoot = fs.mkdtempSync(path.join(os.tmpdir(), "sync-root-"));
+    const scopedProjectDir = path.join(syncRoot, "universes", "universe-1", "book-1-the-lamb");
+    const scrivDir = createScrivenerDraftFixture();
+
+    assert.throws(
+      () => importScrivenerSync({
+        scrivenerDir: scrivDir,
+        mcpSyncDir: scopedProjectDir,
+        projectId: "universe-1/other-book",
+        dryRun: true,
+      }),
+      /does not match WRITING_SYNC_DIR scope/
+    );
+
+    fs.rmSync(syncRoot, { recursive: true, force: true });
+    fs.rmSync(scrivDir, { recursive: true, force: true });
   });
 });
 

--- a/test/unit.test.mjs
+++ b/test/unit.test.mjs
@@ -593,8 +593,11 @@ describe("importScrivenerSync", () => {
     assert.equal(result.scenesDir, scopedSyncDir);
     assert.ok(fs.existsSync(path.join(scopedSyncDir, "001 Scene The Arrival [1].meta.yaml")));
 
-    // Regression guard: ensure no nested projects/<id>/scenes path is created inside scenes/
-    assert.equal(fs.existsSync(path.join(scopedSyncDir, "projects", "universe-1", "scenes")), false);
+    // Regression guard: ensure no nested universes/<id>/<project>/scenes path is created inside scenes/
+    assert.equal(
+      fs.existsSync(path.join(scopedSyncDir, "universes", "universe-1", "book-1-the-lamb", "scenes")),
+      false
+    );
 
     fs.rmSync(syncRoot, { recursive: true, force: true });
     fs.rmSync(scrivDir, { recursive: true, force: true });
@@ -631,6 +634,58 @@ describe("importScrivenerSync", () => {
         dryRun: true,
       }),
       /does not match WRITING_SYNC_DIR scope/
+    );
+
+    fs.rmSync(syncRoot, { recursive: true, force: true });
+    fs.rmSync(scrivDir, { recursive: true, force: true });
+  });
+
+  test("writes into existing project root path when WRITING_SYNC_DIR points to projects/<project>", () => {
+    const syncRoot = fs.mkdtempSync(path.join(os.tmpdir(), "sync-root-"));
+    const scopedProjectDir = path.join(syncRoot, "projects", "book-1-the-lamb");
+    const scrivDir = createScrivenerDraftFixture();
+
+    const result = importScrivenerSync({
+      scrivenerDir: scrivDir,
+      mcpSyncDir: scopedProjectDir,
+      projectId: "book-1-the-lamb",
+      dryRun: false,
+    });
+
+    assert.equal(result.projectId, "book-1-the-lamb");
+    assert.equal(result.scenesDir, path.join(scopedProjectDir, "scenes"));
+    assert.ok(fs.existsSync(path.join(scopedProjectDir, "scenes", "001 Scene The Arrival [1].meta.yaml")));
+
+    // Regression guard: ensure no nested projects/<project>/scenes path is created inside scoped project path.
+    assert.equal(
+      fs.existsSync(path.join(scopedProjectDir, "projects", "book-1-the-lamb", "scenes")),
+      false
+    );
+
+    fs.rmSync(syncRoot, { recursive: true, force: true });
+    fs.rmSync(scrivDir, { recursive: true, force: true });
+  });
+
+  test("writes into existing project scenes path when WRITING_SYNC_DIR points to projects/<project>/scenes", () => {
+    const syncRoot = fs.mkdtempSync(path.join(os.tmpdir(), "sync-root-"));
+    const scopedScenesDir = path.join(syncRoot, "projects", "book-1-the-lamb", "scenes");
+    const scrivDir = createScrivenerDraftFixture();
+
+    const result = importScrivenerSync({
+      scrivenerDir: scrivDir,
+      mcpSyncDir: scopedScenesDir,
+      projectId: "book-1-the-lamb",
+      dryRun: false,
+    });
+
+    assert.equal(result.projectId, "book-1-the-lamb");
+    assert.equal(result.scenesDir, scopedScenesDir);
+    assert.ok(fs.existsSync(path.join(scopedScenesDir, "001 Scene The Arrival [1].meta.yaml")));
+
+    // Regression guard: ensure no nested projects/<project>/scenes path is created inside scoped scenes path.
+    assert.equal(
+      fs.existsSync(path.join(scopedScenesDir, "projects", "book-1-the-lamb", "scenes")),
+      false
     );
 
     fs.rmSync(syncRoot, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- fix import path resolution when WRITING_SYNC_DIR points to a scoped project path (project root or scenes dir)
- infer scoped project_id from WRITING_SYNC_DIR when omitted
- reject conflicting explicit project_id for scoped WRITING_SYNC_DIR
- add unit tests to prevent regressions in nested-path behavior

## Validation
- npm run lint
- npm test