### PR TITLE
docs: correct README license footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,4 +627,4 @@ npm test
 
 ## License
 
-MIT
+AGPL-3.0-only


### PR DESCRIPTION
- Fixes stale README footer that still said MIT.
- Updates License section to AGPL-3.0-only to match repository licensing.