### PR TITLE
Enable metadata-keyword scene search in FTS with safe legacy migration

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -451,7 +451,7 @@ A scene without frontmatter/sidecar metadata is not a hard failure for sync, but
 | `list_places()` | All place entries |
 | `get_place_sheet(place_id)` | Place metadata, canonical sheet content, and adjacent support notes |
 | `create_place_sheet(name, project_id\|universe_id, notes?, fields?)` | Create or reuse a canonical place sheet folder with the same idempotent/backfill semantics as `create_character_sheet`. Exactly one of `project_id` or `universe_id` must be provided; omitting both or supplying both returns a `VALIDATION_ERROR` |
-| `search_metadata(query)` | Lightweight text search across loglines and tags |
+| `search_metadata(query)` | Lightweight text search across scene titles, loglines, and metadata keywords (tags/characters/places/versions) |
 
 ### Prose retrieval (loads file content — use targeted)
 

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ Outcome: you get AI speed with explicit approval and recoverable history for eve
 | `list_places` | All places |
 | `get_place_sheet` | Full place metadata, tags, associated characters, notes, and support notes |
 | `create_place_sheet` | Create a canonical place sheet folder and sidecar |
-| `search_metadata` | Full-text search across scene titles and loglines |
+| `search_metadata` | Full-text search across scene titles, loglines, and metadata keywords (tags/characters/places/versions) |
 | `list_threads` | All subplot threads for a project |
 | `get_thread_arc` | Scenes belonging to a thread, with per-thread beat |
 | `upsert_thread_link` | Create/update a thread and link it to a scene |

--- a/db.js
+++ b/db.js
@@ -116,12 +116,43 @@ export const SCHEMA = `
   );
 
   CREATE VIRTUAL TABLE IF NOT EXISTS scenes_fts USING fts5(
-    scene_id, project_id, logline, title
+    scene_id, project_id, logline, title, keywords
   );
 `;
 
 export function openDb(dbPath) {
   const db = new DatabaseSync(dbPath);
   db.exec(SCHEMA);
+
+  // Rebuild legacy FTS table if it predates keyword indexing.
+  // Preserve existing indexed rows so metadata search remains available
+  // even before the next sync pass repopulates from source files.
+  const ftsSql = db.prepare(`
+    SELECT sql
+    FROM sqlite_master
+    WHERE type = 'table' AND name = 'scenes_fts'
+  `).get()?.sql;
+  if (typeof ftsSql === "string" && !ftsSql.toLowerCase().includes("keywords")) {
+    db.exec(`BEGIN IMMEDIATE;`);
+    try {
+      db.exec(`
+        CREATE VIRTUAL TABLE scenes_fts_migrating USING fts5(
+          scene_id, project_id, logline, title, keywords
+        );
+      `);
+      db.exec(`
+        INSERT INTO scenes_fts_migrating (scene_id, project_id, logline, title, keywords)
+        SELECT scene_id, project_id, logline, title, ''
+        FROM scenes_fts;
+      `);
+      db.exec(`DROP TABLE scenes_fts;`);
+      db.exec(`ALTER TABLE scenes_fts_migrating RENAME TO scenes_fts;`);
+      db.exec(`COMMIT;`);
+    } catch (err) {
+      db.exec(`ROLLBACK;`);
+      throw err;
+    }
+  }
+
   return db;
 }

--- a/index.js
+++ b/index.js
@@ -946,7 +946,7 @@ function createMcpServer() {
   // ---- search_metadata -----------------------------------------------------
   s.tool(
     "search_metadata",
-    "Full-text search across scene titles and loglines (synopsis/logline text fields). Use this when you don't know the exact scene_id or chapter but want to find scenes by topic, theme, or keywords in the description. Not a prose search — use get_scene_prose to read actual text. Supports pagination via page/page_size and auto-paginates large result sets with total_count.",
+    "Full-text search across scene titles, loglines (synopsis/logline text fields), and metadata keywords (tags/characters/places/versions). Use this when you don't know the exact scene_id or chapter but want to find scenes by topic, theme, or metadata keyword. Not a prose search — use get_scene_prose to read actual text. Supports pagination via page/page_size and auto-paginates large result sets with total_count.",
     {
       query: z.string().describe("Search terms (e.g. 'hospital' or 'Sebastian feeding'). FTS5 syntax supported."),
       page: z.number().int().min(1).optional().describe("Optional page number for paginated responses (1-based)."),

--- a/sync.js
+++ b/sync.js
@@ -515,8 +515,24 @@ export function indexSceneFile(db, syncDir, file, meta, prose) {
     );
   }
 
-  db.prepare(`INSERT OR REPLACE INTO scenes_fts (scene_id, project_id, logline, title) VALUES (?, ?, ?, ?)`).run(
-    meta.scene_id, project_id, meta.logline ?? meta.synopsis ?? "", meta.title ?? ""
+  const keywordTokens = [
+    ...(meta.tags ?? []),
+    ...(meta.characters ?? []),
+    ...(meta.places ?? []),
+    ...(meta.versions ?? []),
+  ]
+    .filter(Boolean)
+    .map(String)
+    .map(s => s.trim())
+    .filter(Boolean)
+    .join(" ");
+
+  db.prepare(`INSERT OR REPLACE INTO scenes_fts (scene_id, project_id, logline, title, keywords) VALUES (?, ?, ?, ?, ?)`).run(
+    meta.scene_id,
+    project_id,
+    meta.logline ?? meta.synopsis ?? "",
+    meta.title ?? "",
+    keywordTokens,
   );
 
   return { isStale };

--- a/test/integration.test.mjs
+++ b/test/integration.test.mjs
@@ -204,6 +204,7 @@ tags:
   - conflict
   - backstory
   - harbor
+  - Daniel Nystrom
 `
   );
 
@@ -923,6 +924,11 @@ describe("search_metadata tool", () => {
   test("search envelope returns sc-003 (logline)", async () => {
     const text = await callTool("search_metadata", { query: "envelope" });
     assert.ok(text.includes("sc-003"));
+  });
+
+  test("search matches metadata keyword phrases from sidecar fields", async () => {
+    const text = await callTool("search_metadata", { query: '"Daniel Nystrom"' });
+    assert.ok(text.includes("sc-002"));
   });
 
   test("supports pagination with total_count", async () => {

--- a/test/unit.test.mjs
+++ b/test/unit.test.mjs
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import os from "node:os";
 import fs from "node:fs";
 import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import { spawnSync } from "node:child_process";
 import yaml from "js-yaml";
 import {
@@ -332,6 +333,50 @@ describe("world entity canonical detection", () => {
   test("nested support note is not canonical unless explicitly marked", () => {
     assert.ok(!isCanonicalWorldEntityFile(syncDir, "/sync/projects/novel/world/characters/elena/arc.md"));
     assert.ok(isCanonicalWorldEntityFile(syncDir, "/sync/projects/novel/world/characters/elena/arc.md", { canonical: true }));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// openDb migration safety
+// ---------------------------------------------------------------------------
+describe("openDb", () => {
+  test("migrates legacy scenes_fts schema and preserves existing rows", () => {
+    const dbPath = path.join(os.tmpdir(), `mcp-writing-db-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`);
+
+    try {
+      const legacyDb = new DatabaseSync(dbPath);
+      legacyDb.exec(`
+        CREATE VIRTUAL TABLE scenes_fts USING fts5(
+          scene_id, project_id, logline, title
+        );
+      `);
+      legacyDb.prepare(`
+        INSERT INTO scenes_fts (scene_id, project_id, logline, title)
+        VALUES (?, ?, ?, ?)
+      `).run("sc-legacy", "test-novel", "Legacy envelope logline", "Legacy Scene");
+      legacyDb.close();
+
+      const db = openDb(dbPath);
+
+      const ftsSql = db.prepare(`
+        SELECT sql
+        FROM sqlite_master
+        WHERE type = 'table' AND name = 'scenes_fts'
+      `).get()?.sql;
+      assert.ok(typeof ftsSql === "string" && ftsSql.toLowerCase().includes("keywords"));
+
+      const matches = db.prepare(`
+        SELECT scene_id
+        FROM scenes_fts
+        WHERE scenes_fts MATCH 'envelope'
+      `).all();
+      assert.equal(matches.length, 1);
+      assert.equal(matches[0].scene_id, "sc-legacy");
+
+      db.close();
+    } finally {
+      fs.rmSync(dbPath, { force: true });
+    }
   });
 });
 


### PR DESCRIPTION
## What changed
This PR makes `search_metadata` match free-text metadata keywords (for example Scrivener keyword names) without requiring canonical character ID linkage.

## Implementation
- Added `keywords` to `scenes_fts`.
- Synced keyword tokens from scene metadata arrays:
  - tags
  - characters
  - places
  - versions
- Updated tool/docs wording to reflect the expanded search scope.

## Migration safety
- Legacy `scenes_fts` schemas are migrated transactionally.
- Existing FTS rows are copied forward (`keywords` initialized empty) before swap.

## Tests
- Added integration test proving phrase search finds scene by metadata keyword.
- Added unit test for legacy FTS migration preserving existing searchable rows.
- Full suite passing: `npm test` (145/145).