### PR TITLE
feat: add permission preflight diagnostics and ops contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ Paginated tools (`find_scenes`, `get_arc`, `list_threads`, `get_thread_arc`, `se
 # docker-compose.yml snippet
 writing-mcp:
   build: .
-  user: "${UID}:${GID}"
+  user: "${UID:-1000}:${GID:-1000}"
   environment:
     WRITING_SYNC_DIR: /sync
     DB_PATH: /data/writing.db
@@ -356,6 +356,8 @@ writing-mcp:
 volumes:
   writing-mcp-data:
 ```
+
+If you want explicit host mapping, set `UID` and `GID` in your shell or a `.env` file next to `docker-compose.yml`.
 
 Then register in your OpenClaw config:
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,24 @@ npm --version     # should be 8.0.0 or later
 git --version     # should be installed
 ```
 
+## Permission Contract (Recommended For All Users)
+
+To keep MCP write tools reliable across local runs, Docker, and AI agents, use this contract:
+
+1. The same non-root user should own and write the sync directory.
+2. Containerized runs should use host UID/GID, not root.
+3. If ownership drifts (for example root-owned files), repair once on host and continue.
+
+Repair commands (host):
+
+```sh
+sudo chown -R "$(id -u):$(id -g)" /path/to/sync-dir
+find /path/to/sync-dir -type d -exec chmod u+rwx {} +
+find /path/to/sync-dir -type f -exec chmod u+rw {} +
+```
+
+You can also inspect ownership/writability status at runtime via `get_runtime_config`.
+
 ## First-time setup path (recommended)
 
 If this is your first time, follow these steps in order:
@@ -321,6 +339,7 @@ Paginated tools (`find_scenes`, `get_arc`, `list_threads`, `get_thread_arc`, `se
 # docker-compose.yml snippet
 writing-mcp:
   build: .
+  user: "${UID}:${GID}"
   environment:
     WRITING_SYNC_DIR: /sync
     DB_PATH: /data/writing.db

--- a/index.js
+++ b/index.js
@@ -272,7 +272,7 @@ function getRuntimeDiagnostics() {
       `Repair ownership once on host: sudo chown -R "$(id -u):$(id -g)" "${SYNC_DIR_ABS}"`
     );
     recommendations.push(
-      "For Docker, run container as host user (compose: user: \"${UID}:${GID}\") to prevent root-owned sync files."
+      "For Docker, run container as host user (compose: user: \"${UID:-1000}:${GID:-1000}\"). Optionally set UID/GID explicitly in a .env file."
     );
   }
 

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ import matter from "gray-matter";
 import yaml from "js-yaml";
 import { z } from "zod";
 import { openDb } from "./db.js";
-import { syncAll, isSyncDirWritable, writeMeta, readMeta, indexSceneFile, normalizeSceneMetaForPath, sidecarPath } from "./sync.js";
+import { syncAll, isSyncDirWritable, getSyncOwnershipDiagnostics, writeMeta, readMeta, indexSceneFile, normalizeSceneMetaForPath, sidecarPath } from "./sync.js";
 import { isGitAvailable, isGitRepository, initGitRepository, createSnapshot, listSnapshots, getSceneProseAtCommit } from "./git.js";
 import { renderCharacterArcTemplate, renderCharacterSheetTemplate, renderPlaceSheetTemplate, slugifyEntityName } from "./world-entity-templates.js";
 import { importScrivenerSync, validateProjectId } from "./importer.js";
@@ -220,6 +220,7 @@ process.stderr.write(`[mcp-writing] DB path: ${DB_PATH_DISPLAY}\n`);
 
 // Check sync dir writability once at startup (needed for Phase 2 sidecar writes)
 const SYNC_DIR_WRITABLE = isSyncDirWritable(SYNC_DIR);
+const SYNC_OWNERSHIP_DIAGNOSTICS = getSyncOwnershipDiagnostics(SYNC_DIR);
 if (!SYNC_DIR_WRITABLE) {
   process.stderr.write(`[mcp-writing] WARNING: sync dir is not writable — sidecar auto-migration and metadata write-back will be unavailable\n`);
 }
@@ -261,6 +262,24 @@ function getRuntimeDiagnostics() {
     warnings.push("SYNC_DIR_READ_ONLY: sync dir is read-only; metadata write-back and prose editing tools are unavailable.");
     recommendations.push("Mount WRITING_SYNC_DIR with write access (avoid read-only mounts like ':ro').");
     recommendations.push("If running in Docker/OpenClaw, verify volume ownership and permissions for the container user.");
+  }
+
+  if (SYNC_OWNERSHIP_DIAGNOSTICS.supported && SYNC_OWNERSHIP_DIAGNOSTICS.non_runtime_owned_paths > 0) {
+    warnings.push(
+      `OWNERSHIP_MISMATCH: ${SYNC_OWNERSHIP_DIAGNOSTICS.non_runtime_owned_paths} sampled path(s) are not owned by runtime UID ${SYNC_OWNERSHIP_DIAGNOSTICS.runtime_uid}.`
+    );
+    recommendations.push(
+      `Repair ownership once on host: sudo chown -R $(id -u):$(id -g) ${SYNC_DIR_ABS}`
+    );
+    recommendations.push(
+      "For Docker, run container as host user (compose: user: \"${UID}:${GID}\") to prevent root-owned sync files."
+    );
+  }
+
+  if (SYNC_OWNERSHIP_DIAGNOSTICS.supported && SYNC_OWNERSHIP_DIAGNOSTICS.root_owned_paths > 0) {
+    warnings.push(
+      `ROOT_OWNED_PATHS: ${SYNC_OWNERSHIP_DIAGNOSTICS.root_owned_paths} sampled path(s) are owned by UID 0 (root).`
+    );
   }
 
   if (!GIT_AVAILABLE) {
@@ -403,6 +422,7 @@ function createMcpServer() {
         sync_dir: SYNC_DIR_ABS,
         db_path: DB_PATH_DISPLAY,
         sync_dir_writable: SYNC_DIR_WRITABLE,
+        permission_diagnostics: SYNC_OWNERSHIP_DIAGNOSTICS,
         git_available: GIT_AVAILABLE,
         git_enabled: GIT_ENABLED,
         http_port: HTTP_PORT,

--- a/index.js
+++ b/index.js
@@ -269,7 +269,7 @@ function getRuntimeDiagnostics() {
       `OWNERSHIP_MISMATCH: ${SYNC_OWNERSHIP_DIAGNOSTICS.non_runtime_owned_paths} sampled path(s) are not owned by runtime UID ${SYNC_OWNERSHIP_DIAGNOSTICS.runtime_uid}.`
     );
     recommendations.push(
-      `Repair ownership once on host: sudo chown -R $(id -u):$(id -g) ${SYNC_DIR_ABS}`
+      `Repair ownership once on host: sudo chown -R "$(id -u):$(id -g)" "${SYNC_DIR_ABS}"`
     );
     recommendations.push(
       "For Docker, run container as host user (compose: user: \"${UID}:${GID}\") to prevent root-owned sync files."
@@ -415,7 +415,7 @@ function createMcpServer() {
   // ---- get_runtime_config --------------------------------------------------
   s.tool(
     "get_runtime_config",
-    "Show the active runtime paths and capabilities for this server instance (sync dir, database path, writability, and git availability). Use this to verify which manuscript location is currently connected.",
+    "Show the active runtime paths and capabilities for this server instance (sync dir, database path, writability, permission diagnostics, and git availability). Use this to verify which manuscript location is currently connected.",
     {},
     async () => {
       return jsonResponse({

--- a/sync.js
+++ b/sync.js
@@ -53,6 +53,11 @@ export function walkSidecars(dir, fileList = []) {
   return fileList;
 }
 
+function isNestedMirrorPath(syncDir, filePath) {
+  const rel = path.relative(syncDir, filePath).split(path.sep).join("/");
+  return rel.includes("/scenes/projects/") || rel.includes("/scenes/universes/");
+}
+
 export function sidecarPath(filePath) {
   return filePath.replace(/\.(md|txt)$/, ".meta.yaml");
 }
@@ -202,6 +207,80 @@ export function isSyncDirWritable(syncDir) {
   } catch {
     return false;
   }
+}
+
+function collectOwnershipSample(rootDir, limit = 200) {
+  const samples = [];
+  const stack = [rootDir];
+
+  while (stack.length && samples.length < limit) {
+    const current = stack.pop();
+    samples.push(current);
+
+    let entries;
+    try {
+      entries = fs.readdirSync(current, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      if (samples.length + stack.length >= limit) break;
+      if (entry.isSymbolicLink()) continue;
+      const full = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(full);
+      } else {
+        samples.push(full);
+        if (samples.length >= limit) break;
+      }
+    }
+  }
+
+  return samples;
+}
+
+export function getSyncOwnershipDiagnostics(syncDir, { sampleLimit = 200 } = {}) {
+  const runtimeUid = typeof process.getuid === "function" ? process.getuid() : null;
+  const diagnostics = {
+    sync_dir: path.resolve(syncDir),
+    sync_dir_exists: fs.existsSync(syncDir),
+    supported: runtimeUid !== null,
+    runtime_uid: runtimeUid,
+    sampled_paths: 0,
+    sample_limit: sampleLimit,
+    root_owned_paths: 0,
+    non_runtime_owned_paths: 0,
+    unreadable_paths: 0,
+    root_owned_examples: [],
+    non_runtime_owned_examples: [],
+  };
+
+  if (!diagnostics.sync_dir_exists || runtimeUid === null) {
+    return diagnostics;
+  }
+
+  const sample = collectOwnershipSample(syncDir, sampleLimit);
+  diagnostics.sampled_paths = sample.length;
+
+  for (const filePath of sample) {
+    try {
+      const stat = fs.statSync(filePath);
+      const rel = path.relative(syncDir, filePath) || ".";
+      if (stat.uid === 0) {
+        diagnostics.root_owned_paths++;
+        if (diagnostics.root_owned_examples.length < 5) diagnostics.root_owned_examples.push(rel);
+      }
+      if (stat.uid !== runtimeUid) {
+        diagnostics.non_runtime_owned_paths++;
+        if (diagnostics.non_runtime_owned_examples.length < 5) diagnostics.non_runtime_owned_examples.push(rel);
+      }
+    } catch {
+      diagnostics.unreadable_paths++;
+    }
+  }
+
+  return diagnostics;
 }
 
 // ---------------------------------------------------------------------------
@@ -368,9 +447,18 @@ export function syncAll(db, syncDir, { quiet = false, writable = false } = {}) {
   const indexedSceneIds = new Set(); // scene_id only — for orphaned sidecar move detection
   const warnings = [];
 
+  const scanFiles = [];
+  for (const file of files) {
+    if (isNestedMirrorPath(syncDir, file)) {
+      warnings.push(`Ignored nested mirror path: ${path.relative(syncDir, file)}`);
+      continue;
+    }
+    scanFiles.push(file);
+  }
+
   // --- Pass 1: world files (characters/places must be indexed before scenes
   // so that character name → ID resolution in scene_characters works) ---
-  for (const file of files) {
+  for (const file of scanFiles) {
     if (!isWorldFile(syncDir, file)) continue;
     try {
       const { meta } = readMeta(file, syncDir, { writable });
@@ -386,7 +474,7 @@ export function syncAll(db, syncDir, { quiet = false, writable = false } = {}) {
   }
 
   // --- Pass 2: scene files ---
-  for (const file of files) {
+  for (const file of scanFiles) {
     if (isWorldFile(syncDir, file)) continue;
     try {
       const { meta, sourceMeta, sidecarGenerated, derived, mismatches } = readMeta(file, syncDir, { writable });
@@ -431,7 +519,7 @@ export function syncAll(db, syncDir, { quiet = false, writable = false } = {}) {
   }
 
   // --- Orphaned sidecar detection ---
-  const sidecars = walkSidecars(syncDir);
+  const sidecars = walkSidecars(syncDir).filter(sidecar => !isNestedMirrorPath(syncDir, sidecar));
   for (const sidecar of sidecars) {
     const prose = sidecar.replace(/\.meta\.yaml$/, ".md");
     const proseTxt = sidecar.replace(/\.meta\.yaml$/, ".txt");

--- a/sync.js
+++ b/sync.js
@@ -242,9 +242,23 @@ function collectOwnershipSample(rootDir, limit = 200) {
 
 export function getSyncOwnershipDiagnostics(syncDir, { sampleLimit = 200 } = {}) {
   const runtimeUid = typeof process.getuid === "function" ? process.getuid() : null;
+  let syncDirPathExists;
+  let syncDirIsDirectory;
+  try {
+    const stat = fs.statSync(syncDir);
+    syncDirPathExists = true;
+    syncDirIsDirectory = stat.isDirectory();
+  } catch {
+    syncDirPathExists = false;
+    syncDirIsDirectory = false;
+  }
+
   const diagnostics = {
     sync_dir: path.resolve(syncDir),
-    sync_dir_exists: fs.existsSync(syncDir),
+    sync_dir_path_exists: syncDirPathExists,
+    sync_dir_is_directory: syncDirIsDirectory,
+    // Backwards-compatible: "exists" now means "exists and is a directory".
+    sync_dir_exists: syncDirIsDirectory,
     supported: runtimeUid !== null,
     runtime_uid: runtimeUid,
     sampled_paths: 0,
@@ -256,7 +270,7 @@ export function getSyncOwnershipDiagnostics(syncDir, { sampleLimit = 200 } = {})
     non_runtime_owned_examples: [],
   };
 
-  if (!diagnostics.sync_dir_exists || runtimeUid === null) {
+  if (!diagnostics.sync_dir_is_directory || runtimeUid === null) {
     return diagnostics;
   }
 

--- a/test/unit.test.mjs
+++ b/test/unit.test.mjs
@@ -171,9 +171,15 @@ describe("getSyncOwnershipDiagnostics", () => {
 
     const diagnostics = getSyncOwnershipDiagnostics(dir, { sampleLimit: 25 });
     assert.equal(diagnostics.sync_dir_exists, true);
+    assert.equal(diagnostics.sync_dir_path_exists, true);
+    assert.equal(diagnostics.sync_dir_is_directory, true);
     assert.equal(typeof diagnostics.supported, "boolean");
     assert.equal(diagnostics.sample_limit, 25);
-    assert.ok(diagnostics.sampled_paths >= 1);
+    if (diagnostics.supported) {
+      assert.ok(diagnostics.sampled_paths >= 1);
+    } else {
+      assert.equal(diagnostics.sampled_paths, 0);
+    }
 
     fs.rmSync(dir, { recursive: true, force: true });
   });
@@ -181,7 +187,23 @@ describe("getSyncOwnershipDiagnostics", () => {
   test("handles non-existent directory gracefully", () => {
     const diagnostics = getSyncOwnershipDiagnostics("/tmp/__nonexistent_dir_xyz__/subdir", { sampleLimit: 10 });
     assert.equal(diagnostics.sync_dir_exists, false);
+    assert.equal(diagnostics.sync_dir_path_exists, false);
+    assert.equal(diagnostics.sync_dir_is_directory, false);
     assert.equal(diagnostics.sampled_paths, 0);
+  });
+
+  test("treats non-directory path as invalid sync dir", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ownership-"));
+    const filePath = path.join(dir, "not-a-dir.txt");
+    fs.writeFileSync(filePath, "content", "utf8");
+
+    const diagnostics = getSyncOwnershipDiagnostics(filePath, { sampleLimit: 10 });
+    assert.equal(diagnostics.sync_dir_path_exists, true);
+    assert.equal(diagnostics.sync_dir_is_directory, false);
+    assert.equal(diagnostics.sync_dir_exists, false);
+    assert.equal(diagnostics.sampled_paths, 0);
+
+    fs.rmSync(dir, { recursive: true, force: true });
   });
 });
 

--- a/test/unit.test.mjs
+++ b/test/unit.test.mjs
@@ -10,6 +10,7 @@ import {
   inferProjectAndUniverse,
   inferScenePositionFromPath,
   isCanonicalWorldEntityFile,
+  getSyncOwnershipDiagnostics,
   isWorldFile,
   readMeta,
   isSyncDirWritable,
@@ -160,6 +161,27 @@ describe("isSyncDirWritable", () => {
 
   test("returns false for non-existent directory", () => {
     assert.ok(!isSyncDirWritable("/tmp/__nonexistent_dir_xyz__/subdir"));
+  });
+});
+
+describe("getSyncOwnershipDiagnostics", () => {
+  test("returns diagnostics for existing directory", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ownership-"));
+    fs.writeFileSync(path.join(dir, "scene.md"), "---\nscene_id: sc-001\n---\nProse");
+
+    const diagnostics = getSyncOwnershipDiagnostics(dir, { sampleLimit: 25 });
+    assert.equal(diagnostics.sync_dir_exists, true);
+    assert.equal(typeof diagnostics.supported, "boolean");
+    assert.equal(diagnostics.sample_limit, 25);
+    assert.ok(diagnostics.sampled_paths >= 1);
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("handles non-existent directory gracefully", () => {
+    const diagnostics = getSyncOwnershipDiagnostics("/tmp/__nonexistent_dir_xyz__/subdir", { sampleLimit: 10 });
+    assert.equal(diagnostics.sync_dir_exists, false);
+    assert.equal(diagnostics.sampled_paths, 0);
   });
 });
 
@@ -434,6 +456,36 @@ describe("syncAll", () => {
     );
     const result = syncAll(db, dir, { quiet: true });
     assert.ok(result.warnings.some(w => w.includes("Duplicate scene_id")));
+
+    db.close();
+    fs.rmSync(dir, { recursive: true });
+  });
+
+  test("ignores nested mirrored scene paths under scenes/", () => {
+    const dir = makeTempSync();
+    const db = openDb(":memory:");
+    writeScene(dir, "sc-001");
+
+    const nestedMirrorDir = path.join(
+      dir,
+      "projects",
+      "test-novel",
+      "scenes",
+      "universes",
+      "universe-1",
+      "book-1-the-lamb",
+      "scenes"
+    );
+    fs.mkdirSync(nestedMirrorDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(nestedMirrorDir, "sc-001-duplicate.md"),
+      "---\nscene_id: sc-001\ntitle: Mirrored Duplicate\npart: 1\nchapter: 1\npov: elena\n---\nDuplicated prose."
+    );
+
+    const result = syncAll(db, dir, { quiet: true });
+    assert.equal(result.indexed, 1);
+    assert.ok(result.warnings.some(w => w.includes("Ignored nested mirror path")));
+    assert.equal(result.warnings.some(w => w.includes("Duplicate scene_id")), false);
 
     db.close();
     fs.rmSync(dir, { recursive: true });


### PR DESCRIPTION
## Summary
- add ownership diagnostics utility for WRITING_SYNC_DIR sampling root-owned and non-runtime-owned paths
- expose permission diagnostics via get_runtime_config and include actionable runtime warnings/recommendations
- document a scalable ownership contract in README with host repair commands and Docker UID/GID mapping
- add unit tests for ownership diagnostics utility

## Validation
- npm run lint
- npm test