### PR TITLE
docs: generate tool reference and enforce it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,3 +49,25 @@ jobs:
 
       - name: Run ESLint
         run: npm run lint
+
+  docs:
+    name: Generated Docs
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Regenerate tool reference
+        run: npm run docs
+
+      - name: Verify generated docs are committed
+        run: git diff --exit-code -- docs/tools.md

--- a/README.md
+++ b/README.md
@@ -306,9 +306,10 @@ Outcome: you get AI speed with explicit approval and recoverable history for eve
 | `import_scrivener_sync` | Import Scrivener Draft export into sidecars and optionally auto-run sync |
 | `find_scenes` | Filter scenes by character, beat, tag, part, chapter, or POV |
 | `get_scene_prose` | Load the full prose for a specific scene |
-| `get_chapter_prose` | Load all prose for a chapter |
+| `get_chapter_prose` | Load all prose for a project's chapter |
 | `get_runtime_config` | Show active paths/capabilities plus runtime warnings and setup recommendations |
 | `get_arc` | Ordered scene metadata for all scenes involving a character |
+| `get_relationship_arc` | Show how a recorded relationship between two characters evolves across scenes |
 | `list_characters` | All characters, optionally filtered by project or universe |
 | `get_character_sheet` | Full character metadata, traits, notes, and support notes |
 | `create_character_sheet` | Create a canonical character sheet folder and sidecar |
@@ -325,12 +326,14 @@ Outcome: you get AI speed with explicit approval and recoverable history for eve
 | `update_place_sheet` | Write fields back to a place sidecar |
 | `flag_scene` | Mark a scene with a flag for AI follow-up |
 | `propose_edit` | Stage a scene revision for review without writing it |
-| `commit_edit` | Apply a staged prose edit and create a git-backed snapshot |
+| `commit_edit` | Apply a staged prose edit for a specific scene and create a git-backed snapshot |
 | `discard_edit` | Discard a pending staged prose edit |
-| `snapshot_scene` | Create a manual git snapshot for a scene |
+| `snapshot_scene` | Create a manual git snapshot for a scene in a project |
 | `list_snapshots` | List snapshot history for a scene |
 
 Paginated tools (`find_scenes`, `get_arc`, `list_threads`, `get_thread_arc`, `search_metadata`) accept `page` and `page_size` arguments and return `total_count` / `total_pages` in the response envelope.
+
+For tools that operate on a scene or chapter inside a specific project, follow the required `project_id` fields shown in your MCP client schema.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -300,40 +300,13 @@ Outcome: you get AI speed with explicit approval and recoverable history for eve
 
 ## Reference: Available tools
 
-| Tool | Description |
-| --- | --- |
-| `sync` | Re-scan the sync folder and update the index |
-| `import_scrivener_sync` | Import Scrivener Draft export into sidecars and optionally auto-run sync |
-| `find_scenes` | Filter scenes by character, beat, tag, part, chapter, or POV |
-| `get_scene_prose` | Load the full prose for a specific scene |
-| `get_chapter_prose` | Load all prose for a project's chapter |
-| `get_runtime_config` | Show active paths/capabilities plus runtime warnings and setup recommendations |
-| `get_arc` | Ordered scene metadata for all scenes involving a character |
-| `get_relationship_arc` | Show how a recorded relationship between two characters evolves across scenes |
-| `list_characters` | All characters, optionally filtered by project or universe |
-| `get_character_sheet` | Full character metadata, traits, notes, and support notes |
-| `create_character_sheet` | Create a canonical character sheet folder and sidecar |
-| `list_places` | All places |
-| `get_place_sheet` | Full place metadata, tags, associated characters, notes, and support notes |
-| `create_place_sheet` | Create a canonical place sheet folder and sidecar |
-| `search_metadata` | Full-text search across scene titles, loglines, and metadata keywords (tags/characters/places/versions) |
-| `list_threads` | All subplot threads for a project |
-| `get_thread_arc` | Scenes belonging to a thread, with per-thread beat |
-| `upsert_thread_link` | Create/update a thread and link it to a scene |
-| `enrich_scene` | Re-derive lightweight metadata from current prose and clear `metadata_stale` |
-| `update_scene_metadata` | Write metadata fields back to a scene sidecar |
-| `update_character_sheet` | Write fields back to a character sidecar |
-| `update_place_sheet` | Write fields back to a place sidecar |
-| `flag_scene` | Mark a scene with a flag for AI follow-up |
-| `propose_edit` | Stage a scene revision for review without writing it |
-| `commit_edit` | Apply a staged prose edit for a specific scene and create a git-backed snapshot |
-| `discard_edit` | Discard a pending staged prose edit |
-| `snapshot_scene` | Create a manual git snapshot for a scene in a project |
-| `list_snapshots` | List snapshot history for a scene |
+The full tool reference — with every parameter, type, and description — is auto-generated from source and lives at **[docs/tools.md](docs/tools.md)**.
 
-Paginated tools (`find_scenes`, `get_arc`, `list_threads`, `get_thread_arc`, `search_metadata`) accept `page` and `page_size` arguments and return `total_count` / `total_pages` in the response envelope.
+To regenerate after editing tool definitions in `index.js`:
 
-For tools that operate on a scene or chapter inside a specific project, follow the required `project_id` fields shown in your MCP client schema.
+```bash
+npm run docs
+```
 
 ---
 

--- a/docs/prd/done/editing.md
+++ b/docs/prd/done/editing.md
@@ -62,7 +62,7 @@ If any check fails, no snapshot is created and no prose is written. The tool ret
 
 | Tool | Description |
 | --- | --- |
-| `get_relationship_arc(character_id, character_id)` | Temporal character relationship graph between two characters |
+| `get_relationship_arc(from_character, to_character, project_id?)` | Temporal character relationship graph between two characters |
 
 Shows how the relationship between two characters evolves across scenes with state transitions (TRUST, CONFLICT, DEPENDENCY, AFFECTION, etc.) and their causes.
 

--- a/docs/prd/done/search-analysis.md
+++ b/docs/prd/done/search-analysis.md
@@ -22,6 +22,7 @@ These tools return scene/character/place metadata without loading prose:
 | `create_place_sheet(name, project_id\|universe_id, notes?, fields?)` | Create or reuse a canonical place sheet folder with same semantics as `create_character_sheet` |
 | `list_threads(project_id, page?, page_size?)` | All threads with status |
 | `get_thread_arc(thread_id, page?, page_size?)` | Ordered scene metadata for all scenes in a thread, including per-thread beat |
+| `get_relationship_arc(from_character, to_character, project_id?)` | Ordered relationship entries between two characters, optionally scoped to one project |
 | `search_metadata(query, page?, page_size?)` | Lightweight text search across scene titles, loglines, and metadata keywords (tags/characters/places/versions) |
 | `get_runtime_config()` | Active runtime paths/capabilities, diagnostics (`sync_dir_writable`, permission diagnostics), warnings, setup recommendations, git availability/enabled state |
 
@@ -32,7 +33,7 @@ Use these when you need actual text content:
 | Tool | Description |
 | --- | --- |
 | `get_scene_prose(scene_id, commit?)` | Returns prose for a scene; optionally a past git commit hash |
-| `get_chapter_prose(project_id?, part, chapter)` | Returns all prose for a chapter (use sparingly — see Known Issues) |
+| `get_chapter_prose(project_id, part, chapter)` | Returns all prose for a chapter (use sparingly — see Known Issues) |
 
 ### Search Mechanics
 
@@ -65,8 +66,8 @@ Staleness occurs when prose has been edited since metadata was last updated. Cal
 
 ### 1. Character Arc Consistency Review
 
-1. `get_character_sheet("elena")` — load traits, arc summary
-2. `get_arc("elena")` — ordered scene metadata, loglines, beat tags
+1. `get_character_sheet("char-elena")` — load traits, arc summary
+2. `get_arc("char-elena")` — ordered scene metadata, loglines, beat tags
 3. Model identifies 3 scenes worth examining based on metadata
 4. `get_scene_prose(scene_id)` × 3 — load only those scenes
 5. Model reasons against character sheet
@@ -79,13 +80,13 @@ Staleness occurs when prose has been edited since metadata was last updated. Cal
 
 ### 3. "What Happens in the Harbor?"
 
-1. `find_scenes(places=["harbor-district"])` — metadata only
+1. `search_metadata("harbor-district")` — metadata only
 2. Model summarizes from loglines — may not need prose at all
 
 ### 4. Cross-Scene Continuity Check
 
-1. `find_scenes(character="marcus")` — all Marcus scenes
-2. `get_relationship_arc("marcus", "elena")` — their relationship evolution
+1. `find_scenes(character="char-marcus")` — all Marcus scenes
+2. `get_relationship_arc("char-marcus", "char-elena")` — their relationship evolution
 3. `get_scene_prose(scene_id)` for relationship turning points only
 4. Model identifies continuity gaps or inconsistencies
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,38 +1,38 @@
 # Tool Reference
 
-> Auto-generated from `index.js` on 2026-04-20.
+> Auto-generated from `index.js`.
 > Do not edit manually — run `npm run docs` to regenerate.
 
 ## Tools
 
 - [`sync`](#sync)
-- [`import_scrivener_sync`](#import-scrivener-sync)
-- [`get_runtime_config`](#get-runtime-config)
-- [`find_scenes`](#find-scenes)
-- [`get_scene_prose`](#get-scene-prose)
-- [`get_chapter_prose`](#get-chapter-prose)
-- [`get_arc`](#get-arc)
-- [`list_characters`](#list-characters)
-- [`get_character_sheet`](#get-character-sheet)
-- [`create_character_sheet`](#create-character-sheet)
-- [`list_places`](#list-places)
-- [`create_place_sheet`](#create-place-sheet)
-- [`get_place_sheet`](#get-place-sheet)
-- [`search_metadata`](#search-metadata)
-- [`list_threads`](#list-threads)
-- [`get_thread_arc`](#get-thread-arc)
-- [`upsert_thread_link`](#upsert-thread-link)
-- [`enrich_scene`](#enrich-scene)
-- [`update_scene_metadata`](#update-scene-metadata)
-- [`update_character_sheet`](#update-character-sheet)
-- [`update_place_sheet`](#update-place-sheet)
-- [`flag_scene`](#flag-scene)
-- [`get_relationship_arc`](#get-relationship-arc)
-- [`propose_edit`](#propose-edit)
-- [`commit_edit`](#commit-edit)
-- [`discard_edit`](#discard-edit)
-- [`snapshot_scene`](#snapshot-scene)
-- [`list_snapshots`](#list-snapshots)
+- [`import_scrivener_sync`](#import_scrivener_sync)
+- [`get_runtime_config`](#get_runtime_config)
+- [`find_scenes`](#find_scenes)
+- [`get_scene_prose`](#get_scene_prose)
+- [`get_chapter_prose`](#get_chapter_prose)
+- [`get_arc`](#get_arc)
+- [`list_characters`](#list_characters)
+- [`get_character_sheet`](#get_character_sheet)
+- [`create_character_sheet`](#create_character_sheet)
+- [`list_places`](#list_places)
+- [`create_place_sheet`](#create_place_sheet)
+- [`get_place_sheet`](#get_place_sheet)
+- [`search_metadata`](#search_metadata)
+- [`list_threads`](#list_threads)
+- [`get_thread_arc`](#get_thread_arc)
+- [`upsert_thread_link`](#upsert_thread_link)
+- [`enrich_scene`](#enrich_scene)
+- [`update_scene_metadata`](#update_scene_metadata)
+- [`update_character_sheet`](#update_character_sheet)
+- [`update_place_sheet`](#update_place_sheet)
+- [`flag_scene`](#flag_scene)
+- [`get_relationship_arc`](#get_relationship_arc)
+- [`propose_edit`](#propose_edit)
+- [`commit_edit`](#commit_edit)
+- [`discard_edit`](#discard_edit)
+- [`snapshot_scene`](#snapshot_scene)
+- [`list_snapshots`](#list_snapshots)
 
 ---
 
@@ -96,7 +96,7 @@ Load the full prose text of a single scene. Use this for close reading, continui
 
 ## get_chapter_prose
 
-Load the full prose for every scene in a chapter, concatenated in order. Expensive — only use when you need to read an entire chapter. Capped at ${MAX_CHAPTER_SCENES} scenes. Use find_scenes first to confirm the chapter exists.
+Load the full prose for every scene in a chapter, concatenated in order. Expensive — only use when you need to read an entire chapter. Capped at 10 scenes. Use find_scenes first to confirm the chapter exists.
 
 | Parameter | Type | Required | Description |
 |-----------|------|:--------:|-------------|

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,0 +1,365 @@
+# Tool Reference
+
+> Auto-generated from `index.js` on 2026-04-20.
+> Do not edit manually — run `npm run docs` to regenerate.
+
+## Tools
+
+- [`sync`](#sync)
+- [`import_scrivener_sync`](#import-scrivener-sync)
+- [`get_runtime_config`](#get-runtime-config)
+- [`find_scenes`](#find-scenes)
+- [`get_scene_prose`](#get-scene-prose)
+- [`get_chapter_prose`](#get-chapter-prose)
+- [`get_arc`](#get-arc)
+- [`list_characters`](#list-characters)
+- [`get_character_sheet`](#get-character-sheet)
+- [`create_character_sheet`](#create-character-sheet)
+- [`list_places`](#list-places)
+- [`create_place_sheet`](#create-place-sheet)
+- [`get_place_sheet`](#get-place-sheet)
+- [`search_metadata`](#search-metadata)
+- [`list_threads`](#list-threads)
+- [`get_thread_arc`](#get-thread-arc)
+- [`upsert_thread_link`](#upsert-thread-link)
+- [`enrich_scene`](#enrich-scene)
+- [`update_scene_metadata`](#update-scene-metadata)
+- [`update_character_sheet`](#update-character-sheet)
+- [`update_place_sheet`](#update-place-sheet)
+- [`flag_scene`](#flag-scene)
+- [`get_relationship_arc`](#get-relationship-arc)
+- [`propose_edit`](#propose-edit)
+- [`commit_edit`](#commit-edit)
+- [`discard_edit`](#discard-edit)
+- [`snapshot_scene`](#snapshot-scene)
+- [`list_snapshots`](#list-snapshots)
+
+---
+
+## sync
+
+Re-scan the sync folder and update the scene/character/place index from disk. Call this after making edits in Scrivener or updating sidecar files outside the MCP.
+
+_No parameters._
+
+---
+
+## import_scrivener_sync
+
+Import Scrivener External Folder Sync Draft files into this server's WRITING_SYNC_DIR by generating scene sidecars and reconciling by Scrivener binder ID. Use this for first-time setup before sync().
+
+| Parameter | Type | Required | Description |
+|-----------|------|:--------:|-------------|
+| `source_dir` | `string` | ✓ | Path to Scrivener external sync folder (the folder that contains Draft/, or Draft/ itself). |
+| `project_id` | `string` |  | Project ID override (e.g. 'the-lamb'). Defaults to a slug derived from WRITING_SYNC_DIR. |
+| `dry_run` | `boolean` |  | If true, reports planned writes without changing files. |
+| `auto_sync` | `boolean` |  | If true (default), runs sync() after import when not dry-run. |
+
+---
+
+## get_runtime_config
+
+Show the active runtime paths and capabilities for this server instance (sync dir, database path, writability, permission diagnostics, and git availability). Use this to verify which manuscript location is currently connected.
+
+_No parameters._
+
+---
+
+## find_scenes
+
+Find scenes by filtering on character, Save the Cat beat, tags, part, chapter, or POV. Returns ordered scene metadata only — no prose. All filters are optional and combinable. Supports pagination via page/page_size and auto-paginates large result sets with total_count. Warns if any matching scenes have stale metadata.
+
+| Parameter | Type | Required | Description |
+|-----------|------|:--------:|-------------|
+| `project_id` | `string` |  | Project ID (e.g. 'the-lamb'). Use to scope results to one project. |
+| `character` | `string` |  | A character_id (e.g. 'char-mira-nystrom'). Returns only scenes that character appears in. Use list_characters first to find valid IDs. |
+| `beat` | `string` |  | Save the Cat beat name (e.g. 'Opening Image'). Exact match. |
+| `tag` | `string` |  | Scene tag to filter by. Exact match. |
+| `part` | `integer` |  | Part number (integer, e.g. 1). Chapters are numbered globally across the whole project. |
+| `chapter` | `integer` |  | Chapter number (integer, e.g. 3). Chapters are numbered globally across the whole project — do not reset per part. |
+| `pov` | `string` |  | POV character_id. Use list_characters first to find valid IDs. |
+| `page` | `integer` |  | Optional page number for paginated responses (1-based). |
+| `page_size` | `integer` |  | Optional page size for paginated responses (default: 20, max: 200). |
+
+---
+
+## get_scene_prose
+
+Load the full prose text of a single scene. Use this for close reading, continuity checks, or when you need the actual writing. For overview or filtering, use find_scenes instead — it is much cheaper. Optionally retrieve a past version from git history.
+
+| Parameter | Type | Required | Description |
+|-----------|------|:--------:|-------------|
+| `scene_id` | `string` | ✓ | The scene_id to retrieve (e.g. 'sc-001-prologue'). Get this from find_scenes or get_arc. |
+| `commit` | `string` |  | Optional git commit hash to retrieve a past version. Use list_snapshots to find valid hashes. If omitted, returns the current prose. |
+
+---
+
+## get_chapter_prose
+
+Load the full prose for every scene in a chapter, concatenated in order. Expensive — only use when you need to read an entire chapter. Capped at ${MAX_CHAPTER_SCENES} scenes. Use find_scenes first to confirm the chapter exists.
+
+| Parameter | Type | Required | Description |
+|-----------|------|:--------:|-------------|
+| `project_id` | `string` | ✓ | Project ID (e.g. 'the-lamb'). |
+| `part` | `integer` | ✓ | Part number (integer). |
+| `chapter` | `integer` | ✓ | Chapter number (integer, globally numbered across the whole project). |
+
+---
+
+## get_arc
+
+Get every scene a character appears in, ordered by part/chapter/position. Returns scene metadata only — no prose. Use this to trace a character's arc through the story. Supports pagination via page/page_size and auto-paginates large result sets with total_count. Call list_characters first to get the character_id.
+
+| Parameter | Type | Required | Description |
+|-----------|------|:--------:|-------------|
+| `character_id` | `string` | ✓ | The character_id to trace (e.g. 'char-mira-nystrom'). Use list_characters to find valid IDs. |
+| `project_id` | `string` |  | Limit to a specific project (e.g. 'the-lamb'). |
+| `page` | `integer` |  | Optional page number for paginated responses (1-based). |
+| `page_size` | `integer` |  | Optional page size for paginated responses (default: 20, max: 200). |
+
+---
+
+## list_characters
+
+List all indexed characters with their character_id, name, role, and arc_summary. Call this first whenever you need to filter scenes by character or look up a character sheet — it gives you the character_id values required by other tools.
+
+| Parameter | Type | Required | Description |
+|-----------|------|:--------:|-------------|
+| `project_id` | `string` |  | Limit to a specific project (e.g. 'the-lamb'). |
+| `universe_id` | `string` |  | Limit to a specific universe (if using cross-project world-building). |
+
+---
+
+## get_character_sheet
+
+Get full character details: role, arc_summary, traits, the canonical sheet content, and any adjacent support notes when the character uses a folder-based layout. Use list_characters first to get the character_id.
+
+| Parameter | Type | Required | Description |
+|-----------|------|:--------:|-------------|
+| `character_id` | `string` | ✓ | The character_id to look up (e.g. 'char-sebastian'). Use list_characters to find valid IDs. |
+
+---
+
+## create_character_sheet
+
+Create or reuse a canonical character sheet folder with sheet.md and sheet.meta.yaml so the character can be indexed immediately. If the folder already exists, missing canonical files are backfilled and the existing sheet is preserved.
+
+| Parameter | Type | Required | Description |
+|-----------|------|:--------:|-------------|
+| `name` | `string` | ✓ | Display name of the character (e.g. 'Mira Nystrom'). |
+| `project_id` | `string` |  | Project scope for a book-local character (e.g. 'universe-1/book-1-the-lamb' or 'test-novel'). |
+| `universe_id` | `string` |  | Universe scope for a cross-book shared character (e.g. 'universe-1'). |
+| `notes` | `string` |  | Optional starter prose content for sheet.md. |
+| `fields` | `object` |  | Optional starter metadata fields for the character sidecar. |
+
+---
+
+## list_places
+
+List all indexed places with their place_id and name. Use this to find place_id values for scene filtering or to get an overview of the story's locations.
+
+| Parameter | Type | Required | Description |
+|-----------|------|:--------:|-------------|
+| `project_id` | `string` |  | Limit to a specific project (e.g. 'the-lamb'). |
+| `universe_id` | `string` |  | Limit to a specific universe. |
+
+---
+
+## create_place_sheet
+
+Create or reuse a canonical place sheet folder with sheet.md and sheet.meta.yaml so the place can be indexed immediately. If the folder already exists, missing canonical files are backfilled and the existing sheet is preserved.
+
+| Parameter | Type | Required | Description |
+|-----------|------|:--------:|-------------|
+| `name` | `string` | ✓ | Display name of the place (e.g. 'University Hospital'). |
+| `project_id` | `string` |  | Project scope for a book-local place (e.g. 'universe-1/book-1-the-lamb' or 'test-novel'). |
+| `universe_id` | `string` |  | Universe scope for a cross-book shared place (e.g. 'universe-1'). |
+| `notes` | `string` |  | Optional starter prose content for sheet.md. |
+| `fields` | `object` |  | Optional starter metadata fields for the place sidecar. |
+
+---
+
+## get_place_sheet
+
+Get full place details: associated_characters, tags, the canonical sheet content, and any adjacent support notes when the place uses a folder-based layout. Use list_places first to get the place_id.
+
+| Parameter | Type | Required | Description |
+|-----------|------|:--------:|-------------|
+| `place_id` | `string` | ✓ | The place_id to look up (e.g. 'place-harbor-district'). Use list_places to find valid IDs. |
+
+---
+
+## search_metadata
+
+Full-text search across scene titles, loglines (synopsis/logline text fields), and metadata keywords (tags/characters/places/versions). Use this when you don't know the exact scene_id or chapter but want to find scenes by topic, theme, or metadata keyword. Not a prose search — use get_scene_prose to read actual text. Supports pagination via page/page_size and auto-paginates large result sets with total_count.
+
+| Parameter | Type | Required | Description |
+|-----------|------|:--------:|-------------|
+| `query` | `string` | ✓ | Search terms (e.g. 'hospital' or 'Sebastian feeding'). FTS5 syntax supported. |
+| `page` | `integer` |  | Optional page number for paginated responses (1-based). |
+| `page_size` | `integer` |  | Optional page size for paginated responses (default: 20, max: 200). |
+
+---
+
+## list_threads
+
+List all subplot/storyline threads for a project. Returns a structured JSON envelope with results and total_count. Supports pagination via page/page_size.
+
+| Parameter | Type | Required | Description |
+|-----------|------|:--------:|-------------|
+| `project_id` | `string` | ✓ | Project ID. |
+| `page` | `integer` |  | Optional page number for paginated responses (1-based). |
+| `page_size` | `integer` |  | Optional page size for paginated responses (default: 20, max: 200). |
+
+---
+
+## get_thread_arc
+
+Get ordered scene metadata for all scenes belonging to a thread, including the per-thread beat. Returns a structured JSON envelope with thread metadata, results, and total_count. Supports pagination via page/page_size.
+
+| Parameter | Type | Required | Description |
+|-----------|------|:--------:|-------------|
+| `thread_id` | `string` | ✓ | Thread ID. |
+| `page` | `integer` |  | Optional page number for paginated responses (1-based). |
+| `page_size` | `integer` |  | Optional page size for paginated responses (default: 20, max: 200). |
+
+---
+
+## upsert_thread_link
+
+Create or update a thread and link it to a scene. Idempotent: if the link already exists, updates its beat. Only available when the sync dir is writable.
+
+| Parameter | Type | Required | Description |
+|-----------|------|:--------:|-------------|
+| `project_id` | `string` | ✓ | Project the thread belongs to (e.g. 'the-lamb'). |
+| `thread_id` | `string` | ✓ | Thread ID (e.g. 'thread-reconciliation'). |
+| `thread_name` | `string` | ✓ | Thread display name. |
+| `scene_id` | `string` | ✓ | Scene to link to the thread (e.g. 'sc-011-sebastian'). |
+| `beat` | `string` |  | Optional thread-specific beat label for this scene. |
+| `status` | `string` |  | Thread status (e.g. 'active', 'resolved'). Defaults to 'active'. |
+
+---
+
+## enrich_scene
+
+Re-derive lightweight scene metadata from current prose (logline and character mentions) and clear metadata_stale for that scene. Only available when the sync dir is writable.
+
+| Parameter | Type | Required | Description |
+|-----------|------|:--------:|-------------|
+| `scene_id` | `string` | ✓ | Scene to enrich (e.g. 'sc-011-sebastian'). |
+| `project_id` | `string` |  | Project ID. Required when scene_id is duplicated across projects. |
+
+---
+
+## update_scene_metadata
+
+Update one or more metadata fields for a scene. Writes to the .meta.yaml sidecar — never modifies prose. Changes are immediately reflected in the index. Only available when the sync dir is writable.
+
+| Parameter | Type | Required | Description |
+|-----------|------|:--------:|-------------|
+| `scene_id` | `string` | ✓ | The scene_id to update (e.g. 'sc-011-sebastian'). |
+| `project_id` | `string` | ✓ | Project the scene belongs to (e.g. 'the-lamb'). |
+| `fields` | `object` |  | Fields to update. Only supplied keys are changed. |
+
+---
+
+## update_character_sheet
+
+Update structured metadata fields for a character (role, arc_summary, traits, etc). Writes to the .meta.yaml sidecar — never modifies the prose notes file. Changes are immediately reflected in the index. Only available when the sync dir is writable.
+
+| Parameter | Type | Required | Description |
+|-----------|------|:--------:|-------------|
+| `character_id` | `string` | ✓ | The character_id to update (e.g. 'char-mira-nystrom'). Use list_characters to find valid IDs. |
+| `fields` | `object` |  | Fields to update. Only supplied keys are changed. |
+
+---
+
+## update_place_sheet
+
+Update structured metadata fields for a place (name, associated_characters, tags). Writes to the .meta.yaml sidecar — never modifies the prose notes file. Changes are immediately reflected in the index. Only available when the sync dir is writable.
+
+| Parameter | Type | Required | Description |
+|-----------|------|:--------:|-------------|
+| `place_id` | `string` | ✓ | The place_id to update (e.g. 'place-harbor-district'). Use list_places to find valid IDs. |
+| `fields` | `object` |  | Fields to update. Only supplied keys are changed. |
+
+---
+
+## flag_scene
+
+Attach a continuity or review note to a scene. Flags are appended to the sidecar file and accumulate over time — they are never overwritten. Use this to record continuity problems, revision notes, or questions you want to revisit.
+
+| Parameter | Type | Required | Description |
+|-----------|------|:--------:|-------------|
+| `scene_id` | `string` | ✓ | The scene_id to flag (e.g. 'sc-012-open-to-anyone'). |
+| `project_id` | `string` | ✓ | Project the scene belongs to (e.g. 'the-lamb'). |
+| `note` | `string` | ✓ | The flag note (e.g. 'Victor knows Mira\u2019s name here, but they haven\u2019t been introduced yet \u2014 contradicts sc-006'). |
+
+---
+
+## get_relationship_arc
+
+Show how the relationship between two characters evolves across scenes, in order. Uses explicitly recorded relationship entries — returns nothing if no entries exist yet. Use list_characters to get character_id values.
+
+| Parameter | Type | Required | Description |
+|-----------|------|:--------:|-------------|
+| `from_character` | `string` | ✓ | character_id of the first character (e.g. 'char-sebastian'). |
+| `to_character` | `string` | ✓ | character_id of the second character (e.g. 'char-mira-nystrom'). |
+| `project_id` | `string` |  | Limit to a specific project (e.g. 'the-lamb'). |
+
+---
+
+## propose_edit
+
+Generate a proposed revision for a scene. Returns a proposal_id and a diff preview. Nothing is written yet — you must call commit_edit to apply the change. This tool requires git to be available.
+
+| Parameter | Type | Required | Description |
+|-----------|------|:--------:|-------------|
+| `scene_id` | `string` | ✓ | The scene_id to revise (e.g. 'sc-011-sebastian'). |
+| `instruction` | `string` | ✓ | A brief instruction for the edit (e.g. 'Tighten the opening paragraph'). Used in the git commit message. |
+| `revised_prose` | `string` | ✓ | The complete revised prose text for the scene. |
+
+---
+
+## commit_edit
+
+Apply a proposed edit and commit it to git. First creates a pre-edit snapshot, then writes the revised prose and metadata back to disk. The scene metadata stale flag is cleared.
+
+| Parameter | Type | Required | Description |
+|-----------|------|:--------:|-------------|
+| `scene_id` | `string` | ✓ | The scene_id being revised. |
+| `proposal_id` | `string` | ✓ | The proposal_id returned by propose_edit. |
+
+---
+
+## discard_edit
+
+Discard a pending proposal without applying it. The proposal is deleted and the prose remains unchanged.
+
+| Parameter | Type | Required | Description |
+|-----------|------|:--------:|-------------|
+| `proposal_id` | `string` | ✓ | The proposal_id to discard (from propose_edit). |
+
+---
+
+## snapshot_scene
+
+Manually create a git commit (snapshot) for the current state of a scene. Use this to mark important editing checkpoints outside of the propose/commit workflow.
+
+| Parameter | Type | Required | Description |
+|-----------|------|:--------:|-------------|
+| `scene_id` | `string` | ✓ | The scene_id to snapshot. |
+| `project_id` | `string` | ✓ | Project the scene belongs to. |
+| `reason` | `string` | ✓ | A brief reason for the snapshot (e.g. 'Character arc milestone reached'). |
+
+---
+
+## list_snapshots
+
+List git commit history for a scene, with timestamps and commit messages. Use this to find commit hashes for get_scene_prose historical retrieval.
+
+| Parameter | Type | Required | Description |
+|-----------|------|:--------:|-------------|
+| `scene_id` | `string` | ✓ | The scene_id to list snapshots for. |
+
+---

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -293,7 +293,7 @@ Attach a continuity or review note to a scene. Flags are appended to the sidecar
 |-----------|------|:--------:|-------------|
 | `scene_id` | `string` | ✓ | The scene_id to flag (e.g. 'sc-012-open-to-anyone'). |
 | `project_id` | `string` | ✓ | Project the scene belongs to (e.g. 'the-lamb'). |
-| `note` | `string` | ✓ | The flag note (e.g. 'Victor knows Mira\u2019s name here, but they haven\u2019t been introduced yet \u2014 contradicts sc-006'). |
+| `note` | `string` | ✓ | The flag note (e.g. 'Victor knows Mira’s name here, but they haven’t been introduced yet — contradicts sc-006'). |
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "setup:openclaw-env": "sh scripts/setup-openclaw-env.sh",
     "release": "release-it",
     "lint": "eslint index.js importer.js db.js sync.js metadata-lint.js scripts/",
+    "docs": "node scripts/generate-tool-docs.mjs",
     "lint:metadata": "node scripts/lint-metadata.mjs",
     "test:unit": "node --experimental-sqlite --test test/unit.test.mjs",
     "test:integration": "node --experimental-sqlite --test test/integration.test.mjs",

--- a/scripts/generate-tool-docs.mjs
+++ b/scripts/generate-tool-docs.mjs
@@ -359,13 +359,17 @@ function parseParams(schemaText) {
     const type        = zodTypeString(section);
     const optional    = /\.optional\(\)/.test(section);
 
-    // .describe("...") may be on any line of the section
+    // .describe("...") may be on any line of the section.
     // Use the *last* .describe() in the section so that z.object({...}).describe("outer")
     // wins over any .describe() calls on inner fields.
-    const allDescMatches = [...section.matchAll(/\.describe\("((?:[^"\\]|\\.)*)"\)/g)];
-    const description    = allDescMatches.length > 0
-      ? allDescMatches[allDescMatches.length - 1][1]
-      : '';
+    // Use readQuotedLiteral so JS escape sequences (\u2019 etc.) are decoded, not left raw.
+    let description = '';
+    const descRe = /\.describe\("/g;
+    let descMatch;
+    while ((descMatch = descRe.exec(section)) !== null) {
+      const { text } = readQuotedLiteral(section, descMatch.index + descMatch[0].length, '"');
+      description = text; // keep iterating to get the last one
+    }
 
     params.push({ name, type, optional, description });
   }

--- a/scripts/generate-tool-docs.mjs
+++ b/scripts/generate-tool-docs.mjs
@@ -1,0 +1,351 @@
+#!/usr/bin/env node
+/**
+ * Generates docs/tools.md from tool definitions in index.js.
+ *
+ * Run:  node scripts/generate-tool-docs.mjs
+ *   or: npm run docs
+ *
+ * The output is the single source of truth for the tool reference.
+ * Re-run after editing tool names, descriptions, or parameters in index.js.
+ */
+
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const SRC  = path.join(ROOT, 'index.js');
+const OUT  = path.join(ROOT, 'docs', 'tools.md');
+
+const source = readFileSync(SRC, 'utf8');
+
+// ---------------------------------------------------------------------------
+// Step 1: Extract raw text of each s.tool(...) call
+// ---------------------------------------------------------------------------
+
+/**
+ * Walk `src` from `start`, skipping over a quoted string (the opening quote
+ * character at `src[start]` is already consumed — cursor is just inside it).
+ * Returns the index just past the closing quote.
+ */
+function skipString(src, i, quote) {
+  while (i < src.length) {
+    if (src[i] === '\\') { i += 2; continue; }
+    if (src[i] === quote) return i + 1;
+    i++;
+  }
+  return i;
+}
+
+/**
+ * Returns an array of raw block strings, one per s.tool() registration.
+ * Each block covers from 's' of 's.tool(' to the matching ')'.
+ */
+function extractToolBlocks(src) {
+  const blocks = [];
+  const re = /\bs\.tool\(/g;
+  let m;
+
+  while ((m = re.exec(src)) !== null) {
+    let depth = 0;
+    let j = m.index + m[0].length - 1; // position of the opening '('
+
+    while (j < src.length) {
+      const ch = src[j];
+      if      (ch === '(')                    depth++;
+      else if (ch === ')')                    { depth--; if (depth === 0) break; }
+      else if (ch === '"' || ch === "'")      { j = skipString(src, j + 1, ch) - 1; }
+      else if (ch === '`')                    { j = skipString(src, j + 1, '`') - 1; }
+      j++;
+    }
+
+    blocks.push(src.substring(m.index, j + 1));
+  }
+
+  return blocks;
+}
+
+// ---------------------------------------------------------------------------
+// Step 2: Parse a tool block into { name, description, params }
+// ---------------------------------------------------------------------------
+
+/**
+ * Extracts the first N string literal values from `src` (in order).
+ */
+function extractStringArgs(src, count) {
+  const results = [];
+  let i = 0;
+  while (i < src.length && results.length < count) {
+    const ch = src[i];
+    if (ch === '"' || ch === "'") {
+      let str = '';
+      i++;
+      while (i < src.length) {
+        if (src[i] === '\\') {
+          i++;
+          const esc = src[i];
+          if      (esc === 'n')  str += '\n';
+          else if (esc === 't')  str += '\t';
+          else                   str += esc;
+          i++;
+          continue;
+        }
+        if (src[i] === ch) { i++; break; }
+        str += src[i++];
+      }
+      results.push(str);
+      } else if (ch === '`') {
+        let str = '';
+        i++;
+        while (i < src.length) {
+          if (src[i] === '`') { i++; break; }
+          str += src[i++];
+        }
+        results.push(str);
+      } else {
+        i++;
+    }
+  }
+  return results;
+}
+
+/**
+ * Finds the balanced {…} block that starts at or after `fromIndex` in `src`,
+ * skipping strings and other brackets. Returns { text, end } or null.
+ */
+function extractBalancedBraces(src, fromIndex) {
+  let i = fromIndex;
+  while (i < src.length && src[i] !== '{') i++;
+  if (i >= src.length) return null;
+
+  const start = i;
+  let depth = 0;
+  while (i < src.length) {
+    const ch = src[i];
+    if      (ch === '{')                    depth++;
+    else if (ch === '}')                    { depth--; if (depth === 0) { i++; break; } }
+    else if (ch === '"' || ch === "'")      { i = skipString(src, i + 1, ch) - 1; }
+    else if (ch === '`')                    { i = skipString(src, i + 1, '`') - 1; }
+    i++;
+  }
+
+  return { text: src.substring(start, i), end: i };
+}
+
+function readTemplateLiteral(src, i) {
+  let str = "";
+  while (i < src.length) {
+    if (src[i] === "\\") {
+      i++;
+      str += src[i++];
+      continue;
+    }
+    if (src[i] === "`") return { text: str, end: i + 1 };
+    str += src[i++];
+  }
+  return { text: str, end: i };
+}
+
+/**
+ * Finds the position in `block` right after the 2nd string argument + comma.
+ * Used to locate where the schema object begins.
+ */
+function posAfterTwoStringArgs(block) {
+  // Skip "s.tool("
+  let i = block.indexOf('s.tool(') + 7;
+  let count = 0;
+  while (i < block.length && count < 2) {
+    const ch = block[i];
+    if (ch === '"' || ch === "'") {
+      i = skipString(block, i + 1, ch);
+      count++;
+    } else if (ch === '`') {
+      const { end } = readTemplateLiteral(block, i + 1);
+      i = end;
+      count++;
+    } else {
+      i++;
+    }
+  }
+  return i; // points to content after the description string
+}
+
+/**
+ * Splits a schema text {…} at top-level commas (not inside nested brackets or
+ * strings), yielding one string per top-level parameter declaration.
+ * Multi-line z.object({…}) params are returned as a single string.
+ */
+function splitTopLevelParams(schemaText) {
+  const sections = [];
+  // Skip the outer { }
+  const inner = schemaText.slice(1, schemaText.length - 1);
+
+  let depth = 0;      // {} depth
+  let pdepth = 0;     // () depth
+  let adepth = 0;     // [] depth
+  let sectionStart = 0;
+
+  for (let i = 0; i < inner.length; i++) {
+    const ch = inner[i];
+
+    if      (ch === '"' || ch === "'") { i = skipString(inner, i + 1, ch) - 1; }
+    else if (ch === '`')               { i = skipString(inner, i + 1, '`') - 1; }
+    else if (ch === '{')  depth++;
+    else if (ch === '}')  depth--;
+    else if (ch === '(')  pdepth++;
+    else if (ch === ')')  pdepth--;
+    else if (ch === '[')  adepth++;
+    else if (ch === ']')  adepth--;
+    else if (ch === ',' && depth === 0 && pdepth === 0 && adepth === 0) {
+      const text = inner.substring(sectionStart, i).trim();
+      if (text) sections.push(text);
+      sectionStart = i + 1;
+    }
+  }
+
+  // Push whatever remains after the last comma
+  const tail = inner.substring(sectionStart).trim();
+  if (tail) sections.push(tail);
+
+  return sections.filter(s => /^\w/.test(s)); // skip blank/whitespace chunks
+}
+
+/**
+ * Derives a display type string from a Zod chain.
+ * Works on the raw text of a single parameter declaration.
+ */
+function zodTypeString(text) {
+  // Extract the base type: z.TYPE(
+  const base = (text.match(/z\.(\w+)\(/) ?? [])[1] ?? 'unknown';
+
+  if (base === 'number') {
+    return /\.int\(\)/.test(text) ? 'integer' : 'number';
+  }
+  if (base === 'array') {
+    const inner = (text.match(/z\.array\(\s*z\.(\w+)\(\)/) ?? [])[1];
+    return inner ? `${inner}[]` : 'array';
+  }
+  if (base === 'object') return 'object';
+  if (base === 'boolean') return 'boolean';
+  if (base === 'string') return 'string';
+  if (base === 'enum') {
+    const vals = (text.match(/z\.enum\(\[([^\]]+)\]/) ?? [])[1];
+    return vals ? `enum(${vals.replace(/\s+/g, '')})` : 'enum';
+  }
+  return base;
+}
+
+/**
+ * Parses the parameters from a schema text block.
+ * Returns [{name, type, optional, description}].
+ */
+function parseParams(schemaText) {
+  if (!schemaText) return [];
+  const trimmed = schemaText.trim();
+  if (trimmed === '{}') return [];
+
+  const sections = splitTopLevelParams(schemaText);
+  const params = [];
+
+  for (const section of sections) {
+    const nameMatch = section.match(/^([\w_]+)\s*:/);
+    if (!nameMatch) continue;
+
+    const name        = nameMatch[1];
+    const type        = zodTypeString(section);
+    const optional    = /\.optional\(\)/.test(section);
+
+    // .describe("...") may be on any line of the section
+    // Use the *last* .describe() in the section so that z.object({...}).describe("outer")
+    // wins over any .describe() calls on inner fields.
+    const allDescMatches = [...section.matchAll(/\.describe\("((?:[^"\\]|\\.)*)"\)/g)];
+    const description    = allDescMatches.length > 0
+      ? allDescMatches[allDescMatches.length - 1][1]
+      : '';
+
+    params.push({ name, type, optional, description });
+  }
+
+  return params;
+}
+
+/**
+ * Parse a single tool block into { name, description, params }.
+ */
+function parseTool(block) {
+  const [name, description] = extractStringArgs(block, 2);
+  if (!name) return null;
+
+  const schemaStart = posAfterTwoStringArgs(block);
+  const schema = extractBalancedBraces(block, schemaStart);
+  const params = schema ? parseParams(schema.text) : [];
+
+  return { name, description, params };
+}
+
+// ---------------------------------------------------------------------------
+// Step 3: Generate markdown
+// ---------------------------------------------------------------------------
+
+/** Converts a tool name to a GitHub-compatible anchor (replaces _ with -). */
+function anchor(name) {
+  return name.replace(/_/g, '-');
+}
+
+function generateMarkdown(tools) {
+  const now = new Date().toISOString().slice(0, 10);
+  const lines = [
+    '# Tool Reference',
+    '',
+    `> Auto-generated from \`index.js\` on ${now}.`,
+    '> Do not edit manually — run `npm run docs` to regenerate.',
+    '',
+    '## Tools',
+    '',
+    ...tools.map(t => `- [\`${t.name}\`](#${anchor(t.name)})`),
+    '',
+    '---',
+    '',
+  ];
+
+  for (const tool of tools) {
+    lines.push(`## ${tool.name}`);
+    lines.push('');
+    lines.push(tool.description);
+    lines.push('');
+
+    if (tool.params.length === 0) {
+      lines.push('_No parameters._');
+    } else {
+      lines.push('| Parameter | Type | Required | Description |');
+      lines.push('|-----------|------|:--------:|-------------|');
+      for (const p of tool.params) {
+        const req  = p.optional ? '' : '✓';
+        const desc = p.description.replace(/\|/g, '\\|'); // escape pipes
+        lines.push(`| \`${p.name}\` | \`${p.type}\` | ${req} | ${desc} |`);
+      }
+    }
+
+    lines.push('');
+    lines.push('---');
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+const blocks = extractToolBlocks(source);
+const tools  = blocks.map(parseTool).filter(Boolean);
+
+mkdirSync(path.join(ROOT, 'docs'), { recursive: true });
+const md = generateMarkdown(tools);
+writeFileSync(OUT, md, 'utf8');
+
+const paramCounts = tools.map(t => `  ${t.name}: ${t.params.length} param(s)`);
+console.log(`Generated ${OUT}`);
+console.log(`  ${tools.length} tools documented`);
+console.log(paramCounts.join('\n'));

--- a/scripts/generate-tool-docs.mjs
+++ b/scripts/generate-tool-docs.mjs
@@ -19,6 +19,119 @@ const OUT  = path.join(ROOT, 'docs', 'tools.md');
 
 const source = readFileSync(SRC, 'utf8');
 
+function decodeEscape(src, i) {
+  const esc = src[i];
+
+  if (esc === undefined) {
+    return { value: '', end: i };
+  }
+
+  switch (esc) {
+    case 'n': return { value: '\n', end: i + 1 };
+    case 'r': return { value: '\r', end: i + 1 };
+    case 't': return { value: '\t', end: i + 1 };
+    case 'b': return { value: '\b', end: i + 1 };
+    case 'f': return { value: '\f', end: i + 1 };
+    case 'v': return { value: '\v', end: i + 1 };
+    case '0': return { value: '\0', end: i + 1 };
+    case '\\': return { value: '\\', end: i + 1 };
+    case '"': return { value: '"', end: i + 1 };
+    case "'": return { value: "'", end: i + 1 };
+    case '`': return { value: '`', end: i + 1 };
+    case 'x': {
+      const hex = src.slice(i + 1, i + 3);
+      if (/^[0-9a-fA-F]{2}$/.test(hex)) {
+        return { value: String.fromCodePoint(Number.parseInt(hex, 16)), end: i + 3 };
+      }
+      return { value: 'x', end: i + 1 };
+    }
+    case 'u': {
+      if (src[i + 1] === '{') {
+        const close = src.indexOf('}', i + 2);
+        const codePoint = close === -1 ? '' : src.slice(i + 2, close);
+        if (/^[0-9a-fA-F]+$/.test(codePoint)) {
+          return { value: String.fromCodePoint(Number.parseInt(codePoint, 16)), end: close + 1 };
+        }
+      } else {
+        const hex = src.slice(i + 1, i + 5);
+        if (/^[0-9a-fA-F]{4}$/.test(hex)) {
+          return { value: String.fromCodePoint(Number.parseInt(hex, 16)), end: i + 5 };
+        }
+      }
+      return { value: 'u', end: i + 1 };
+    }
+    default:
+      return { value: esc, end: i + 1 };
+  }
+}
+
+function readQuotedLiteral(src, i, quote) {
+  let str = '';
+
+  while (i < src.length) {
+    if (src[i] === '\\') {
+      const decoded = decodeEscape(src, i + 1);
+      str += decoded.value;
+      i = decoded.end;
+      continue;
+    }
+    if (src[i] === quote) {
+      return { text: str, end: i + 1 };
+    }
+    str += src[i++];
+  }
+
+  return { text: str, end: i };
+}
+
+function readTemplateExpression(src, i) {
+  const start = i;
+  let depth = 1;
+
+  while (i < src.length && depth > 0) {
+    const ch = src[i];
+
+    if (ch === '"' || ch === "'") {
+      i = skipString(src, i + 1, ch);
+      continue;
+    }
+    if (ch === '`') {
+      i = skipString(src, i + 1, ch);
+      continue;
+    }
+    if (ch === '{') depth++;
+    if (ch === '}') depth--;
+    i++;
+  }
+
+  return { text: src.slice(start, i - 1).trim(), end: i };
+}
+
+function extractConstantValues(src) {
+  const values = new Map();
+
+  for (const match of src.matchAll(/const\s+(\w+)\s*=\s*parseInt\([^\n]*\?\?\s*"([^"]+)"[^\n]*\);/g)) {
+    values.set(match[1], Number.parseInt(match[2], 10));
+  }
+
+  for (const match of src.matchAll(/const\s+(\w+)\s*=\s*process\.env\.\w+\s*\?\?\s*(["'`])([\s\S]*?)\2;/g)) {
+    if (!values.has(match[1])) {
+      values.set(match[1], match[3]);
+    }
+  }
+
+  for (const match of src.matchAll(/const\s+(\w+)\s*=\s*(\d+|true|false);/g)) {
+    if (!values.has(match[1])) {
+      const raw = match[2];
+      values.set(match[1], raw === 'true' ? true : raw === 'false' ? false : Number.parseInt(raw, 10));
+    }
+  }
+
+  return values;
+}
+
+const constantValues = extractConstantValues(source);
+
 // ---------------------------------------------------------------------------
 // Step 1: Extract raw text of each s.tool(...) call
 // ---------------------------------------------------------------------------
@@ -78,32 +191,15 @@ function extractStringArgs(src, count) {
   while (i < src.length && results.length < count) {
     const ch = src[i];
     if (ch === '"' || ch === "'") {
-      let str = '';
+      const { text, end } = readQuotedLiteral(src, i + 1, ch);
+      results.push(text);
+      i = end;
+    } else if (ch === '`') {
+      const { text, end } = readTemplateLiteral(src, i + 1);
+      results.push(text);
+      i = end;
+    } else {
       i++;
-      while (i < src.length) {
-        if (src[i] === '\\') {
-          i++;
-          const esc = src[i];
-          if      (esc === 'n')  str += '\n';
-          else if (esc === 't')  str += '\t';
-          else                   str += esc;
-          i++;
-          continue;
-        }
-        if (src[i] === ch) { i++; break; }
-        str += src[i++];
-      }
-      results.push(str);
-      } else if (ch === '`') {
-        let str = '';
-        i++;
-        while (i < src.length) {
-          if (src[i] === '`') { i++; break; }
-          str += src[i++];
-        }
-        results.push(str);
-      } else {
-        i++;
     }
   }
   return results;
@@ -133,14 +229,22 @@ function extractBalancedBraces(src, fromIndex) {
 }
 
 function readTemplateLiteral(src, i) {
-  let str = "";
+  let str = '';
   while (i < src.length) {
     if (src[i] === "\\") {
-      i++;
-      str += src[i++];
+      const decoded = decodeEscape(src, i + 1);
+      str += decoded.value;
+      i = decoded.end;
       continue;
     }
-    if (src[i] === "`") return { text: str, end: i + 1 };
+    if (src[i] === '$' && src[i + 1] === '{') {
+      const { text, end } = readTemplateExpression(src, i + 2);
+      const value = constantValues.get(text);
+      str += value === undefined ? `\${${text}}` : String(value);
+      i = end;
+      continue;
+    }
+    if (src[i] === '`') return { text: str, end: i + 1 };
     str += src[i++];
   }
   return { text: str, end: i };
@@ -287,17 +391,16 @@ function parseTool(block) {
 // Step 3: Generate markdown
 // ---------------------------------------------------------------------------
 
-/** Converts a tool name to a GitHub-compatible anchor (replaces _ with -). */
+/** Converts a tool name to the GitHub heading slug used by this document. */
 function anchor(name) {
-  return name.replace(/_/g, '-');
+  return name.toLowerCase();
 }
 
 function generateMarkdown(tools) {
-  const now = new Date().toISOString().slice(0, 10);
   const lines = [
     '# Tool Reference',
     '',
-    `> Auto-generated from \`index.js\` on ${now}.`,
+    '> Auto-generated from `index.js`.',
     '> Do not edit manually — run `npm run docs` to regenerate.',
     '',
     '## Tools',


### PR DESCRIPTION
## Summary
- align remaining README and PRD tool references with the live MCP tool definitions
- generate docs/tools.md directly from index.js tool registrations and Zod schemas
- add CI enforcement so generated tool docs cannot drift from source

## Why
The tool reference was still a manual maintenance surface. This changes the source of truth to the code itself and adds a CI guard so drift is caught on every PR and push.

## Validation
- npm run docs
- git diff --exit-code -- docs/tools.md