### PR TITLE
docs: add data ownership model section to README

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -7,7 +7,7 @@ Canonical release setup and maintainer operations live in `MAINTAINERS.md`.
 ## Ways of working
 
 - Always review the `PRD.md` for related notes to the functionality discussed to maintain consistency over time, and avoid unnecessary scope creep.
-- Don't implement features immediately, first, discuss potential tradeoffs with the user.
+- Don't implement features immediately. First, discuss potential tradeoffs with the user.
   - Consider if a feature is in line with the established design principles of the tool, as established in the PRD.
   - Consider if the added scope and maintenance is proportional to the added value of new functionality.
   - Critically analyze not only the new feature, but how it relates to existing features.

--- a/AGENT.md
+++ b/AGENT.md
@@ -4,6 +4,44 @@ Purpose: Persist project-specific operating context for future AI sessions.
 
 Canonical release setup and maintainer operations live in `MAINTAINERS.md`.
 
+## Ways of working
+
+- Always review the `PRD.md` for related notes to the functionality discussed to maintain consistency over time, and avoid unnecessary scope creep.
+- Don't implement features immediately, first, discuss potential tradeoffs with the user.
+  - Consider if a feature is in line with the established design principles of the tool, as established in the PRD.
+  - Consider if the added scope and maintenance is proportional to the added value of new functionality.
+  - Critically analyze not only the new feature, but how it relates to existing features.
+  - Always consider unit tests and integration tests as part of changes.
+- All changes should start with a new branch from `main`.
+- Always open a PR at the end
+  - Write an appropriate description that helps the reviewer effectively.
+
+## PR description template
+
+Use this template to structure PR descriptions for clarity and consistency:
+
+```
+## <Feature/Fix Title>
+
+**What changed:**
+Brief summary of the change and which files were modified.
+
+**Why:**
+Design rationale, problem context, or architectural decision. Reference PRD.md where relevant.
+
+**Review focus:**
+- Key areas/files reviewers should scrutinize
+- Non-obvious design choices or tradeoffs
+- Anything that deviates from established patterns
+
+**Testing:**
+- New tests added (unit, integration, etc.)
+- Test coverage (pass count before/after, or statement coverage)
+- Manual verification steps if applicable
+```
+
+Adjust sections as needed (omit if not applicable), but maintain the structure for consistency.
+
 ## Repo workflow defaults
 
 - Branch strategy: PR-only into main.

--- a/README.md
+++ b/README.md
@@ -261,7 +261,11 @@ The importer is the authoritative writer for Scrivener-imported prose; any edits
 | `scenes/**/*.md` | **Scrivener / importer** | Full prose content | **Unconditionally overwritten.** Never edit `.md` files directly — changes will be lost on the next import. |
 | `scenes/**/*.meta.yaml` | **Importer** (Scrivener fields) + **AI agent** (enrichment fields) | Importer controls: `scene_id`, `title`, `timeline_position`, `external_source`, `external_id`, `save_the_cat_beat` | Importer spreads existing sidecar first, then overlays only its 5–6 fields. All other fields (logline, status, tags, characters, notes, flags, …) are preserved across re-imports. |
 
-**Rule:** only write AI-side fields (`logline`, `status`, `tags`, `characters`, `notes`, `metadata_stale`, etc.) via `update_scene_metadata`, `enrich_scene`, or `flag_scene`. Never write the Scrivener-controlled fields manually — the importer will overwrite them.
+**Rule:** write AI-side fields via the appropriate tool — never touch the Scrivener-controlled fields manually or the importer will overwrite them.
+- `update_scene_metadata` supports: `logline`, `status`, `tags`, `characters`, `places`, `pov`, `part`, `chapter`, `timeline_position`, `story_time`, `save_the_cat_beat`, `title`.
+- `flag_scene` appends accumulating continuity/review notes (free-text `flags` list).
+- `enrich_scene` re-derives lightweight metadata from the current prose and clears staleness.
+- `metadata_stale` is a SQLite-only flag set automatically by sync when prose changes — it is not a sidecar field and cannot be written by tools.
 
 ### sync — read-only with respect to files
 
@@ -270,7 +274,7 @@ The importer is the authoritative writer for Scrivener-imported prose; any edits
 | Operation | Reads | Writes |
 |---|---|---|
 | Indexing pass | `scenes/**/*.md`, `scenes/**/*.meta.yaml`, `world/**/*.md`, `world/**/*.meta.yaml` | SQLite only |
-| Frontmatter auto-migration | `scenes/**/*.md` (frontmatter) | `scenes/**/*.meta.yaml` (created once if missing) |
+| Frontmatter auto-migration | Any `.md`/`.txt` file (frontmatter block) | Corresponding `.meta.yaml` (created once if missing, for any file type including `world/**`) |
 
 `sync` never overwrites an existing sidecar and never touches a `.md` prose file.
 
@@ -280,11 +284,11 @@ The importer never reads or writes anything under `world/`. These files are full
 
 | File | Writer | Description |
 |---|---|---|
-| `world/characters/<slug>/sheet.md` | **Human or AI agent** | Canonical character sheet. Editable directly or via `update_character_sheet`. |
+| `world/characters/<slug>/sheet.md` | **Human** | Canonical character sheet prose. Edit directly — no tool writes this file. |
 | `world/characters/<slug>/*.md` | **Human or AI agent** | Arc notes, relationship docs, history. Add and edit freely. |
-| `world/characters/<slug>/sheet.meta.yaml` | **AI agent** | Character metadata. Written by `create_character_sheet`, `update_character_sheet`. |
-| `world/places/<slug>/sheet.md` | **Human or AI agent** | Canonical place sheet. Editable directly or via `update_character_sheet`. |
-| `world/places/<slug>/sheet.meta.yaml` | **AI agent** | Place metadata. Written by `create_place_sheet`. |
+| `world/characters/<slug>/sheet.meta.yaml` | **AI agent** | Character metadata (`name`, `role`, `arc_summary`, `first_appearance`, `traits`). Written by `create_character_sheet`, `update_character_sheet`. |
+| `world/places/<slug>/sheet.md` | **Human** | Canonical place sheet prose. Edit directly — no tool writes this file. |
+| `world/places/<slug>/sheet.meta.yaml` | **AI agent** | Place metadata (`name`, `associated_characters`, `tags`). Written by `create_place_sheet`, `update_place_sheet`. |
 | `world/reference/**/*.md` | **Human** | Free-form reference notes (world rules, timelines, etc.). Never indexed as entities. |
 
 **Rule:** all character and place changes that should survive forever — backstory, relationships, traits, arc notes — belong in `world/`. This content is never at risk from a Scrivener re-import.

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ Two separate rulesets apply depending on whether a file lives under `scenes/` (i
 
 ### scenes/ — import-managed files
 
-The importer is the only writer for prose. Sidecars are shared but with clearly partitioned fields.
+The importer is the authoritative writer for Scrivener-imported prose; any edits to `scenes/**/*.md` (manual or via tools) will be overwritten on re-import. Sidecars are shared but with clearly partitioned fields.
 
 | File | Writer | Fields written | Behaviour on re-import |
 |---|---|---|---|

--- a/README.md
+++ b/README.md
@@ -248,6 +248,59 @@ Recommended workflow:
 
 ---
 
+## Data ownership model
+
+Two separate rulesets apply depending on whether a file lives under `scenes/` (import-managed) or `world/` (human/agent-managed). Mixing writers outside these rules risks silent data loss.
+
+### scenes/ — import-managed files
+
+The importer is the only writer for prose. Sidecars are shared but with clearly partitioned fields.
+
+| File | Writer | Fields written | Behaviour on re-import |
+|---|---|---|---|
+| `scenes/**/*.md` | **Scrivener / importer** | Full prose content | **Unconditionally overwritten.** Never edit `.md` files directly — changes will be lost on the next import. |
+| `scenes/**/*.meta.yaml` | **Importer** (Scrivener fields) + **AI agent** (enrichment fields) | Importer controls: `scene_id`, `title`, `timeline_position`, `external_source`, `external_id`, `save_the_cat_beat` | Importer spreads existing sidecar first, then overlays only its 5–6 fields. All other fields (logline, status, tags, characters, notes, flags, …) are preserved across re-imports. |
+
+**Rule:** only write AI-side fields (`logline`, `status`, `tags`, `characters`, `notes`, `metadata_stale`, etc.) via `update_scene_metadata`, `enrich_scene`, or `flag_scene`. Never write the Scrivener-controlled fields manually — the importer will overwrite them.
+
+### sync — read-only with respect to files
+
+`sync` reads files and writes only to SQLite. It never touches `.md` prose. The one exception is auto-migration: if a `.md` file has YAML frontmatter but no sidecar yet, sync will create the `.meta.yaml` from the frontmatter (one-time, non-destructive). After that, the sidecar is the source of truth and frontmatter is ignored.
+
+| Operation | Reads | Writes |
+|---|---|---|
+| Indexing pass | `scenes/**/*.md`, `scenes/**/*.meta.yaml`, `world/**/*.md`, `world/**/*.meta.yaml` | SQLite only |
+| Frontmatter auto-migration | `scenes/**/*.md` (frontmatter) | `scenes/**/*.meta.yaml` (created once if missing) |
+
+`sync` never overwrites an existing sidecar and never touches a `.md` prose file.
+
+### world/ — human/agent-managed files
+
+The importer never reads or writes anything under `world/`. These files are fully owned by humans and the AI agent and are safe to edit at any time without import risk.
+
+| File | Writer | Description |
+|---|---|---|
+| `world/characters/<slug>/sheet.md` | **Human or AI agent** | Canonical character sheet. Editable directly or via `update_character_sheet`. |
+| `world/characters/<slug>/*.md` | **Human or AI agent** | Arc notes, relationship docs, history. Add and edit freely. |
+| `world/characters/<slug>/sheet.meta.yaml` | **AI agent** | Character metadata. Written by `create_character_sheet`, `update_character_sheet`. |
+| `world/places/<slug>/sheet.md` | **Human or AI agent** | Canonical place sheet. Editable directly or via `update_character_sheet`. |
+| `world/places/<slug>/sheet.meta.yaml` | **AI agent** | Place metadata. Written by `create_place_sheet`. |
+| `world/reference/**/*.md` | **Human** | Free-form reference notes (world rules, timelines, etc.). Never indexed as entities. |
+
+**Rule:** all character and place changes that should survive forever — backstory, relationships, traits, arc notes — belong in `world/`. This content is never at risk from a Scrivener re-import.
+
+### Summary
+
+| What you want to change | Where to make the change |
+|---|---|
+| Prose wording | Scrivener → re-import |
+| Scene logline, status, tags, beat analysis | `scenes/*.meta.yaml` via AI tools |
+| Character traits, backstory, relationships | `world/characters/<slug>/` files |
+| Place descriptions and lore | `world/places/<slug>/` files |
+| Shared world rules, timelines, reference | `world/reference/` files |
+
+---
+
 ## Appendix: Real-world usage scenarios
 
 The tool list is useful as reference. These example workflows show how people actually use `mcp-writing` while drafting and revising.

--- a/README.md
+++ b/README.md
@@ -256,10 +256,10 @@ Two separate rulesets apply depending on whether a file lives under `scenes/` (i
 
 The importer is the authoritative writer for Scrivener-imported prose; any edits to `scenes/**/*.md` (manual or via tools) will be overwritten on re-import. Sidecars are shared but with clearly partitioned fields.
 
-| File | Writer | Fields written | Behaviour on re-import |
+| File | Writer | Fields written | Behavior on re-import |
 |---|---|---|---|
 | `scenes/**/*.md` | **Scrivener / importer** | Full prose content | **Unconditionally overwritten.** Never edit `.md` files directly — changes will be lost on the next import. |
-| `scenes/**/*.meta.yaml` | **Importer** (Scrivener fields) + **AI agent** (enrichment fields) | Importer controls: `scene_id`, `title`, `timeline_position`, `external_source`, `external_id`, `save_the_cat_beat` | Importer spreads existing sidecar first, then overlays only its 5–6 fields. All other fields (logline, status, tags, characters, notes, flags, …) are preserved across re-imports. |
+| `scenes/**/*.meta.yaml` | **Importer** (Scrivener fields) + **AI agent** (enrichment fields) | Importer writes: `scene_id`, `external_source`, `external_id` (always); `title`, `timeline_position`, `save_the_cat_beat` (from Scrivener metadata, also writable by agents via `update_scene_metadata`) | Importer spreads existing sidecar first, then overlays only its fields. All other fields (logline, status, tags, characters, notes, flags, …) are preserved across re-imports. |
 
 **Rule:** write AI-side fields via the appropriate tool — never touch the Scrivener-controlled fields manually or the importer will overwrite them.
 - `update_scene_metadata` supports: `logline`, `status`, `tags`, `characters`, `places`, `pov`, `part`, `chapter`, `timeline_position`, `story_time`, `save_the_cat_beat`, `title`.
@@ -284,10 +284,10 @@ The importer never reads or writes anything under `world/`. These files are full
 
 | File | Writer | Description |
 |---|---|---|
-| `world/characters/<slug>/sheet.md` | **Human** | Canonical character sheet prose. Edit directly — no tool writes this file. |
+| `world/characters/<slug>/sheet.md` | **Human** (after creation) | Canonical character sheet prose. `create_character_sheet` writes this file once on first setup; after that it is human-owned and no tool modifies it. |
 | `world/characters/<slug>/*.md` | **Human or AI agent** | Arc notes, relationship docs, history. Add and edit freely. |
 | `world/characters/<slug>/sheet.meta.yaml` | **AI agent** | Character metadata (`name`, `role`, `arc_summary`, `first_appearance`, `traits`). Written by `create_character_sheet`, `update_character_sheet`. |
-| `world/places/<slug>/sheet.md` | **Human** | Canonical place sheet prose. Edit directly — no tool writes this file. |
+| `world/places/<slug>/sheet.md` | **Human** (after creation) | Canonical place sheet prose. `create_place_sheet` writes this file once on first setup; after that it is human-owned and no tool modifies it. |
 | `world/places/<slug>/sheet.meta.yaml` | **AI agent** | Place metadata (`name`, `associated_characters`, `tags`). Written by `create_place_sheet`, `update_place_sheet`. |
 | `world/reference/**/*.md` | **Human** | Free-form reference notes (world rules, timelines, etc.). Never indexed as entities. |
 


### PR DESCRIPTION
Documents the three-way split between importer, sync, and AI agent writes to prevent silent data loss from conflicting writers.

- scenes/*.md: Scrivener/importer only, unconditionally overwritten on re-import
- scenes/*.meta.yaml: shared surface; importer owns 5-6 Scrivener fields, AI agent owns enrichment fields (logline, status, tags, notes, flags, ...)
- sync: read-only with respect to files; only writes SQLite + one-time frontmatter-to-sidecar auto-migration if no sidecar exists yet
- world/**:  importer never touches this tree; fully owned by human/agent, safe to edit at any time without import risk

Includes a summary table mapping 'what to change' to 'where to change it'.