### PR TITLE
fix: preflight prose writes and make canonical sheet creation idempotent

### DIFF
--- a/index.js
+++ b/index.js
@@ -209,12 +209,17 @@ function createCanonicalWorldEntity({ kind, name, notes, projectId, universeId, 
     }
   }
 
-  const payload = {
-    ...existingMeta,
-    ...(meta ?? {}),
-    [idKey]: existingMeta[idKey] ?? `${prefix}-${slug}`,
-    name: existingMeta.name ?? name,
-  };
+  const payload = hadMeta
+    ? {
+      ...existingMeta,
+      [idKey]: existingMeta[idKey] ?? `${prefix}-${slug}`,
+      name: existingMeta.name ?? name,
+    }
+    : {
+      [idKey]: `${prefix}-${slug}`,
+      name,
+      ...(meta ?? {}),
+    };
 
   fs.writeFileSync(metaPath, yaml.dump(payload, { lineWidth: 120 }), "utf8");
 
@@ -753,7 +758,7 @@ function createMcpServer() {
       }
 
       try {
-        const created = createCanonicalWorldEntity({
+        const result = createCanonicalWorldEntity({
           kind: "character",
           name,
           notes,
@@ -762,7 +767,7 @@ function createMcpServer() {
           meta: fields ?? {},
         });
 
-        return jsonResponse({ ok: true, action: created.created ? "created" : "exists", kind: "character", ...created });
+        return jsonResponse({ ok: true, action: result.created ? "created" : "exists", kind: "character", ...result });
       } catch (err) {
         return errorResponse("IO_ERROR", `Failed to create character sheet: ${err.message}`);
       }
@@ -817,7 +822,7 @@ function createMcpServer() {
       }
 
       try {
-        const created = createCanonicalWorldEntity({
+        const result = createCanonicalWorldEntity({
           kind: "place",
           name,
           notes,
@@ -826,7 +831,7 @@ function createMcpServer() {
           meta: fields ?? {},
         });
 
-        return jsonResponse({ ok: true, action: created.created ? "created" : "exists", kind: "place", ...created });
+        return jsonResponse({ ok: true, action: result.created ? "created" : "exists", kind: "place", ...result });
       } catch (err) {
         return errorResponse("IO_ERROR", `Failed to create place sheet: ${err.message}`);
       }

--- a/index.js
+++ b/index.js
@@ -200,7 +200,6 @@ function createCanonicalWorldEntity({ kind, name, notes, projectId, universeId, 
     }
   }
 
-  let existingMeta = {};
   let shouldWriteMeta = !hadMeta;
   let payload;
   const derivedId = `${prefix}-${slug}`;
@@ -215,13 +214,11 @@ function createCanonicalWorldEntity({ kind, name, notes, projectId, universeId, 
       );
     }
 
-    if (parsedMeta == null) {
-      existingMeta = {};
-    } else if (typeof parsedMeta === "object" && !Array.isArray(parsedMeta)) {
-      existingMeta = parsedMeta;
-    } else {
+    if (parsedMeta != null && (typeof parsedMeta !== "object" || Array.isArray(parsedMeta))) {
       throw new Error(`Existing metadata sidecar must be a YAML mapping at ${metaPath}.`);
     }
+
+    const existingMeta = parsedMeta ?? {};
 
     const backfilledId = existingMeta[idKey] ?? derivedId;
     const backfilledName = existingMeta.name ?? name;

--- a/index.js
+++ b/index.js
@@ -201,6 +201,9 @@ function createCanonicalWorldEntity({ kind, name, notes, projectId, universeId, 
   }
 
   let existingMeta = {};
+  let shouldWriteMeta = !hadMeta;
+  let payload;
+  const derivedId = `${prefix}-${slug}`;
   if (hadMeta) {
     let parsedMeta;
     try {
@@ -219,21 +222,28 @@ function createCanonicalWorldEntity({ kind, name, notes, projectId, universeId, 
     } else {
       throw new Error(`Existing metadata sidecar must be a YAML mapping at ${metaPath}.`);
     }
-  }
 
-  const payload = hadMeta
-    ? {
-      ...existingMeta,
-      [idKey]: existingMeta[idKey] ?? `${prefix}-${slug}`,
-      name: existingMeta.name ?? name,
-    }
-    : {
-      [idKey]: `${prefix}-${slug}`,
+    const backfilledId = existingMeta[idKey] ?? derivedId;
+    const backfilledName = existingMeta.name ?? name;
+    shouldWriteMeta = existingMeta[idKey] == null || existingMeta.name == null;
+    payload = shouldWriteMeta
+      ? {
+        ...existingMeta,
+        [idKey]: backfilledId,
+        name: backfilledName,
+      }
+      : existingMeta;
+  } else {
+    payload = {
+      [idKey]: derivedId,
       name,
       ...(meta ?? {}),
     };
+  }
 
-  fs.writeFileSync(metaPath, yaml.dump(payload, { lineWidth: 120 }), "utf8");
+  if (shouldWriteMeta) {
+    fs.writeFileSync(metaPath, yaml.dump(payload, { lineWidth: 120 }), "utf8");
+  }
 
   syncAll(db, SYNC_DIR, { writable: SYNC_DIR_WRITABLE });
 
@@ -1421,6 +1431,28 @@ function createMcpServer() {
 
       try {
         const proseWriteDiagnostics = getFileWriteDiagnostics(proposal.scene_file_path);
+        if (proseWriteDiagnostics.stat_error_code === "EACCES" || proseWriteDiagnostics.stat_error_code === "EPERM") {
+          return errorResponse(
+            "PROSE_FILE_NOT_WRITABLE",
+            "Scene prose file cannot be accessed by the current runtime user.",
+            {
+              indexed_path: proposal.scene_file_path,
+              prose_write_diagnostics: proseWriteDiagnostics,
+            }
+          );
+        }
+
+        if (proseWriteDiagnostics.stat_error_code && proseWriteDiagnostics.stat_error_code !== "ENOENT" && proseWriteDiagnostics.stat_error_code !== "ENOTDIR") {
+          return errorResponse(
+            "IO_ERROR",
+            "Failed to inspect scene prose path before writing.",
+            {
+              indexed_path: proposal.scene_file_path,
+              prose_write_diagnostics: proseWriteDiagnostics,
+            }
+          );
+        }
+
         if (!proseWriteDiagnostics.exists) {
           return errorResponse("STALE_PATH", "Prose file not found at indexed path.", {
             indexed_path: proposal.scene_file_path,

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ import matter from "gray-matter";
 import yaml from "js-yaml";
 import { z } from "zod";
 import { openDb } from "./db.js";
-import { syncAll, isSyncDirWritable, getSyncOwnershipDiagnostics, writeMeta, readMeta, indexSceneFile, normalizeSceneMetaForPath, sidecarPath } from "./sync.js";
+import { syncAll, isSyncDirWritable, getSyncOwnershipDiagnostics, getFileWriteDiagnostics, writeMeta, readMeta, indexSceneFile, normalizeSceneMetaForPath, sidecarPath } from "./sync.js";
 import { isGitAvailable, isGitRepository, initGitRepository, createSnapshot, listSnapshots, getSceneProseAtCommit } from "./git.js";
 import { renderCharacterArcTemplate, renderCharacterSheetTemplate, renderPlaceSheetTemplate, slugifyEntityName } from "./world-entity-templates.js";
 import { importScrivenerSync, validateProjectId } from "./importer.js";
@@ -180,28 +180,48 @@ function createCanonicalWorldEntity({ kind, name, notes, projectId, universeId, 
   const { dir } = resolveWorldEntityDir({ kind, projectId, universeId, name });
   const prosePath = path.join(dir, "sheet.md");
   const metaPath = sidecarPath(prosePath);
-  if (fs.existsSync(prosePath) || fs.existsSync(metaPath)) {
-    throw new Error(`Canonical sheet already exists at ${dir}`);
-  }
+  const hadProse = fs.existsSync(prosePath);
+  const hadMeta = fs.existsSync(metaPath);
 
   fs.mkdirSync(dir, { recursive: true });
-  const defaultSheet = kind === "character"
-    ? renderCharacterSheetTemplate(name)
-    : renderPlaceSheetTemplate(name);
-  fs.writeFileSync(prosePath, `${notes?.trim() ?? defaultSheet}${(notes?.trim() ?? defaultSheet) ? "\n" : ""}`, "utf8");
-  if (kind === "character") {
-    fs.writeFileSync(path.join(dir, "arc.md"), `${renderCharacterArcTemplate(name)}\n`, "utf8");
+
+  if (!hadProse) {
+    const defaultSheet = kind === "character"
+      ? renderCharacterSheetTemplate(name)
+      : renderPlaceSheetTemplate(name);
+    const body = notes?.trim() ?? defaultSheet;
+    fs.writeFileSync(prosePath, `${body}${body ? "\n" : ""}`, "utf8");
   }
+
+  if (kind === "character") {
+    const arcPath = path.join(dir, "arc.md");
+    if (!fs.existsSync(arcPath)) {
+      fs.writeFileSync(arcPath, `${renderCharacterArcTemplate(name)}\n`, "utf8");
+    }
+  }
+
+  let existingMeta = {};
+  if (hadMeta) {
+    try {
+      existingMeta = yaml.load(fs.readFileSync(metaPath, "utf8")) ?? {};
+    } catch {
+      existingMeta = {};
+    }
+  }
+
   const payload = {
-    [idKey]: `${prefix}-${slug}`,
-    name,
-    ...meta,
+    ...existingMeta,
+    ...(meta ?? {}),
+    [idKey]: existingMeta[idKey] ?? `${prefix}-${slug}`,
+    name: existingMeta.name ?? name,
   };
+
   fs.writeFileSync(metaPath, yaml.dump(payload, { lineWidth: 120 }), "utf8");
 
   syncAll(db, SYNC_DIR, { writable: SYNC_DIR_WRITABLE });
 
   return {
+    created: !hadProse && !hadMeta,
     id: payload[idKey],
     prose_path: prosePath,
     meta_path: metaPath,
@@ -711,7 +731,7 @@ function createMcpServer() {
   // ---- create_character_sheet ---------------------------------------------
   s.tool(
     "create_character_sheet",
-    "Create a canonical character sheet folder with sheet.md and sheet.meta.yaml so the character can be indexed immediately. Use this before migrating freeform notes into the new folder structure.",
+    "Create or reuse a canonical character sheet folder with sheet.md and sheet.meta.yaml so the character can be indexed immediately. If the folder already exists, missing canonical files are backfilled and the existing sheet is preserved.",
     {
       name: z.string().describe("Display name of the character (e.g. 'Mira Nystrom')."),
       project_id: z.string().optional().describe("Project scope for a book-local character (e.g. 'universe-1/book-1-the-lamb' or 'test-novel')."),
@@ -742,7 +762,7 @@ function createMcpServer() {
           meta: fields ?? {},
         });
 
-        return jsonResponse({ ok: true, action: "created", kind: "character", ...created });
+        return jsonResponse({ ok: true, action: created.created ? "created" : "exists", kind: "character", ...created });
       } catch (err) {
         return errorResponse("IO_ERROR", `Failed to create character sheet: ${err.message}`);
       }
@@ -777,7 +797,7 @@ function createMcpServer() {
   // ---- create_place_sheet -------------------------------------------------
   s.tool(
     "create_place_sheet",
-    "Create a canonical place sheet folder with sheet.md and sheet.meta.yaml so the place can be indexed immediately. Use this before migrating freeform notes into the new folder structure.",
+    "Create or reuse a canonical place sheet folder with sheet.md and sheet.meta.yaml so the place can be indexed immediately. If the folder already exists, missing canonical files are backfilled and the existing sheet is preserved.",
     {
       name: z.string().describe("Display name of the place (e.g. 'University Hospital')."),
       project_id: z.string().optional().describe("Project scope for a book-local place (e.g. 'universe-1/book-1-the-lamb' or 'test-novel')."),
@@ -806,7 +826,7 @@ function createMcpServer() {
           meta: fields ?? {},
         });
 
-        return jsonResponse({ ok: true, action: "created", kind: "place", ...created });
+        return jsonResponse({ ok: true, action: created.created ? "created" : "exists", kind: "place", ...created });
       } catch (err) {
         return errorResponse("IO_ERROR", `Failed to create place sheet: ${err.message}`);
       }
@@ -1383,6 +1403,32 @@ function createMcpServer() {
       }
 
       try {
+        const proseWriteDiagnostics = getFileWriteDiagnostics(proposal.scene_file_path);
+        if (!proseWriteDiagnostics.exists) {
+          return errorResponse("STALE_PATH", "Prose file not found at indexed path.", {
+            indexed_path: proposal.scene_file_path,
+            prose_write_diagnostics: proseWriteDiagnostics,
+          });
+        }
+
+        if (!proseWriteDiagnostics.is_file) {
+          return errorResponse("INVALID_PROSE_PATH", "Indexed prose path is not a regular file.", {
+            indexed_path: proposal.scene_file_path,
+            prose_write_diagnostics: proseWriteDiagnostics,
+          });
+        }
+
+        if (!proseWriteDiagnostics.writable) {
+          return errorResponse(
+            "PROSE_FILE_NOT_WRITABLE",
+            "Scene prose file is not writable by the current runtime user.",
+            {
+              indexed_path: proposal.scene_file_path,
+              prose_write_diagnostics: proseWriteDiagnostics,
+            }
+          );
+        }
+
         // Reconstruct file content, preserving frontmatter only if the original had it
         const hasFrontmatter = proposal.metadata && Object.keys(proposal.metadata).length > 0;
         const content = hasFrontmatter

--- a/index.js
+++ b/index.js
@@ -202,10 +202,19 @@ function createCanonicalWorldEntity({ kind, name, notes, projectId, universeId, 
 
   let existingMeta = {};
   if (hadMeta) {
+    let parsedMeta;
     try {
-      existingMeta = yaml.load(fs.readFileSync(metaPath, "utf8")) ?? {};
-    } catch {
+      parsedMeta = yaml.load(fs.readFileSync(metaPath, "utf8"));
+    } catch (err) {
+      throw new Error(`Existing metadata sidecar is invalid YAML at ${metaPath}: ${err.message}`);
+    }
+
+    if (parsedMeta == null) {
       existingMeta = {};
+    } else if (typeof parsedMeta === "object" && !Array.isArray(parsedMeta)) {
+      existingMeta = parsedMeta;
+    } else {
+      throw new Error(`Existing metadata sidecar must be a YAML mapping at ${metaPath}.`);
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -183,23 +183,6 @@ function createCanonicalWorldEntity({ kind, name, notes, projectId, universeId, 
   const hadProse = fs.existsSync(prosePath);
   const hadMeta = fs.existsSync(metaPath);
 
-  fs.mkdirSync(dir, { recursive: true });
-
-  if (!hadProse) {
-    const defaultSheet = kind === "character"
-      ? renderCharacterSheetTemplate(name)
-      : renderPlaceSheetTemplate(name);
-    const body = notes?.trim() ?? defaultSheet;
-    fs.writeFileSync(prosePath, `${body}${body ? "\n" : ""}`, "utf8");
-  }
-
-  if (kind === "character") {
-    const arcPath = path.join(dir, "arc.md");
-    if (!fs.existsSync(arcPath)) {
-      fs.writeFileSync(arcPath, `${renderCharacterArcTemplate(name)}\n`, "utf8");
-    }
-  }
-
   let shouldWriteMeta = !hadMeta;
   let payload;
   const derivedId = `${prefix}-${slug}`;
@@ -236,6 +219,23 @@ function createCanonicalWorldEntity({ kind, name, notes, projectId, universeId, 
       name,
       ...(meta ?? {}),
     };
+  }
+
+  fs.mkdirSync(dir, { recursive: true });
+
+  if (!hadProse) {
+    const defaultSheet = kind === "character"
+      ? renderCharacterSheetTemplate(name)
+      : renderPlaceSheetTemplate(name);
+    const body = notes?.trim() ?? defaultSheet;
+    fs.writeFileSync(prosePath, `${body}${body ? "\n" : ""}`, "utf8");
+  }
+
+  if (kind === "character") {
+    const arcPath = path.join(dir, "arc.md");
+    if (!fs.existsSync(arcPath)) {
+      fs.writeFileSync(arcPath, `${renderCharacterArcTemplate(name)}\n`, "utf8");
+    }
   }
 
   if (shouldWriteMeta) {

--- a/index.js
+++ b/index.js
@@ -206,7 +206,10 @@ function createCanonicalWorldEntity({ kind, name, notes, projectId, universeId, 
     try {
       parsedMeta = yaml.load(fs.readFileSync(metaPath, "utf8"));
     } catch (err) {
-      throw new Error(`Existing metadata sidecar is invalid YAML at ${metaPath}: ${err.message}`);
+      throw new Error(
+        `Existing metadata sidecar is invalid YAML at ${metaPath}: ${err.message}`,
+        { cause: err }
+      );
     }
 
     if (parsedMeta == null) {

--- a/sync.js
+++ b/sync.js
@@ -312,6 +312,8 @@ export function getFileWriteDiagnostics(filePath) {
     runtime_uid: runtimeUid,
     owner_uid: null,
     root_owned: false,
+    stat_error_code: null,
+    stat_error_message: null,
   };
 
   try {
@@ -327,7 +329,9 @@ export function getFileWriteDiagnostics(filePath) {
     diagnostics.is_file = stat.isFile();
     diagnostics.owner_uid = typeof stat.uid === "number" ? stat.uid : null;
     diagnostics.root_owned = stat.uid === 0;
-  } catch {
+  } catch (err) {
+    diagnostics.stat_error_code = typeof err?.code === "string" ? err.code : null;
+    diagnostics.stat_error_message = typeof err?.message === "string" ? err.message : String(err);
     return diagnostics;
   }
 

--- a/sync.js
+++ b/sync.js
@@ -315,6 +315,13 @@ export function getFileWriteDiagnostics(filePath) {
   };
 
   try {
+    fs.accessSync(parentDir, fs.constants.W_OK);
+    diagnostics.parent_dir_writable = true;
+  } catch {
+    diagnostics.parent_dir_writable = false;
+  }
+
+  try {
     const stat = fs.statSync(resolvedPath);
     diagnostics.exists = true;
     diagnostics.is_file = stat.isFile();
@@ -329,13 +336,6 @@ export function getFileWriteDiagnostics(filePath) {
     diagnostics.writable = diagnostics.is_file;
   } catch {
     diagnostics.writable = false;
-  }
-
-  try {
-    fs.accessSync(parentDir, fs.constants.W_OK);
-    diagnostics.parent_dir_writable = true;
-  } catch {
-    diagnostics.parent_dir_writable = false;
   }
 
   return diagnostics;

--- a/sync.js
+++ b/sync.js
@@ -297,6 +297,50 @@ export function getSyncOwnershipDiagnostics(syncDir, { sampleLimit = 200 } = {})
   return diagnostics;
 }
 
+export function getFileWriteDiagnostics(filePath) {
+  const runtimeUid = typeof process.getuid === "function" ? process.getuid() : null;
+  const resolvedPath = path.resolve(filePath);
+  const parentDir = path.dirname(resolvedPath);
+  const diagnostics = {
+    path: resolvedPath,
+    parent_dir: parentDir,
+    exists: false,
+    is_file: false,
+    writable: false,
+    parent_dir_writable: false,
+    supported: runtimeUid !== null,
+    runtime_uid: runtimeUid,
+    owner_uid: null,
+    root_owned: false,
+  };
+
+  try {
+    const stat = fs.statSync(resolvedPath);
+    diagnostics.exists = true;
+    diagnostics.is_file = stat.isFile();
+    diagnostics.owner_uid = typeof stat.uid === "number" ? stat.uid : null;
+    diagnostics.root_owned = stat.uid === 0;
+  } catch {
+    return diagnostics;
+  }
+
+  try {
+    fs.accessSync(resolvedPath, fs.constants.W_OK);
+    diagnostics.writable = diagnostics.is_file;
+  } catch {
+    diagnostics.writable = false;
+  }
+
+  try {
+    fs.accessSync(parentDir, fs.constants.W_OK);
+    diagnostics.parent_dir_writable = true;
+  } catch {
+    diagnostics.parent_dir_writable = false;
+  }
+
+  return diagnostics;
+}
+
 // ---------------------------------------------------------------------------
 // DB-dependent sync (takes db + syncDir as arguments for testability)
 // ---------------------------------------------------------------------------

--- a/test/integration.test.mjs
+++ b/test/integration.test.mjs
@@ -1103,6 +1103,37 @@ describe("create_character_sheet tool", () => {
     assert.ok(sidecarRaw.includes("character_id: char-leah-quinn"));
   });
 
+  test("does not rewrite existing valid sidecar when no backfill is needed", async () => {
+    const existingDir = path.join(
+      writeSyncDir,
+      "projects",
+      "test-novel",
+      "world",
+      "characters",
+      "leah-preserve"
+    );
+    fs.mkdirSync(existingDir, { recursive: true });
+    fs.writeFileSync(path.join(existingDir, "sheet.md"), "# Leah Preserve\n\nExisting notes.\n", "utf8");
+
+    const metaPath = path.join(existingDir, "sheet.meta.yaml");
+    const originalMeta = "# keep this comment\ncharacter_id: char-leah-preserve\nname: Leah Preserve\nrole: support\n";
+    fs.writeFileSync(metaPath, originalMeta, "utf8");
+
+    const text = await callWriteTool("create_character_sheet", {
+      name: "Leah Preserve",
+      project_id: "test-novel",
+      fields: {
+        role: "lead",
+      },
+    });
+    const parsed = JSON.parse(text);
+
+    assert.equal(parsed.ok, true);
+    assert.equal(parsed.action, "exists");
+    assert.equal(parsed.id, "char-leah-preserve");
+    assert.equal(fs.readFileSync(metaPath, "utf8"), originalMeta);
+  });
+
   test("returns error and preserves sidecar when existing YAML is invalid", async () => {
     const existingDir = path.join(
       writeSyncDir,
@@ -1241,17 +1272,24 @@ describe("commit_edit preflight diagnostics", () => {
     assert.ok(proposal.proposal_id);
 
     const scenePath = path.join(writeSyncDir, "projects", "test-novel", "part-1", "chapter-1", "sc-001.md");
-    fs.unlinkSync(scenePath);
+    const originalContent = fs.readFileSync(scenePath, "utf8");
+    try {
+      fs.unlinkSync(scenePath);
 
-    const commitText = await callWriteTool("commit_edit", {
-      scene_id: "sc-001",
-      proposal_id: proposal.proposal_id,
-    });
-    const commitResult = JSON.parse(commitText);
+      const commitText = await callWriteTool("commit_edit", {
+        scene_id: "sc-001",
+        proposal_id: proposal.proposal_id,
+      });
+      const commitResult = JSON.parse(commitText);
 
-    assert.equal(commitResult.ok, false);
-    assert.equal(commitResult.error.code, "STALE_PATH");
-    assert.equal(commitResult.error.details?.prose_write_diagnostics?.exists, false);
+      assert.equal(commitResult.ok, false);
+      assert.equal(commitResult.error.code, "STALE_PATH");
+      assert.equal(commitResult.error.details?.prose_write_diagnostics?.exists, false);
+    } finally {
+      if (!fs.existsSync(scenePath)) {
+        fs.writeFileSync(scenePath, originalContent, "utf8");
+      }
+    }
   });
 
   test("returns INVALID_PROSE_PATH when indexed prose path points to a directory", async () => {
@@ -1265,17 +1303,26 @@ describe("commit_edit preflight diagnostics", () => {
 
     const originalScenePath = path.join(writeSyncDir, "projects", "test-novel", "part-1", "chapter-2", "sc-003.md");
     const replacementPath = path.join(writeSyncDir, "projects", "test-novel", "part-1", "chapter-2", "sc-003-original.md");
-    fs.renameSync(originalScenePath, replacementPath);
-    fs.mkdirSync(originalScenePath, { recursive: true });
+    try {
+      fs.renameSync(originalScenePath, replacementPath);
+      fs.mkdirSync(originalScenePath, { recursive: true });
 
-    const commitText = await callWriteTool("commit_edit", {
-      scene_id: "sc-003",
-      proposal_id: proposal.proposal_id,
-    });
-    const commitResult = JSON.parse(commitText);
+      const commitText = await callWriteTool("commit_edit", {
+        scene_id: "sc-003",
+        proposal_id: proposal.proposal_id,
+      });
+      const commitResult = JSON.parse(commitText);
 
-    assert.equal(commitResult.ok, false);
-    assert.equal(commitResult.error.code, "INVALID_PROSE_PATH");
-    assert.equal(commitResult.error.details?.prose_write_diagnostics?.is_file, false);
+      assert.equal(commitResult.ok, false);
+      assert.equal(commitResult.error.code, "INVALID_PROSE_PATH");
+      assert.equal(commitResult.error.details?.prose_write_diagnostics?.is_file, false);
+    } finally {
+      if (fs.existsSync(originalScenePath) && fs.statSync(originalScenePath).isDirectory()) {
+        fs.rmdirSync(originalScenePath);
+      }
+      if (fs.existsSync(replacementPath) && !fs.existsSync(originalScenePath)) {
+        fs.renameSync(replacementPath, originalScenePath);
+      }
+    }
   });
 });

--- a/test/integration.test.mjs
+++ b/test/integration.test.mjs
@@ -1102,6 +1102,67 @@ describe("create_character_sheet tool", () => {
     const sidecarRaw = fs.readFileSync(parsed.meta_path, "utf8");
     assert.ok(sidecarRaw.includes("character_id: char-leah-quinn"));
   });
+
+  test("returns error and preserves sidecar when existing YAML is invalid", async () => {
+    const existingDir = path.join(
+      writeSyncDir,
+      "projects",
+      "test-novel",
+      "world",
+      "characters",
+      "leah-invalid-yaml"
+    );
+    fs.mkdirSync(existingDir, { recursive: true });
+    fs.writeFileSync(path.join(existingDir, "sheet.md"), "# Leah Invalid YAML\n\nExisting notes.\n", "utf8");
+
+    const metaPath = path.join(existingDir, "sheet.meta.yaml");
+    const invalidYaml = "name: [unterminated\n";
+    fs.writeFileSync(metaPath, invalidYaml, "utf8");
+
+    const text = await callWriteTool("create_character_sheet", {
+      name: "Leah Invalid YAML",
+      project_id: "test-novel",
+      fields: {
+        role: "support",
+      },
+    });
+    const parsed = JSON.parse(text);
+
+    assert.equal(parsed.ok, false);
+    assert.equal(parsed.error.code, "IO_ERROR");
+    assert.ok(parsed.error.message.includes("invalid YAML"));
+    assert.equal(fs.readFileSync(metaPath, "utf8"), invalidYaml);
+  });
+
+  test("returns error when existing sidecar is not a YAML mapping", async () => {
+    const existingDir = path.join(
+      writeSyncDir,
+      "projects",
+      "test-novel",
+      "world",
+      "characters",
+      "leah-array-meta"
+    );
+    fs.mkdirSync(existingDir, { recursive: true });
+    fs.writeFileSync(path.join(existingDir, "sheet.md"), "# Leah Array Meta\n\nExisting notes.\n", "utf8");
+
+    const metaPath = path.join(existingDir, "sheet.meta.yaml");
+    fs.writeFileSync(metaPath, "- one\n- two\n", "utf8");
+
+    const text = await callWriteTool("create_character_sheet", {
+      name: "Leah Array Meta",
+      project_id: "test-novel",
+      fields: {
+        role: "support",
+      },
+    });
+    const parsed = JSON.parse(text);
+
+    assert.equal(parsed.ok, false);
+    assert.equal(parsed.error.code, "IO_ERROR");
+    assert.ok(parsed.error.message.includes("YAML mapping"));
+    assert.equal(fs.readFileSync(metaPath, "utf8"), "- one\n- two\n");
+  });
 });
 
 describe("create_place_sheet tool", () => {

--- a/test/integration.test.mjs
+++ b/test/integration.test.mjs
@@ -1168,3 +1168,53 @@ describe("get_relationship_arc tool", () => {
     assert.ok(text.toLowerCase().includes("no relationship data"));
   });
 });
+
+describe("commit_edit preflight diagnostics", () => {
+  test("returns STALE_PATH when indexed prose file is missing", async () => {
+    const proposalText = await callWriteTool("propose_edit", {
+      scene_id: "sc-001",
+      instruction: "Tighten opening paragraph",
+      revised_prose: "Revised prose for stale path test.",
+    });
+    const proposal = JSON.parse(proposalText);
+    assert.ok(proposal.proposal_id);
+
+    const scenePath = path.join(writeSyncDir, "projects", "test-novel", "part-1", "chapter-1", "sc-001.md");
+    fs.unlinkSync(scenePath);
+
+    const commitText = await callWriteTool("commit_edit", {
+      scene_id: "sc-001",
+      proposal_id: proposal.proposal_id,
+    });
+    const commitResult = JSON.parse(commitText);
+
+    assert.equal(commitResult.ok, false);
+    assert.equal(commitResult.error.code, "STALE_PATH");
+    assert.equal(commitResult.error.details?.prose_write_diagnostics?.exists, false);
+  });
+
+  test("returns INVALID_PROSE_PATH when indexed prose path points to a directory", async () => {
+    const proposalText = await callWriteTool("propose_edit", {
+      scene_id: "sc-003",
+      instruction: "Try writing to non-file path",
+      revised_prose: "Revised prose for invalid path test.",
+    });
+    const proposal = JSON.parse(proposalText);
+    assert.ok(proposal.proposal_id);
+
+    const originalScenePath = path.join(writeSyncDir, "projects", "test-novel", "part-1", "chapter-2", "sc-003.md");
+    const replacementPath = path.join(writeSyncDir, "projects", "test-novel", "part-1", "chapter-2", "sc-003-original.md");
+    fs.renameSync(originalScenePath, replacementPath);
+    fs.mkdirSync(originalScenePath, { recursive: true });
+
+    const commitText = await callWriteTool("commit_edit", {
+      scene_id: "sc-003",
+      proposal_id: proposal.proposal_id,
+    });
+    const commitResult = JSON.parse(commitText);
+
+    assert.equal(commitResult.ok, false);
+    assert.equal(commitResult.error.code, "INVALID_PROSE_PATH");
+    assert.equal(commitResult.error.details?.prose_write_diagnostics?.is_file, false);
+  });
+});

--- a/test/integration.test.mjs
+++ b/test/integration.test.mjs
@@ -1070,6 +1070,38 @@ describe("create_character_sheet tool", () => {
     const listed = await callWriteTool("list_characters", { project_id: "test-novel" });
     assert.ok(listed.includes("char-mira-nystrom"));
   });
+
+  test("reuses an existing canonical folder and returns exists", async () => {
+    const existingDir = path.join(
+      writeSyncDir,
+      "projects",
+      "test-novel",
+      "world",
+      "characters",
+      "leah-quinn"
+    );
+    fs.mkdirSync(existingDir, { recursive: true });
+    fs.writeFileSync(path.join(existingDir, "sheet.md"), "# Leah Quinn\n\nExisting notes.\n", "utf8");
+
+    const text = await callWriteTool("create_character_sheet", {
+      name: "Leah Quinn",
+      project_id: "test-novel",
+      fields: {
+        role: "support",
+      },
+    });
+    const parsed = JSON.parse(text);
+
+    assert.equal(parsed.ok, true);
+    assert.equal(parsed.action, "exists");
+    assert.equal(parsed.id, "char-leah-quinn");
+    assert.ok(fs.existsSync(parsed.prose_path));
+    assert.ok(fs.existsSync(parsed.meta_path));
+    assert.ok(fs.existsSync(path.join(path.dirname(parsed.prose_path), "arc.md")));
+
+    const sidecarRaw = fs.readFileSync(parsed.meta_path, "utf8");
+    assert.ok(sidecarRaw.includes("character_id: char-leah-quinn"));
+  });
 });
 
 describe("create_place_sheet tool", () => {

--- a/test/integration.test.mjs
+++ b/test/integration.test.mjs
@@ -1318,7 +1318,7 @@ describe("commit_edit preflight diagnostics", () => {
       assert.equal(commitResult.error.details?.prose_write_diagnostics?.is_file, false);
     } finally {
       if (fs.existsSync(originalScenePath) && fs.statSync(originalScenePath).isDirectory()) {
-        fs.rmdirSync(originalScenePath);
+        fs.rmSync(originalScenePath, { recursive: true, force: true });
       }
       if (fs.existsSync(replacementPath) && !fs.existsSync(originalScenePath)) {
         fs.renameSync(replacementPath, originalScenePath);

--- a/test/unit.test.mjs
+++ b/test/unit.test.mjs
@@ -234,6 +234,7 @@ describe("getFileWriteDiagnostics", () => {
       assert.equal(diagnostics.is_file, false);
       assert.equal(diagnostics.writable, false);
       assert.equal(diagnostics.parent_dir_writable, true);
+      assert.ok(diagnostics.stat_error_code === "ENOENT" || diagnostics.stat_error_code === "ENOTDIR");
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/test/unit.test.mjs
+++ b/test/unit.test.mjs
@@ -211,34 +211,43 @@ describe("getSyncOwnershipDiagnostics", () => {
 describe("getFileWriteDiagnostics", () => {
   test("reports writable regular files", () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "file-write-"));
-    const filePath = path.join(dir, "scene.md");
-    fs.writeFileSync(filePath, "Prose", "utf8");
+    try {
+      const filePath = path.join(dir, "scene.md");
+      fs.writeFileSync(filePath, "Prose", "utf8");
 
-    const diagnostics = getFileWriteDiagnostics(filePath);
-    assert.equal(diagnostics.exists, true);
-    assert.equal(diagnostics.is_file, true);
-    assert.equal(diagnostics.parent_dir_writable, true);
-    assert.equal(typeof diagnostics.writable, "boolean");
-
-    fs.rmSync(dir, { recursive: true, force: true });
+      const diagnostics = getFileWriteDiagnostics(filePath);
+      assert.equal(diagnostics.exists, true);
+      assert.equal(diagnostics.is_file, true);
+      assert.equal(diagnostics.parent_dir_writable, true);
+      assert.equal(typeof diagnostics.writable, "boolean");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   test("reports missing files without throwing", () => {
-    const diagnostics = getFileWriteDiagnostics("/tmp/__nonexistent_dir_xyz__/missing.md");
-    assert.equal(diagnostics.exists, false);
-    assert.equal(diagnostics.is_file, false);
-    assert.equal(diagnostics.writable, false);
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "file-write-missing-"));
+    try {
+      const missingPath = path.join(dir, "definitely-missing.md");
+      const diagnostics = getFileWriteDiagnostics(missingPath);
+      assert.equal(diagnostics.exists, false);
+      assert.equal(diagnostics.is_file, false);
+      assert.equal(diagnostics.writable, false);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   test("reports directories as non-writable prose targets", () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "file-write-"));
-
-    const diagnostics = getFileWriteDiagnostics(dir);
-    assert.equal(diagnostics.exists, true);
-    assert.equal(diagnostics.is_file, false);
-    assert.equal(diagnostics.writable, false);
-
-    fs.rmSync(dir, { recursive: true, force: true });
+    try {
+      const diagnostics = getFileWriteDiagnostics(dir);
+      assert.equal(diagnostics.exists, true);
+      assert.equal(diagnostics.is_file, false);
+      assert.equal(diagnostics.writable, false);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/test/unit.test.mjs
+++ b/test/unit.test.mjs
@@ -233,6 +233,7 @@ describe("getFileWriteDiagnostics", () => {
       assert.equal(diagnostics.exists, false);
       assert.equal(diagnostics.is_file, false);
       assert.equal(diagnostics.writable, false);
+      assert.equal(diagnostics.parent_dir_writable, true);
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/test/unit.test.mjs
+++ b/test/unit.test.mjs
@@ -11,6 +11,7 @@ import {
   inferScenePositionFromPath,
   isCanonicalWorldEntityFile,
   getSyncOwnershipDiagnostics,
+  getFileWriteDiagnostics,
   isWorldFile,
   readMeta,
   isSyncDirWritable,
@@ -202,6 +203,40 @@ describe("getSyncOwnershipDiagnostics", () => {
     assert.equal(diagnostics.sync_dir_is_directory, false);
     assert.equal(diagnostics.sync_dir_exists, false);
     assert.equal(diagnostics.sampled_paths, 0);
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+describe("getFileWriteDiagnostics", () => {
+  test("reports writable regular files", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "file-write-"));
+    const filePath = path.join(dir, "scene.md");
+    fs.writeFileSync(filePath, "Prose", "utf8");
+
+    const diagnostics = getFileWriteDiagnostics(filePath);
+    assert.equal(diagnostics.exists, true);
+    assert.equal(diagnostics.is_file, true);
+    assert.equal(diagnostics.parent_dir_writable, true);
+    assert.equal(typeof diagnostics.writable, "boolean");
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("reports missing files without throwing", () => {
+    const diagnostics = getFileWriteDiagnostics("/tmp/__nonexistent_dir_xyz__/missing.md");
+    assert.equal(diagnostics.exists, false);
+    assert.equal(diagnostics.is_file, false);
+    assert.equal(diagnostics.writable, false);
+  });
+
+  test("reports directories as non-writable prose targets", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "file-write-"));
+
+    const diagnostics = getFileWriteDiagnostics(dir);
+    assert.equal(diagnostics.exists, true);
+    assert.equal(diagnostics.is_file, false);
+    assert.equal(diagnostics.writable, false);
 
     fs.rmSync(dir, { recursive: true, force: true });
   });


### PR DESCRIPTION
## Summary
This PR improves the reliability of prose writing and character/place sheet creation.

## Changes
- `commit_edit` now checks file existence/type/writability and returns specific errors.
- `create_character_sheet`/`create_place_sheet` now reuse existing canonical folders, backfill missing files, and return `action: "exists"`.

## Tests
- `npm run test:unit` and `npm run test:integration` passing.