### PR TITLE
feat: add reusable manual real-data Scrivener test runner

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -53,6 +53,8 @@ Unit tests use an in-memory SQLite database and temporary directories — no ser
 
 For real projects, keep your manuscript sync folder outside this tool repository and point `WRITING_SYNC_DIR` at that external path.
 
+For manual Scrivener import and merge verification with real project data, keep both the copied `.scriv` bundle and the generated temp sync output outside the repository too. The current local convention is `/Users/hanna/.mcp-writing-manual-data/`, and the reusable runner is `npm run manual:realtest -- --source-dir <external-sync-dir> --scriv-path <external-copied-project.scriv> --project-id <project-id>`.
+
 Maintainers: see `MAINTAINERS.md` for release and operational setup notes, and `AGENT.md` for persistent workflow conventions and release/recovery guidance.
 
 ---

--- a/docs/development.md
+++ b/docs/development.md
@@ -53,7 +53,7 @@ Unit tests use an in-memory SQLite database and temporary directories — no ser
 
 For real projects, keep your manuscript sync folder outside this tool repository and point `WRITING_SYNC_DIR` at that external path.
 
-For manual Scrivener import and merge verification with real project data, keep both the copied `.scriv` bundle and the generated temp sync output outside the repository too. The current local convention is `/Users/hanna/.mcp-writing-manual-data/`, and the reusable runner is `npm run manual:realtest -- --source-dir <external-sync-dir> --scriv-path <external-copied-project.scriv> --project-id <project-id>`.
+For manual Scrivener import and merge verification with real project data, keep both the copied `.scriv` bundle and the generated temp sync output outside the repository too. The current local convention is `$HOME/.mcp-writing-manual-data/`, and the reusable runner is `npm run manual:realtest -- --source-dir <external-sync-dir> --scriv-path <external-copied-project.scriv> --project-id <project-id>`.
 
 Maintainers: see `MAINTAINERS.md` for release and operational setup notes, and `AGENT.md` for persistent workflow conventions and release/recovery guidance.
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "scripts": {
     "start": "node --experimental-sqlite index.js",
     "new:entity": "node scripts/new-world-entity.js",
+    "manual:realtest": "node scripts/manual-scrivener-realtest.mjs",
     "setup:openclaw-env": "sh scripts/setup-openclaw-env.sh",
     "release": "release-it",
     "lint": "eslint index.js importer.js db.js sync.js metadata-lint.js scripts/",

--- a/scripts/manual-scrivener-realtest.mjs
+++ b/scripts/manual-scrivener-realtest.mjs
@@ -58,7 +58,11 @@ function parseArgs(argv) {
       options.syncDir = argv[++index];
     } else if (arg === "--sample-count") {
       if (index + 1 >= argv.length) throw new Error(`${arg} requires a value.`);
-      options.sampleCount = parseInt(argv[++index], 10);
+      const sampleCountValue = argv[++index];
+      if (!/^\d+$/.test(sampleCountValue)) {
+        throw new Error("--sample-count must be a positive integer.");
+      }
+      options.sampleCount = Number(sampleCountValue);
     } else if (arg === "--no-clean") {
       options.clean = false;
     } else {
@@ -233,11 +237,12 @@ function main() {
     dryRun: false,
   }))));
 
-  const scenesDir = options.projectId.includes("/")
-    ? path.join(syncDir, "universes", ...options.projectId.split("/"), "scenes")
-    : path.join(syncDir, "projects", options.projectId, "scenes");
-
-  const sidecars = fs.existsSync(scenesDir) ? walkSidecars(scenesDir) : [];
+  
+  // Use scenesDir from import_write result (the actual written path) instead of re-deriving
+  const importWriteResult = report.tests.find((test) => test.name === "import_write" && test.ok)?.result;
+  const scenesDir = importWriteResult?.scenesDir;
+  
+  const sidecars = scenesDir && fs.existsSync(scenesDir) ? walkSidecars(scenesDir) : [];
   report.sidecarCount = sidecars.length;
   report.sampleSidecars = sidecars
     .slice(0, options.sampleCount)

--- a/scripts/manual-scrivener-realtest.mjs
+++ b/scripts/manual-scrivener-realtest.mjs
@@ -1,0 +1,196 @@
+import fs from "node:fs";
+import path from "node:path";
+import { importScrivenerSync, validateProjectId } from "../importer.js";
+import { mergeScrivenerProjectMetadata } from "../scrivener-direct.js";
+
+function usage() {
+  console.error(
+    [
+      "Usage:",
+      "  node scripts/manual-scrivener-realtest.mjs \\",
+      "    --source-dir <external-sync-dir> \\",
+      "    --scriv-path <copied-project.scriv> \\",
+      "    --project-id <project|universe/project> [options]",
+      "",
+      "Keep large real-data test assets outside the repository so they cannot be",
+      "accidentally committed. Example external storage location:",
+      "  /Users/hanna/.mcp-writing-manual-data/",
+      "",
+      "Options:",
+      "  --sync-dir <path>       Temp sync root to write into.",
+      "                         Default: ./tmp/manual-realtest-sync",
+      "  --sample-count <n>      Number of sample sidecars to include. Default: 5",
+      "  --no-clean              Reuse existing sync dir instead of recreating it.",
+      "",
+      "Example:",
+      "  npm run manual:realtest -- \\",
+      "    --source-dir /Users/hanna/Code/writing/universes/universe-1/book-1-the-lamb \\",
+      "    --scriv-path /Users/hanna/.mcp-writing-manual-data/manual-test-data/Sebastian\\ the\\ Vampire.scriv \\",
+      "    --project-id universe-1/book-1-the-lamb \\",
+      "    --sync-dir /Users/hanna/.mcp-writing-manual-data/manual-realtest-sync",
+    ].join("\n")
+  );
+}
+
+function parseArgs(argv) {
+  const options = {
+    syncDir: "./tmp/manual-realtest-sync",
+    sampleCount: 5,
+    clean: true,
+  };
+
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index];
+    if (arg === "--source-dir") options.sourceDir = argv[++index];
+    else if (arg === "--scriv-path") options.scrivPath = argv[++index];
+    else if (arg === "--project-id") options.projectId = argv[++index];
+    else if (arg === "--sync-dir") options.syncDir = argv[++index];
+    else if (arg === "--sample-count") options.sampleCount = parseInt(argv[++index], 10);
+    else if (arg === "--no-clean") options.clean = false;
+    else throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (!options.sourceDir || !options.scrivPath || !options.projectId) {
+    usage();
+    throw new Error("Missing required arguments.");
+  }
+
+  if (!Number.isInteger(options.sampleCount) || options.sampleCount < 1) {
+    throw new Error("--sample-count must be a positive integer.");
+  }
+
+  return options;
+}
+
+function walkSidecars(dir, out = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) walkSidecars(fullPath, out);
+    else if (entry.name.endsWith(".meta.yaml")) out.push(fullPath);
+  }
+  return out;
+}
+
+function summarizeImport(result) {
+  return {
+    projectId: result.projectId,
+    scenesDir: result.scenesDir,
+    sourceFiles: result.sourceFiles,
+    created: result.created,
+    existing: result.existing,
+    skipped: result.skipped,
+    beatMarkersSeen: result.beatMarkersSeen,
+    ignoredFiles: result.ignoredFiles,
+    filesToProcess: result.filesToProcess,
+    existingSidecars: result.existingSidecars,
+    filePreviews: result.filePreviews,
+    dryRun: result.dryRun,
+    preflight: result.preflight,
+  };
+}
+
+function summarizeMerge(result) {
+  return {
+    projectId: result.projectId,
+    scenesDir: result.scenesDir,
+    sidecarFiles: result.sidecarFiles,
+    updated: result.updated,
+    unchanged: result.unchanged,
+    skippedNoBracketId: result.skippedNoBracketId,
+    noData: result.noData,
+    fieldAddCounts: result.fieldAddCounts,
+    previewChanges: result.previewChanges,
+    stats: result.stats,
+  };
+}
+
+function runStep(name, fn) {
+  try {
+    return { name, ok: true, result: fn() };
+  } catch (error) {
+    return {
+      name,
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const projectIdCheck = validateProjectId(options.projectId);
+  if (!projectIdCheck.ok) {
+    throw new Error(`Invalid --project-id '${options.projectId}': ${projectIdCheck.reason}`);
+  }
+
+  const syncDir = path.resolve(options.syncDir);
+  const sourceDir = path.resolve(options.sourceDir);
+  const scrivPath = path.resolve(options.scrivPath);
+
+  if (!fs.existsSync(sourceDir) || !fs.statSync(sourceDir).isDirectory()) {
+    throw new Error(`--source-dir not found or not a directory: ${sourceDir}`);
+  }
+  if (!fs.existsSync(scrivPath) || !fs.statSync(scrivPath).isDirectory()) {
+    throw new Error(`--scriv-path not found or not a directory: ${scrivPath}`);
+  }
+
+  if (options.clean) {
+    fs.rmSync(syncDir, { recursive: true, force: true });
+  }
+  fs.mkdirSync(syncDir, { recursive: true });
+
+  const report = {
+    syncDir,
+    sourceDir,
+    scrivPath,
+    projectId: options.projectId,
+    cleanStart: options.clean,
+    tests: [],
+  };
+
+  report.tests.push(runStep("import_preflight", () => summarizeImport(importScrivenerSync({
+    scrivenerDir: sourceDir,
+    mcpSyncDir: syncDir,
+    projectId: options.projectId,
+    dryRun: true,
+    preflight: true,
+  }))));
+
+  report.tests.push(runStep("import_write", () => summarizeImport(importScrivenerSync({
+    scrivenerDir: sourceDir,
+    mcpSyncDir: syncDir,
+    projectId: options.projectId,
+    dryRun: false,
+    preflight: false,
+  }))));
+
+  report.tests.push(runStep("merge_dry_run", () => summarizeMerge(mergeScrivenerProjectMetadata({
+    scrivPath,
+    mcpSyncDir: syncDir,
+    projectId: options.projectId,
+    dryRun: true,
+  }))));
+
+  report.tests.push(runStep("merge_write", () => summarizeMerge(mergeScrivenerProjectMetadata({
+    scrivPath,
+    mcpSyncDir: syncDir,
+    projectId: options.projectId,
+    dryRun: false,
+  }))));
+
+  const scenesDir = options.projectId.includes("/")
+    ? path.join(syncDir, "universes", ...options.projectId.split("/"), "scenes")
+    : path.join(syncDir, "projects", options.projectId, "scenes");
+
+  const sidecars = fs.existsSync(scenesDir) ? walkSidecars(scenesDir) : [];
+  report.sidecarCount = sidecars.length;
+  report.sampleSidecars = sidecars
+    .slice(0, options.sampleCount)
+    .map((filePath) => path.relative(syncDir, filePath));
+
+  const failures = report.tests.filter((test) => !test.ok);
+  console.log(JSON.stringify(report, null, 2));
+  if (failures.length) process.exit(1);
+}
+
+main();

--- a/scripts/manual-scrivener-realtest.mjs
+++ b/scripts/manual-scrivener-realtest.mjs
@@ -135,7 +135,7 @@ function runStep(name, fn) {
   }
 }
 
-function isSafeToDeletSync(syncDir) {
+function isSafeToDeleteSync(syncDir) {
   const resolvedPath = path.resolve(syncDir);
 
   // Never delete root or home directory
@@ -146,10 +146,15 @@ function isSafeToDeletSync(syncDir) {
 
   // Allow deletion only if path contains a manual-realtest marker or is in ./tmp or /tmp
   const hasMarker = resolvedPath.includes("manual-realtest");
-  const inTmpDir =
-    resolvedPath.startsWith(path.resolve("./tmp")) ||
-    resolvedPath.startsWith("/tmp") ||
-    resolvedPath.startsWith(path.join(path.sep, "tmp"));
+  
+  // Check if in tmp directories with proper path boundary checking
+  const localTmpDir = path.resolve("./tmp");
+  const isInLocalTmp =
+    resolvedPath === localTmpDir || resolvedPath.startsWith(localTmpDir + path.sep);
+  const isInSystemTmp =
+    resolvedPath === "/tmp" || resolvedPath.startsWith("/tmp" + path.sep);
+  const inTmpDir = isInLocalTmp || isInSystemTmp;
+  
   return hasMarker || inTmpDir;
 }
 
@@ -180,7 +185,7 @@ function main() {
   }
 
   if (options.clean) {
-    if (!isSafeToDeletSync(syncDir)) {
+    if (!isSafeToDeleteSync(syncDir)) {
       throw new Error(
         `Safety check failed: --sync-dir must contain 'manual-realtest' or be in ./tmp or /tmp. Got: ${syncDir}`
       );
@@ -246,7 +251,7 @@ function main() {
 try {
   main();
 } catch (err) {
-  console.error(err.message);
+  console.error(err instanceof Error ? err.message : String(err));
   console.error(usage());
   process.exit(1);
 }

--- a/scripts/manual-scrivener-realtest.mjs
+++ b/scripts/manual-scrivener-realtest.mjs
@@ -1,35 +1,35 @@
 import fs from "node:fs";
 import path from "node:path";
+import os from "node:os";
 import { importScrivenerSync, validateProjectId } from "../importer.js";
 import { mergeScrivenerProjectMetadata } from "../scrivener-direct.js";
 
 function usage() {
-  console.error(
-    [
-      "Usage:",
-      "  node scripts/manual-scrivener-realtest.mjs \\",
-      "    --source-dir <external-sync-dir> \\",
-      "    --scriv-path <copied-project.scriv> \\",
-      "    --project-id <project|universe/project> [options]",
-      "",
-      "Keep large real-data test assets outside the repository so they cannot be",
-      "accidentally committed. Example external storage location:",
-      "  /Users/hanna/.mcp-writing-manual-data/",
-      "",
-      "Options:",
-      "  --sync-dir <path>       Temp sync root to write into.",
-      "                         Default: ./tmp/manual-realtest-sync",
-      "  --sample-count <n>      Number of sample sidecars to include. Default: 5",
-      "  --no-clean              Reuse existing sync dir instead of recreating it.",
-      "",
-      "Example:",
-      "  npm run manual:realtest -- \\",
-      "    --source-dir /Users/hanna/Code/writing/universes/universe-1/book-1-the-lamb \\",
-      "    --scriv-path /Users/hanna/.mcp-writing-manual-data/manual-test-data/Sebastian\\ the\\ Vampire.scriv \\",
-      "    --project-id universe-1/book-1-the-lamb \\",
-      "    --sync-dir /Users/hanna/.mcp-writing-manual-data/manual-realtest-sync",
-    ].join("\n")
-  );
+  return [
+    "Usage:",
+    "  node scripts/manual-scrivener-realtest.mjs \\",
+    "    --source-dir <external-sync-dir> \\",
+    "    --scriv-path <copied-project.scriv> \\",
+    "    --project-id <project|universe/project> [options]",
+    "",
+    "Keep large real-data test assets outside the repository so they cannot be",
+    "accidentally committed. Example external storage location:",
+    "  $HOME/.mcp-writing-manual-data/",
+    "",
+    "Options:",
+    "  --help                  Show this help message.",
+    "  --sync-dir <path>       Temp sync root to write into.",
+    "                         Default: ./tmp/manual-realtest-sync",
+    "  --sample-count <n>      Number of sample sidecars to include. Default: 5",
+    "  --no-clean              Reuse existing sync dir instead of recreating it.",
+    "",
+    "Example:",
+    "  npm run manual:realtest -- \\",
+    "    --source-dir <path-to-external-sync-source> \\",
+    "    --scriv-path <path-to-external-test-data>/<project-name>.scriv \\",
+    "    --project-id <universe>/<project-name> \\",
+    "    --sync-dir <path-to-external-test-data>/manual-realtest-sync",
+  ].join("\n");
 }
 
 function parseArgs(argv) {
@@ -37,29 +37,48 @@ function parseArgs(argv) {
     syncDir: "./tmp/manual-realtest-sync",
     sampleCount: 5,
     clean: true,
+    help: false,
   };
 
   for (let index = 0; index < argv.length; index++) {
     const arg = argv[index];
-    if (arg === "--source-dir") options.sourceDir = argv[++index];
-    else if (arg === "--scriv-path") options.scrivPath = argv[++index];
-    else if (arg === "--project-id") options.projectId = argv[++index];
-    else if (arg === "--sync-dir") options.syncDir = argv[++index];
-    else if (arg === "--sample-count") options.sampleCount = parseInt(argv[++index], 10);
-    else if (arg === "--no-clean") options.clean = false;
-    else throw new Error(`Unknown argument: ${arg}`);
+    if (arg === "--help") {
+      options.help = true;
+    } else if (arg === "--source-dir") {
+      if (index + 1 >= argv.length) throw new Error(`${arg} requires a value.`);
+      options.sourceDir = argv[++index];
+    } else if (arg === "--scriv-path") {
+      if (index + 1 >= argv.length) throw new Error(`${arg} requires a value.`);
+      options.scrivPath = argv[++index];
+    } else if (arg === "--project-id") {
+      if (index + 1 >= argv.length) throw new Error(`${arg} requires a value.`);
+      options.projectId = argv[++index];
+    } else if (arg === "--sync-dir") {
+      if (index + 1 >= argv.length) throw new Error(`${arg} requires a value.`);
+      options.syncDir = argv[++index];
+    } else if (arg === "--sample-count") {
+      if (index + 1 >= argv.length) throw new Error(`${arg} requires a value.`);
+      options.sampleCount = parseInt(argv[++index], 10);
+    } else if (arg === "--no-clean") {
+      options.clean = false;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
   }
 
+  return options;
+}
+
+function validateOptions(options) {
+  if (options.help) return;
+
   if (!options.sourceDir || !options.scrivPath || !options.projectId) {
-    usage();
-    throw new Error("Missing required arguments.");
+    throw new Error("Missing required arguments: --source-dir, --scriv-path, --project-id are required.");
   }
 
   if (!Number.isInteger(options.sampleCount) || options.sampleCount < 1) {
     throw new Error("--sample-count must be a positive integer.");
   }
-
-  return options;
 }
 
 function walkSidecars(dir, out = []) {
@@ -116,8 +135,34 @@ function runStep(name, fn) {
   }
 }
 
+function isSafeToDeletSync(syncDir) {
+  const resolvedPath = path.resolve(syncDir);
+
+  // Never delete root or home directory
+  const parsed = path.parse(resolvedPath);
+  if (resolvedPath === parsed.root || resolvedPath === path.resolve(process.env.HOME || os.homedir())) {
+    return false;
+  }
+
+  // Allow deletion only if path contains a manual-realtest marker or is in ./tmp or /tmp
+  const hasMarker = resolvedPath.includes("manual-realtest");
+  const inTmpDir =
+    resolvedPath.startsWith(path.resolve("./tmp")) ||
+    resolvedPath.startsWith("/tmp") ||
+    resolvedPath.startsWith(path.join(path.sep, "tmp"));
+  return hasMarker || inTmpDir;
+}
+
 function main() {
   const options = parseArgs(process.argv.slice(2));
+
+  if (options.help) {
+    console.log(usage());
+    process.exit(0);
+  }
+
+  validateOptions(options);
+
   const projectIdCheck = validateProjectId(options.projectId);
   if (!projectIdCheck.ok) {
     throw new Error(`Invalid --project-id '${options.projectId}': ${projectIdCheck.reason}`);
@@ -135,6 +180,11 @@ function main() {
   }
 
   if (options.clean) {
+    if (!isSafeToDeletSync(syncDir)) {
+      throw new Error(
+        `Safety check failed: --sync-dir must contain 'manual-realtest' or be in ./tmp or /tmp. Got: ${syncDir}`
+      );
+    }
     fs.rmSync(syncDir, { recursive: true, force: true });
   }
   fs.mkdirSync(syncDir, { recursive: true });
@@ -193,4 +243,10 @@ function main() {
   if (failures.length) process.exit(1);
 }
 
-main();
+try {
+  main();
+} catch (err) {
+  console.error(err.message);
+  console.error(usage());
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
Add a reusable local script to run end-to-end manual verification of Scrivener import + merge on real project data, while keeping large `.scriv` assets outside the repository.

## What changed
- Added `scripts/manual-scrivener-realtest.mjs`.
  - Runs: `import_preflight`, `import_write`, `merge_dry_run`, `merge_write`.
  - Emits a JSON report with per-step results, sidecar counts, and sample sidecar paths.
  - Supports required args (`--source-dir`, `--scriv-path`, `--project-id`) and optional args (`--sync-dir`, `--sample-count`, `--no-clean`).
  - Added `--help` flag, robust argument parsing with strict validation, and top-level error handling.
  - Added safety guard on `fs.rmSync` with proper path boundary checking.
- Added npm script alias in `package.json`:
  - `manual:realtest` → `node scripts/manual-scrivener-realtest.mjs`
- Updated `docs/development.md` with the manual real-data validation convention and command pattern.

## Safety / data handling
- Real `.scriv` test assets and generated manual-test sync output are intentionally kept outside the repo to avoid accidental commits.
- Use an external directory (e.g., `$HOME/.mcp-writing-manual-data/`) to store test data by convention.
- Script includes a safety check that prevents deletion of directories unless they contain a `manual-realtest` marker or are in `./tmp` or `/tmp`.
- Path boundary checks use proper separators to avoid matching edge cases like `/tmpfoo` or `./tmp-backup`.
- Argument parsing validates strictly (e.g., `--sample-count` must be purely numeric, not `"5abc"`).

## Validation
- `npm run lint` passed.
- `node --run test` passed (174 tests).
- Manual real-data run succeeded locally with:
  - import created 104 sidecars from 192 source files
  - merge updated 104 sidecars
- Help flag and error handling tested and working correctly.
- All argument parsing validation tested.

## Copilot review feedback addressed
✅ All 10 feedback comments resolved:
1. ✅ Hard-coded paths (usage text) → Replaced with generic `$HOME` placeholder
2. ✅ Missing `--help` flag → Added with proper implementation
3. ✅ Unsafe argument parsing → Added validation for flag values
4. ✅ Dangerous `fs.rmSync` → Added safety guard with marker checking
5. ✅ Missing error handling → Wrapped in try/catch with normalized error handling
6. ✅ Hard-coded path (docs) → Updated to generic `$HOME` placeholder
7. ✅ Function name typo → Fixed `isSafeToDeletSync` → `isSafeToDeleteSync`
8. ✅ Path boundary check precision → Improved with proper `path.sep` checks
9. ✅ `parseInt` coercion → Added strict regex validation before converting
10. ✅ `scenesDir` derivation mismatch → Use scenesDir from import results instead of re-deriving

## Example usage
```bash
npm run manual:realtest -- \
  --source-dir <path-to-external-sync-source> \
  --scriv-path <path-to-external-test-data>/<project-name>.scriv \
  --project-id <universe>/<project-name> \
  --sync-dir <path-to-external-test-data>/manual-realtest-sync \
  --sample-count 10
```