### PR TITLE
Scrivener beta: opt-in chapter organization + raw keyword tags

### DIFF
--- a/db.js
+++ b/db.js
@@ -18,6 +18,7 @@ export const SCHEMA = `
     title             TEXT,
     part              INTEGER,
     chapter           INTEGER,
+    chapter_title     TEXT,
     pov               TEXT,
     logline           TEXT,
     scene_change      TEXT,
@@ -123,6 +124,11 @@ export const SCHEMA = `
 export function openDb(dbPath) {
   const db = new DatabaseSync(dbPath);
   db.exec(SCHEMA);
+
+  const sceneColumns = db.prepare(`PRAGMA table_info(scenes)`).all();
+  if (!sceneColumns.some(column => column.name === "chapter_title")) {
+    db.exec(`ALTER TABLE scenes ADD COLUMN chapter_title TEXT;`);
+  }
 
   // Rebuild legacy FTS table if it predates keyword indexing.
   // Preserve existing indexed rows so metadata search remains available

--- a/docs/development.md
+++ b/docs/development.md
@@ -135,6 +135,25 @@ Fix:
 3. Verify the export folder has a `Draft/` subdirectory with `.txt` files
 4. Try the import again: `node scripts/import.js ~/my-novel-txt /path/to/sync-dir --project my-novel`
 
+### "SCRIVENER_DIRECT_BETA_FAILED"
+
+The beta direct-merge path could not parse or reconcile the `.scriv` project safely.
+
+Common causes:
+
+1. `source_project_dir` points to the wrong path
+2. the `.scriv` bundle has no `.scrivx` file at its root
+3. the bundle layout differs from the currently tested beta fixture shape
+4. existing sidecars were not created from the same Scrivener project lineage
+
+Fix:
+
+1. Confirm you passed the `.scriv` directory path itself.
+2. Re-run `merge_scrivener_project_beta` with `dry_run: true` and inspect `merge.warnings` / `merge.warning_summary` if present.
+3. If the parser still fails, use the stable fallback path: External Folder Sync plus `import_scrivener_sync`.
+
+Beta direct parsing is intentionally opt-in. A parser/schema mismatch should not block the stable sync-folder workflow.
+
 ### Tests fail after updating Node.js
 
 Local install state may be stale after the Node.js change.

--- a/docs/prd/in-progress/scrivener-direct-extraction-beta-implementation.md
+++ b/docs/prd/in-progress/scrivener-direct-extraction-beta-implementation.md
@@ -32,18 +32,21 @@ Scope:
 - Enforce importer-authoritative write boundaries in beta merge.
 - Keep additive-only behavior for non-authoritative fields.
 - Make overwrite/skip decisions explicit in result payloads and warnings.
+- Align `walkYamls` in `scrivener-direct.js` to skip mirror subdirectories (`projects/`, `universes/`) consistent with `walkSidecarFiles` in `importer.js`, to prevent phantom `missing_bracket_id` warnings from nested mirror trees.
 
 Acceptance checks:
 - Beta merge never silently overwrites agent-authoritative fields.
 - Attempted writes to importer-authoritative fields follow explicit policy and are reported.
 - Unit tests cover allowed write, blocked write, and no-op merge outcomes.
 - Integration tests verify stable importer behavior remains unchanged.
+- `walkYamls` skips mirror subdirectories; test confirms no phantom warnings from nested mirrors.
 
 Exit signal:
 - Close checklist items:
   - Enforce importer-authoritative field boundaries during merge
   - No silent overwrite of agent-authoritative fields
   - Ownership-safe merge policy implementation
+  - `walkYamls` mirror-path guard parity with `walkSidecarFiles`
 
 ### PR-3b: Ambiguity Conflicts + Warning Taxonomy
 
@@ -190,6 +193,7 @@ This phase was identified during manual testing against a real 430+ file project
 
 - [ ] Enforce importer-authoritative field boundaries during merge
 - [x] Ensure non-authoritative sidecar fields are preserved
+- [ ] Align `walkYamls` (in `scrivener-direct.js`) to skip `projects/`/`universes/` mirror subdirectories, consistent with `walkSidecarFiles` in `importer.js`
 - [ ] Normalize handling for:
   - [x] missing UUID mappings
   - [x] missing synopsis files

--- a/docs/prd/in-progress/scrivener-direct-extraction-beta-implementation.md
+++ b/docs/prd/in-progress/scrivener-direct-extraction-beta-implementation.md
@@ -22,6 +22,81 @@ Use focused PRs with one concern each. Do not combine milestones unless explicit
 4. PR-3: Ownership and parity hardening
 5. PR-4: Docs, compatibility matrix, and beta operational guidance
 
+## Next PR Sequence (Concrete)
+
+Use this as the execution plan for remaining work. Keep each PR narrowly scoped.
+
+### PR-3a: Ownership Enforcement
+
+Scope:
+- Enforce importer-authoritative write boundaries in beta merge.
+- Keep additive-only behavior for non-authoritative fields.
+- Make overwrite/skip decisions explicit in result payloads and warnings.
+
+Acceptance checks:
+- Beta merge never silently overwrites agent-authoritative fields.
+- Attempted writes to importer-authoritative fields follow explicit policy and are reported.
+- Unit tests cover allowed write, blocked write, and no-op merge outcomes.
+- Integration tests verify stable importer behavior remains unchanged.
+
+Exit signal:
+- Close checklist items:
+  - Enforce importer-authoritative field boundaries during merge
+  - No silent overwrite of agent-authoritative fields
+  - Ownership-safe merge policy implementation
+
+### PR-3b: Ambiguity Conflicts + Warning Taxonomy
+
+Scope:
+- Define and document ambiguous mapping conditions (e.g., unresolved identity ties, contradictory source metadata, ambiguous folder-derived structure).
+- Add dedicated conflict/warning codes for each condition.
+- Ensure warnings are stable, summarized, and test-covered.
+
+Acceptance checks:
+- Warning taxonomy documented in this file and reflected in tool/runtime outputs.
+- Ambiguous mapping scenarios emit deterministic conflict/warning codes.
+- Unit/integration tests cover each new code and summary behavior.
+
+Exit signal:
+- Close checklist items:
+  - Add conflict/warning reporting for ambiguous mappings
+  - Warning taxonomy is stable and documented
+
+### PR-4b: Compatibility Matrix Expansion
+
+Scope:
+- Add and validate fixtures B/C/D:
+  - B: missing optional metadata files
+  - C: custom metadata-heavy project
+  - D: reordered binder hierarchy
+- Record tested-version coverage and warning profile outcomes.
+
+Acceptance checks:
+- Each fixture has parse success + merge success + sidecar preservation checks.
+- Warning profile reviewed and recorded for each fixture.
+- Compatibility notes updated with tested-version details and known constraints.
+
+Exit signal:
+- Close checklist items:
+  - Compatibility matrix expansion beyond baseline fixture
+  - Tested-version coverage documentation partial -> complete
+  - Compatibility matrix representative coverage
+
+### PR-4c: Graduation Gate Validation
+
+Scope:
+- Validate fallback to stable importer in automated tests as an explicit gate.
+- Summarize release-window risk posture for data-loss class bugs.
+
+Acceptance checks:
+- Automated tests assert fallback guidance path on beta failure conditions.
+- Graduation criteria checklist updated with concrete evidence links.
+
+Exit signal:
+- Close checklist items:
+  - Fallback path to stable importer validated in automated tests
+  - Milestones M1-M4 complete
+
 ---
 
 ## Phase A — Parser Core Extraction (M1) ✅

--- a/docs/prd/in-progress/scrivener-direct-extraction-beta-implementation.md
+++ b/docs/prd/in-progress/scrivener-direct-extraction-beta-implementation.md
@@ -10,7 +10,7 @@ This document translates the beta PRD into execution-ready tasks. It is intentio
 - M2: Official beta entrypoints (MCP + CLI) ✅
 - M2.5: Large-project UX (async jobs, warning aggregation, scoped parsing) ✅
 - M3: Safety and parity hardening
-- M4: Docs, compatibility posture, and beta operations
+- M4: Docs, compatibility posture, and beta operations ✅ (baseline docs slice)
 
 ## Recommended Execution Order
 
@@ -140,21 +140,21 @@ This phase was identified during manual testing against a real 430+ file project
 
 ### Phase D Tasks
 
-- [ ] Update setup docs with two-path guidance (stable vs beta)
-- [ ] Add "tested versions" compatibility section for beta path
-- [ ] Add troubleshooting section for parser/schema mismatch failures
-- [ ] Add tool reference updates and explicit stability tier labeling
+- [x] Update setup docs with two-path guidance (stable vs beta)
+- [x] Add "tested versions" compatibility section for beta path (initial baseline posture)
+- [x] Add troubleshooting section for parser/schema mismatch failures
+- [x] Add tool reference updates and explicit stability tier labeling
 
 ### Phase D Acceptance Criteria
 
-- [ ] Users can clearly distinguish stable default from beta option
-- [ ] Docs provide a clear fallback path when beta ingestion fails
-- [ ] Beta caveats appear in all relevant surfaces (setup, tools, runtime)
+- [x] Users can clearly distinguish stable default from beta option
+- [x] Docs provide a clear fallback path when beta ingestion fails
+- [x] Beta caveats appear in all relevant surfaces (setup, tools, runtime)
 
 ### Phase D Deliverables
 
-- [ ] Documentation updates across setup and tool reference docs
-- [ ] Compatibility notes and operational troubleshooting guidance
+- [x] Documentation updates across setup and tool reference docs
+- [x] Compatibility notes and operational troubleshooting guidance (baseline beta posture)
 
 ---
 
@@ -208,6 +208,8 @@ For each fixture:
 - Unknown Scrivener custom fields are ignored unless explicitly mapped into supported sidecar fields.
 - Invalid numeric Scrivener custom field values are ignored with structured warnings rather than hard-failing the merge.
 - Remaining Phase C work is concentrated in explicit ownership policy and conflict reporting for ambiguous mappings.
+- Phase D baseline docs slice is complete: setup guidance, troubleshooting, stability-tier tool descriptions, and generated tool reference are in place.
+- Remaining docs work is now mostly depth expansion (broader tested-version matrix and fixture coverage), not baseline guidance.
 
 ---
 

--- a/docs/prd/in-progress/scrivener-direct-extraction-beta-implementation.md
+++ b/docs/prd/in-progress/scrivener-direct-extraction-beta-implementation.md
@@ -26,7 +26,7 @@ Use focused PRs with one concern each. Do not combine milestones unless explicit
 
 ## Phase A — Parser Core Extraction (M1) ✅
 
-### Tasks
+### Phase A Tasks
 
 - [x] Extract `.scrivx` parsing and Scrivener data reads from `scripts/merge-scrivx.js` into reusable module(s)
 - [x] Define typed internal model for:
@@ -37,7 +37,7 @@ Use focused PRs with one concern each. Do not combine milestones unless explicit
 - [x] Define deterministic merge contract (input scene sidecar + extracted data -> merged sidecar)
 - [x] Preserve current script behavior while moving logic out of script wrapper
 
-### Deliverables
+### Phase A Deliverables
 
 - [x] `scrivener-direct.js` — parser/merge module with `loadScrivenerProjectData`, `mergeSidecarData`, `mergeScrivenerProjectMetadata` exports
 - [x] `scripts/merge-scrivx.js` — thinned to ~15-line arg-parsing wrapper
@@ -46,7 +46,7 @@ Use focused PRs with one concern each. Do not combine milestones unless explicit
 
 ## Phase B — Official Beta Entry Points (M2) ✅
 
-### Tasks
+### Phase B Tasks
 
 - [x] Add MCP beta tool for direct Scrivener extraction (`merge_scrivener_project_beta`)
 - [x] Keep stable `import_scrivener_sync` unchanged and documented as default
@@ -55,7 +55,7 @@ Use focused PRs with one concern each. Do not combine milestones unless explicit
 - [x] Add `scenes_dir` override parameter for non-standard sync layouts
 - [x] Universe-scoped `project_id` (`universe/project`) resolves to correct `universes/` path
 
-### Deliverables
+### Phase B Deliverables
 
 - [x] MCP tool in `index.js` with structured success/error payloads
 - [x] `SCRIVENER_DIRECT_BETA_FAILED` error code with `details.fallback` guidance
@@ -67,7 +67,7 @@ Use focused PRs with one concern each. Do not combine milestones unless explicit
 
 This phase was identified during manual testing against a real 430+ file project where blocking MCP calls timed out.
 
-### Tasks
+### Phase B.5 Tasks
 
 - [x] Async job infrastructure: `startAsyncJob`, `toPublicJob`, TTL-based pruning
 - [x] `import_scrivener_sync_async` — non-blocking import, returns `job_id` immediately
@@ -81,10 +81,10 @@ This phase was identified during manual testing against a real 430+ file project
 - [x] `import_scrivener_sync` and `import_scrivener_sync_async`: `ignore_patterns` (array of regex strings matched against filenames)
 - [x] `MCP_TRANSPORT=stdio` env var: starts server in stdio mode, no HTTP listener, no port conflicts for local tooling and debug scripts
 
-### Warning types tracked
+### Phase B.5 Warning Types Tracked
 
 | Type | Trigger |
-|---|---|
+| --- | --- |
 | `no_scene_id` | File has no `scene_id` in metadata |
 | `duplicate_scene_id` | Same `scene_id` in two files under same project |
 | `path_metadata_mismatch` | Part/chapter in sidecar doesn't match filesystem path |
@@ -92,7 +92,7 @@ This phase was identified during manual testing against a real 430+ file project
 | `moved_scene` | Sidecar exists at stale path (prose moved) |
 | `nested_mirror` | Path is inside a nested mirror directory |
 
-### Acceptance Criteria
+### Phase B.5 Acceptance Criteria
 
 - [x] Large imports don't block MCP; clients poll status until completion
 - [x] Async jobs retain result for TTL window (default 24h, configurable via `ASYNC_JOB_TTL_MS`)
@@ -101,7 +101,7 @@ This phase was identified during manual testing against a real 430+ file project
 - [x] `ignore_patterns` excludes noise files (fragments, beat sheets) from import scope
 - [x] `MCP_TRANSPORT=stdio` allows local debug scripts without port conflicts
 
-### Deliverables
+### Phase B.5 Deliverables
 
 - [x] `scripts/async-job-runner.mjs` — worker process
 - [x] 5 new MCP tools: `import_scrivener_sync_async`, `merge_scrivener_project_beta_async`, `get_async_job_status`, `list_async_jobs`, `cancel_async_job`
@@ -111,47 +111,47 @@ This phase was identified during manual testing against a real 430+ file project
 
 ## Phase C — Safety and Parity Hardening (M3)
 
-### Tasks
+### Phase C Tasks
 
 - [ ] Enforce importer-authoritative field boundaries during merge
-- [ ] Ensure non-authoritative sidecar fields are preserved
+- [x] Ensure non-authoritative sidecar fields are preserved
 - [ ] Normalize handling for:
-  - [ ] missing UUID mappings
-  - [ ] missing synopsis files
-  - [ ] unknown custom fields
-  - [ ] malformed metadata values
+  - [x] missing UUID mappings
+  - [x] missing synopsis files
+  - [x] unknown custom fields
+  - [x] malformed metadata values
 - [ ] Add conflict/warning reporting for ambiguous mappings
-- [ ] Preserve scene identity and reconciliation assumptions from current importer model
+- [x] Preserve scene identity and reconciliation assumptions from current importer model
 
-### Acceptance Criteria
+### Phase C Acceptance Criteria
 
-- [ ] No duplicate logical scenes created due to ordering or path changes in source
+- [x] No duplicate logical scenes created due to ordering or path changes in source
 - [ ] No silent overwrite of agent-authoritative fields
 - [ ] Warning taxonomy is stable and documented
 
-### Deliverables
+### Phase C Deliverables
 
 - [ ] Ownership-safe merge policy implementation
-- [ ] Structured warnings and error codes
+- [x] Structured warnings and error codes
 
 ---
 
 ## Phase D — Docs and Beta Ops (M4)
 
-### Tasks
+### Phase D Tasks
 
 - [ ] Update setup docs with two-path guidance (stable vs beta)
 - [ ] Add "tested versions" compatibility section for beta path
 - [ ] Add troubleshooting section for parser/schema mismatch failures
 - [ ] Add tool reference updates and explicit stability tier labeling
 
-### Acceptance Criteria
+### Phase D Acceptance Criteria
 
 - [ ] Users can clearly distinguish stable default from beta option
 - [ ] Docs provide a clear fallback path when beta ingestion fails
 - [ ] Beta caveats appear in all relevant surfaces (setup, tools, runtime)
 
-### Deliverables
+### Phase D Deliverables
 
 - [ ] Documentation updates across setup and tool reference docs
 - [ ] Compatibility notes and operational troubleshooting guidance
@@ -165,13 +165,13 @@ This phase was identified during manual testing against a real 430+ file project
 - [x] Parser reads `.scrivx` maps correctly (sync map, keyword map, binder traversal)
 - [x] Metadata extraction handles absent optional files without crash
 - [x] Merge contract preserves non-authoritative fields
-- [ ] Custom-field mapping allowlist behavior is deterministic
+- [x] Custom-field mapping allowlist behavior is deterministic
 
 ### Integration Tests
 
 - [x] MCP beta tool dry-run against fixture `.scriv` bundle
 - [x] MCP beta tool write mode updates sidecars as expected
-- [ ] Re-run idempotency: second run does not produce unintended drift
+- [x] Re-run idempotency: second run does not produce unintended drift
 - [x] Fallback messaging on incompatible or malformed source structure
 - [x] `scenes_dir` override and priority over `project_id`
 - [x] Async import and merge jobs complete successfully
@@ -196,186 +196,20 @@ Track explicitly as fixtures are added.
 
 For each fixture:
 
-- [ ] parse success
-- [ ] merge success
+- [x] parse success
+- [x] merge success
 - [ ] warning profile reviewed
-- [ ] sidecar preservation checks pass
+- [x] sidecar preservation checks pass
+
+## Implementation Notes
+
+- Current merge behavior is additive-only: beta merge fills missing sidecar fields and does not overwrite existing values.
+- Missing UUID mappings are skipped with structured warning payloads, and missing synopsis files are tolerated without failing the merge.
+- Unknown Scrivener custom fields are ignored unless explicitly mapped into supported sidecar fields.
+- Invalid numeric Scrivener custom field values are ignored with structured warnings rather than hard-failing the merge.
+- Remaining Phase C work is concentrated in explicit ownership policy and conflict reporting for ambiguous mappings.
 
 ---
-
-## Exit Criteria For Beta Graduation Review
-
-All must be true before proposing graduation from beta status.
-
-- [ ] Milestones M1-M4 complete
-- [ ] No unresolved high-severity data loss issues
-- [ ] Compatibility matrix has representative coverage and documented tested versions
-- [ ] Fallback path to stable importer validated in automated tests
-
-## Non-Goals Reminder
-
-- Replacing stable sync-folder importer in this initiative
-- Supporting every historical Scrivener version on day one
-- Expanding into unrelated metadata model changes not required for parity or beta value
-
-## Related
-
-- [scrivener-direct-extraction-beta.md](scrivener-direct-extraction-beta.md)
-- [../done/import-sync.md](../done/import-sync.md)
-- [../done/metadata.md](../done/metadata.md)
-
-
-## First PR Scope (PR-1)
-
-Goal: establish reusable parser/merge internals without changing product behavior.
-
-### In Scope
-
-- Extract reusable parser and merge modules from `scripts/merge-scrivx.js`
-- Keep the existing script as a thin wrapper
-- Add unit tests for parser + merge contract
-- Preserve current script outputs for existing fixture data
-
-### Out of Scope
-
-- No MCP tool additions
-- No docs/tool-surface labeling changes
-- No ownership policy expansion beyond preserving current behavior
-- No migration or deprecation messaging
-
-### PR-1 Acceptance Criteria
-
-- Existing script remains runnable with same CLI inputs
-- Shared module API is stable enough for later MCP integration
-- Unit tests cover success and malformed-input paths
-- No changes to stable `import_scrivener_sync` behavior
-
-## Phase A — Parser Core Extraction (M1)
-
-### Tasks
-
-- [ ] Extract `.scrivx` parsing and Scrivener data reads from `scripts/merge-scrivx.js` into reusable module(s)
-- [ ] Define typed internal model for:
-  - [ ] binder items
-  - [ ] sync number to UUID mapping
-  - [ ] keyword map
-  - [ ] per-scene extracted metadata
-- [ ] Define deterministic merge contract (input scene sidecar + extracted data -> merged sidecar)
-- [ ] Preserve current script behavior while moving logic out of script wrapper
-
-### Acceptance Criteria
-
-- [ ] Existing script behavior remains functionally equivalent for current supported fixture
-- [ ] Core parser/merge logic can be called by both CLI and MCP surfaces
-- [ ] Merge function is pure and unit-testable
-
-### Deliverables
-
-- [ ] New parser/merge module(s) under source root
-- [ ] Thin `scripts/merge-scrivx.js` wrapper using shared module
-
-## Phase B — Official Beta Entry Points (M2)
-
-### Tasks
-
-- [ ] Add MCP beta tool for direct Scrivener extraction
-- [ ] Keep stable `import_scrivener_sync` unchanged and documented as default
-- [ ] Add CLI command alias for beta flow (or formalize existing script usage)
-- [ ] Add explicit beta wording in tool/CLI descriptions and responses
-- [ ] Add `dry_run` summary with field-level change preview counts
-
-### Acceptance Criteria
-
-- [ ] Beta entrypoint is opt-in and never auto-invoked by stable import path
-- [ ] On parser/schema failure, output includes actionable fallback to stable import path
-- [ ] `dry_run` output gives enough detail for user trust before writes
-
-### Deliverables
-
-- [ ] MCP tool in `index.js` with structured success/error payloads
-- [ ] CLI behavior documented and consistent with MCP payload semantics
-
-## Phase C — Safety and Parity Hardening (M3)
-
-### Tasks
-
-- [ ] Enforce importer-authoritative field boundaries during merge
-- [ ] Ensure non-authoritative sidecar fields are preserved
-- [ ] Normalize handling for:
-  - [ ] missing UUID mappings
-  - [ ] missing synopsis files
-  - [ ] unknown custom fields
-  - [ ] malformed metadata values
-- [ ] Add conflict/warning reporting for ambiguous mappings
-- [ ] Preserve scene identity and reconciliation assumptions from current importer model
-
-### Acceptance Criteria
-
-- [ ] No duplicate logical scenes created due to ordering or path changes in source
-- [ ] No silent overwrite of agent-authoritative fields
-- [ ] Warning taxonomy is stable and documented
-
-### Deliverables
-
-- [ ] Ownership-safe merge policy implementation
-- [ ] Structured warnings and error codes
-
-## Phase D — Docs and Beta Ops (M4)
-
-### Tasks
-
-- [ ] Update setup docs with two-path guidance (stable vs beta)
-- [ ] Add "tested versions" compatibility section for beta path
-- [ ] Add troubleshooting section for parser/schema mismatch failures
-- [ ] Add tool reference updates and explicit stability tier labeling
-
-### Acceptance Criteria
-
-- [ ] Users can clearly distinguish stable default from beta option
-- [ ] Docs provide a clear fallback path when beta ingestion fails
-- [ ] Beta caveats appear in all relevant surfaces (setup, tools, runtime)
-
-### Deliverables
-
-- [ ] Documentation updates across setup and tool reference docs
-- [ ] Compatibility notes and operational troubleshooting guidance
-
-## Test Plan
-
-## Unit Tests
-
-- [ ] Parser reads `.scrivx` maps correctly (sync map, keyword map, binder traversal)
-- [ ] Metadata extraction handles absent optional files without crash
-- [ ] Merge contract preserves non-authoritative fields
-- [ ] Custom-field mapping allowlist behavior is deterministic
-
-## Integration Tests
-
-- [ ] MCP beta tool dry-run against fixture `.scriv` bundle
-- [ ] MCP beta tool write mode updates sidecars as expected
-- [ ] Re-run idempotency: second run does not produce unintended drift
-- [ ] Fallback messaging on incompatible or malformed source structure
-
-## Regression Coverage
-
-- [ ] Existing `import_scrivener_sync` integration tests remain green
-- [ ] Stable sync-folder import behavior unchanged
-
-## Compatibility Matrix (Initial)
-
-Track explicitly as fixtures are added.
-
-- [ ] Scrivener fixture A: baseline project structure
-- [ ] Scrivener fixture B: missing optional metadata files
-- [ ] Scrivener fixture C: custom metadata-heavy project
-- [ ] Scrivener fixture D: reordered binder hierarchy
-
-For each fixture:
-
-- [ ] parse success
-- [ ] merge success
-- [ ] warning profile reviewed
-- [ ] sidecar preservation checks pass
 
 ## Exit Criteria For Beta Graduation Review
 

--- a/docs/prd/in-progress/scrivener-direct-extraction-beta.md
+++ b/docs/prd/in-progress/scrivener-direct-extraction-beta.md
@@ -38,10 +38,10 @@ Because internal schema may change, direct extraction is an opt-in beta feature,
 
 ### Prototype/Hidden Today
 
-- `scripts/merge-scrivx.js` already parses `.scrivx` + project data to merge metadata into scene sidecars
-- Not currently an official MCP tool
-- Not currently documented as a supported ingestion mode
-- Not currently covered by equivalent test depth as the stable import path
+- `scripts/merge-scrivx.js` and `scrivener-direct.js` parse `.scrivx` + project data to merge metadata into scene sidecars
+- Official MCP beta tools exist: `merge_scrivener_project_beta` and `merge_scrivener_project_beta_async`
+- Documented as an opt-in beta ingestion mode with explicit stable fallback guidance
+- Covered by focused unit and integration tests, including dry-run behavior, fallback messaging, `scenes_dir` precedence, async completion, warning surfaces, and rerun idempotency
 
 ## Beta Scope (Phase 1)
 
@@ -117,6 +117,13 @@ Direct extraction should unlock metadata quality improvements not available from
 3. Errors include fallback guidance to stable sync-folder import
 4. Runtime outputs identify parser assumptions when they fail
 
+### Current Status
+
+- Stable-vs-beta setup guidance is documented in `docs/setup.md`.
+- Beta parser/schema mismatch troubleshooting and fallback guidance is documented in `docs/development.md`.
+- Tool reference labels stable and beta tiers for Scrivener import/merge tools.
+- Beta merge responses provide structured warning payloads and warning summaries for skipped or normalized inputs.
+
 ## Rollout Plan
 
 1. **Phase A: Formalize current script core**
@@ -142,6 +149,13 @@ This feature remains beta until all criteria are met:
 4. Sufficient integration coverage for representative `.scriv` fixtures
 
 If any criterion regresses, the feature stays beta.
+
+## Current Gaps Before Graduation
+
+1. Explicit importer-authoritative ownership policy enforcement remains incomplete.
+2. Conflict reporting for ambiguous mappings still needs dedicated treatment.
+3. Compatibility matrix expansion beyond the baseline fixture remains open.
+4. Tested-version coverage documentation is still partial.
 
 ## Related
 

--- a/docs/prd/in-progress/scrivener-direct-extraction-beta.md
+++ b/docs/prd/in-progress/scrivener-direct-extraction-beta.md
@@ -66,6 +66,8 @@ Provide a supported beta capability that can be called intentionally and safely.
 3. Full support promise across all historical/future Scrivener versions
 4. Implicit writes outside scene sidecars
 
+Note: Optional scene relocation into chapter-based folders may be exposed as an explicit opt-in (`organize_by_chapters`). It must remain off by default and never run implicitly.
+
 ## Feature Parity Requirements
 
 Direct extraction must reach functional parity with the stable importer in safety and operational behavior before any graduation discussion.

--- a/docs/prd/in-progress/scrivener-direct-extraction-beta.md
+++ b/docs/prd/in-progress/scrivener-direct-extraction-beta.md
@@ -53,6 +53,7 @@ Provide a supported beta capability that can be called intentionally and safely.
 2. Keep the existing stable sync-folder import unchanged
 3. Parse and merge at least:
    - Scrivener keywords
+   - Preserve keyword assignments as raw tags/keyword graph entries; do not infer semantic meaning (for example, auto-mapping keywords into `characters` or `versions`) in Phase 1
    - synopsis/card summary
    - selected custom metadata fields (initial allowlist)
 4. Preserve identity/reconciliation behavior compatible with current scene IDs and external IDs
@@ -93,6 +94,7 @@ Direct extraction must reach functional parity with the stable importer in safet
 Direct extraction should unlock metadata quality improvements not available from text export alone.
 
 1. Keyword graph from Scrivener keyword assignments
+   - Maintain source fidelity: keyword values should be stored and exposed verbatim (subject to normalization like trimming/dedup), without interpretation-based remapping
 2. Synopsis from Scrivener synopsis files
 3. Binder hierarchy metadata for more reliable structural mapping
 4. Custom metadata fields (via explicit mapping contract)

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -3,7 +3,10 @@
 - [Prerequisites](#prerequisites)
 - [Permission contract](#permission-contract)
 - [First-time setup path (recommended)](#first-time-setup-path-recommended)
-- [Quick start with Scrivener](#quick-start-with-scrivener)
+- [Choosing a Scrivener path](#choosing-a-scrivener-path)
+- [Quick start with Scrivener (stable default)](#quick-start-with-scrivener-stable-default)
+- [Direct Scrivener project merge (beta)](#direct-scrivener-project-merge-beta)
+- [Beta compatibility and fallback](#beta-compatibility-and-fallback)
 - [Advanced: Native sync format](#advanced-native-sync-format)
 - [Data ownership model](data-ownership.md)
 
@@ -61,9 +64,28 @@ Once this is working, you can come back to:
 - **[docs/tools.md](tools.md)** for the full tool catalog
 - **[README.md](../README.md#usage-scenarios)** for workflow ideas
 
+If you later want richer metadata from a full `.scriv` bundle, add the **Direct Scrivener project merge (beta)** step after the stable import has already created your scene sidecars.
+
 ---
 
-## Quick start with Scrivener
+## Choosing a Scrivener path
+
+There are two supported Scrivener ingestion paths, and they are not equally stable.
+
+| Path | Stability | Use when | Tooling |
+| --- | --- | --- | --- |
+| External Folder Sync export | Stable default | First-time setup, routine imports, safest long-term path | `import_scrivener_sync`, `import_scrivener_sync_async` |
+| Direct `.scriv` project merge | Beta / opt-in | You already imported scenes and want extra metadata from Scrivener internals | `merge_scrivener_project_beta`, `merge_scrivener_project_beta_async` |
+
+Recommendation:
+
+1. Start with the stable External Folder Sync path.
+2. Confirm your scene sidecars and indexing are correct.
+3. Use the beta direct-merge path only if you need metadata that plain-text sync cannot provide, such as Scrivener keywords, synopsis files, or selected custom fields.
+
+---
+
+## Quick start with Scrivener (stable default)
 
 If you write in [Scrivener](https://www.literatureandlatte.com/scrivener), this gives you the smoothest path to get started.
 
@@ -142,6 +164,89 @@ node scripts/lint-metadata.mjs --sync-dir /path/to/sync-dir
 ```
 
 This exits with a non-zero code if it finds errors. Warnings (for example `UNKNOWN_KEY`) are informational.
+
+---
+
+## Direct Scrivener project merge (beta)
+
+Use this only after the stable import path has already created your scene sidecars.
+
+What this beta path is for:
+
+- pull Scrivener keywords into sidecars
+- merge synopsis text from `Files/Data/<UUID>/synopsis.txt`
+- carry selected Scrivener custom fields into supported scene metadata keys
+
+What it is not for:
+
+- first-time scene creation
+- replacing `import_scrivener_sync` as the default path
+- broad compatibility guarantees across all Scrivener schema variations
+
+Recommended beta flow:
+
+1. Run the stable `import_scrivener_sync` flow first.
+2. Run the beta merge as a dry run.
+3. Inspect `merge.preview_changes`, `merge.warnings`, and `merge.warning_summary`.
+4. Re-run with `dry_run: false` only if the preview looks correct.
+
+Example dry run:
+
+```json
+{
+  "source_project_dir": "/Users/yourname/My Novel.scriv",
+  "project_id": "my-novel",
+  "dry_run": true,
+  "auto_sync": false
+}
+```
+
+If the preview is correct, write the merge:
+
+```json
+{
+  "source_project_dir": "/Users/yourname/My Novel.scriv",
+  "project_id": "my-novel",
+  "dry_run": false,
+  "auto_sync": true
+}
+```
+
+Use `scenes_dir` instead of `project_id` when your sidecars live in a non-standard layout or under a universe/project path that you want to resolve explicitly.
+
+---
+
+## Beta compatibility and fallback
+
+Current beta posture:
+
+- Runtime requirement: Node.js 22.6.0 or newer
+- Stable fallback remains: Scrivener External Folder Sync plus `import_scrivener_sync`
+- Current automated bundle coverage includes a baseline `.scriv` fixture with:
+  - `.scrivx` sync-number mapping
+  - Scrivener keywords
+  - synopsis files
+  - selected custom metadata fields
+  - `scenes_dir` override coverage
+- Not yet declared as broadly compatible:
+  - historical Scrivener versions as a published matrix
+  - custom-metadata-heavy projects
+  - reordered binder hierarchies beyond current fixture coverage
+
+Treat direct `.scriv` parsing as version-fragile until the beta coverage matrix expands.
+
+If the beta merge fails:
+
+1. Confirm `source_project_dir` points to the `.scriv` bundle directory itself, not the `.scrivx` file.
+2. Re-run with `dry_run: true` first.
+3. If you get `SCRIVENER_DIRECT_BETA_FAILED`, fall back to `import_scrivener_sync` from an External Folder Sync export.
+
+If the beta merge returns warnings:
+
+1. `missing_bracket_id`: the sidecar filename does not contain a Scrivener sync number like `[123]`; re-import via the stable path if needed.
+2. `missing_uuid_mapping`: the sidecar sync number is not present in the `.scrivx` sync map; confirm the sidecars came from the same Scrivener project/export lineage.
+3. `ignored_custom_field`: the Scrivener project contains custom metadata that this beta path does not map yet.
+4. `invalid_custom_field_value`: the source custom field value could not be normalized into the supported sidecar type and was ignored.
 
 ---
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -77,6 +77,7 @@ _No parameters._
 | `scenes_dir` | `string` | No | Absolute path to the scenes directory containing .meta.yaml sidecars. Overrides the path derived from project_id. Use this for non-standard sync layouts. |
 | `dry_run` | `boolean` | No | If true (default), reports planned merges without writing files. |
 | `auto_sync` | `boolean` | No | If true (default), runs sync() after a non-dry-run merge. |
+| `organize_by_chapters` | `boolean` | No | If true (default false), relocate scene files into chapter-based folder hierarchies (e.g., chapter-7-harbor/). Chapter metadata is always extracted to sidecars regardless of this flag. |
 
 ---
 
@@ -106,6 +107,7 @@ _No parameters._
 | `scenes_dir` | `string` | No | Absolute path to the scenes directory containing .meta.yaml sidecars. Overrides the path derived from project_id. |
 | `dry_run` | `boolean` | No | If true (default), reports planned merges without writing files. |
 | `auto_sync` | `boolean` | No | If true, runs sync() after a non-dry-run async merge finishes. |
+| `organize_by_chapters` | `boolean` | No | If true (default false), relocate scene files into chapter-based folder hierarchies. Chapter metadata is always extracted to sidecars. |
 
 ---
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -53,59 +53,59 @@ _No parameters._
 
 ## import_scrivener_sync
 
-Import Scrivener External Folder Sync Draft files into this server's WRITING_SYNC_DIR by generating scene sidecars and reconciling by Scrivener binder ID. Use this for first-time setup before sync().
+[STABLE] Import Scrivener External Folder Sync Draft files into this server's WRITING_SYNC_DIR by generating scene sidecars and reconciling by Scrivener binder ID. This is the recommended default path for first-time setup before sync().
 
 | Parameter | Type | Required | Description |
-|-----------|------|:--------:|-------------|
-| `source_dir` | `string` | ✓ | Path to Scrivener external sync folder (the folder that contains Draft/, or Draft/ itself). |
-| `project_id` | `string` |  | Project ID override (e.g. 'the-lamb'). Defaults to a slug derived from WRITING_SYNC_DIR. |
-| `dry_run` | `boolean` |  | If true, reports planned writes without changing files. |
-| `auto_sync` | `boolean` |  | If true (default), runs sync() after import when not dry-run. |
-| `preflight` | `boolean` |  | If true, returns a list of files that would be processed without doing any work. Use to verify scope before a large import. |
-| `ignore_patterns` | `string[]` |  | Array of regex patterns matched against filenames. Files matching any pattern are excluded from import. Useful to skip fragments, beat-sheet notes, or feedback files. |
+| --- | --- | :---: | --- |
+| `source_dir` | `string` | Yes | Path to Scrivener external sync folder (the folder that contains Draft/, or Draft/ itself). |
+| `project_id` | `string` | No | Project ID override (e.g. 'the-lamb'). Defaults to a slug derived from WRITING_SYNC_DIR. |
+| `dry_run` | `boolean` | No | If true, reports planned writes without changing files. |
+| `auto_sync` | `boolean` | No | If true (default), runs sync() after import when not dry-run. |
+| `preflight` | `boolean` | No | If true, returns a list of files that would be processed without doing any work. Use to verify scope before a large import. |
+| `ignore_patterns` | `string[]` | No | Array of regex patterns matched against filenames. Files matching any pattern are excluded from import. Useful to skip fragments, beat-sheet notes, or feedback files. |
 
 ---
 
 ## merge_scrivener_project_beta
 
-[BETA] Merge metadata directly from a Scrivener .scriv project into existing scene sidecars. This path is opt-in and may be sensitive to Scrivener internal format changes. Requires scenes sidecars to already exist (for example, from import_scrivener_sync).
+[BETA] Merge metadata directly from a Scrivener .scriv project into existing scene sidecars. This path is opt-in, requires sidecars to already exist (for example, from import_scrivener_sync), and may be sensitive to Scrivener internal format changes.
 
 | Parameter | Type | Required | Description |
-|-----------|------|:--------:|-------------|
-| `source_project_dir` | `string` | ✓ | Path to a Scrivener .scriv bundle directory. |
-| `project_id` | `string` |  | Project ID containing existing sidecars (e.g. 'the-lamb' or 'universe-1/book-1-the-lamb'). Defaults to a slug derived from WRITING_SYNC_DIR. |
-| `scenes_dir` | `string` |  | Absolute path to the scenes directory containing .meta.yaml sidecars. Overrides the path derived from project_id. Use this for non-standard sync layouts. |
-| `dry_run` | `boolean` |  | If true (default), reports planned merges without writing files. |
-| `auto_sync` | `boolean` |  | If true (default), runs sync() after a non-dry-run merge. |
+| --- | --- | :---: | --- |
+| `source_project_dir` | `string` | Yes | Path to a Scrivener .scriv bundle directory. |
+| `project_id` | `string` | No | Project ID containing existing sidecars (e.g. 'the-lamb' or 'universe-1/book-1-the-lamb'). Defaults to a slug derived from WRITING_SYNC_DIR. |
+| `scenes_dir` | `string` | No | Absolute path to the scenes directory containing .meta.yaml sidecars. Overrides the path derived from project_id. Use this for non-standard sync layouts. |
+| `dry_run` | `boolean` | No | If true (default), reports planned merges without writing files. |
+| `auto_sync` | `boolean` | No | If true (default), runs sync() after a non-dry-run merge. |
 
 ---
 
 ## import_scrivener_sync_async
 
-Start an asynchronous Scrivener External Folder Sync import job. Returns immediately with a job_id to poll via get_async_job_status.
+[STABLE] Start an asynchronous Scrivener External Folder Sync import job. This is the recommended default import path when the sync tree is large. Returns immediately with a job_id to poll via get_async_job_status.
 
 | Parameter | Type | Required | Description |
-|-----------|------|:--------:|-------------|
-| `source_dir` | `string` | ✓ | Path to Scrivener external sync folder (the folder that contains Draft/, or Draft/ itself). |
-| `project_id` | `string` |  | Project ID override (e.g. 'the-lamb' or 'universe-1/book-1-the-lamb'). |
-| `dry_run` | `boolean` |  | If true, reports planned writes without changing files. |
-| `auto_sync` | `boolean` |  | If true, runs sync() after a non-dry-run async import finishes. |
-| `preflight` | `boolean` |  | If true, returns a list of files that would be processed without doing any work. |
-| `ignore_patterns` | `string[]` |  | Array of regex patterns matched against filenames. Files matching any pattern are excluded from import. |
+| --- | --- | :---: | --- |
+| `source_dir` | `string` | Yes | Path to Scrivener external sync folder (the folder that contains Draft/, or Draft/ itself). |
+| `project_id` | `string` | No | Project ID override (e.g. 'the-lamb' or 'universe-1/book-1-the-lamb'). |
+| `dry_run` | `boolean` | No | If true, reports planned writes without changing files. |
+| `auto_sync` | `boolean` | No | If true, runs sync() after a non-dry-run async import finishes. |
+| `preflight` | `boolean` | No | If true, returns a list of files that would be processed without doing any work. |
+| `ignore_patterns` | `string[]` | No | Array of regex patterns matched against filenames. Files matching any pattern are excluded from import. |
 
 ---
 
 ## merge_scrivener_project_beta_async
 
-Start an asynchronous beta Scrivener metadata merge job. Returns immediately with a job_id to poll via get_async_job_status.
+[BETA] Start an asynchronous Scrivener metadata merge job from a `.scriv` project into existing scene sidecars. Use this only after the stable import path has created sidecars. Returns immediately with a job_id to poll via get_async_job_status.
 
 | Parameter | Type | Required | Description |
-|-----------|------|:--------:|-------------|
-| `source_project_dir` | `string` | ✓ | Path to a Scrivener .scriv bundle directory. |
-| `project_id` | `string` |  | Project ID containing existing sidecars (e.g. 'the-lamb' or 'universe-1/book-1-the-lamb'). |
-| `scenes_dir` | `string` |  | Absolute path to the scenes directory containing .meta.yaml sidecars. Overrides the path derived from project_id. |
-| `dry_run` | `boolean` |  | If true (default), reports planned merges without writing files. |
-| `auto_sync` | `boolean` |  | If true, runs sync() after a non-dry-run async merge finishes. |
+| --- | --- | :---: | --- |
+| `source_project_dir` | `string` | Yes | Path to a Scrivener .scriv bundle directory. |
+| `project_id` | `string` | No | Project ID containing existing sidecars (e.g. 'the-lamb' or 'universe-1/book-1-the-lamb'). |
+| `scenes_dir` | `string` | No | Absolute path to the scenes directory containing .meta.yaml sidecars. Overrides the path derived from project_id. |
+| `dry_run` | `boolean` | No | If true (default), reports planned merges without writing files. |
+| `auto_sync` | `boolean` | No | If true, runs sync() after a non-dry-run async merge finishes. |
 
 ---
 
@@ -114,17 +114,17 @@ Start an asynchronous beta Scrivener metadata merge job. Returns immediately wit
 Start an asynchronous batch job that infers scene character mentions and updates scene metadata links. Version 1 uses canonical character names only (no aliases). Defaults to dry_run=true.
 
 | Parameter | Type | Required | Description |
-|-----------|------|:--------:|-------------|
-| `project_id` | `string` | ✓ | Project ID (e.g. 'the-lamb' or 'universe-1/book-1-the-lamb'). |
-| `scene_ids` | `string[]` |  | Optional allowlist of scene IDs to process before other filters are applied. |
-| `part` | `integer` |  | Optional part number filter. |
-| `chapter` | `integer` |  | Optional chapter number filter. |
-| `only_stale` | `boolean` |  | If true, only process scenes currently marked metadata_stale. |
-| `dry_run` | `boolean` |  | If true (default), returns preview results without writing sidecars. |
-| `replace_mode` | `enum("merge","replace")` |  | merge (default): add inferred IDs; replace: overwrite characters with inferred IDs. |
-| `max_scenes` | `integer` |  | Hard guardrail for resolved scene count (default: 200). |
-| `include_match_details` | `boolean` |  | If true, include extra match diagnostics per scene. |
-| `confirm_replace` | `boolean` |  | Must be true when replace_mode=replace. |
+| --- | --- | :---: | --- |
+| `project_id` | `string` | Yes | Project ID (e.g. 'the-lamb' or 'universe-1/book-1-the-lamb'). |
+| `scene_ids` | `string[]` | No | Optional allowlist of scene IDs to process before other filters are applied. |
+| `part` | `integer` | No | Optional part number filter. |
+| `chapter` | `integer` | No | Optional chapter number filter. |
+| `only_stale` | `boolean` | No | If true, only process scenes currently marked metadata_stale. |
+| `dry_run` | `boolean` | No | If true (default), returns preview results without writing sidecars. |
+| `replace_mode` | `enum("merge","replace")` | No | merge (default): add inferred IDs; replace: overwrite characters with inferred IDs. |
+| `max_scenes` | `integer` | No | Hard guardrail for resolved scene count (default: 200). |
+| `include_match_details` | `boolean` | No | If true, include extra match diagnostics per scene. |
+| `confirm_replace` | `boolean` | No | Must be true when replace_mode=replace. |
 
 ---
 
@@ -133,9 +133,9 @@ Start an asynchronous batch job that infers scene character mentions and updates
 Get status and result for an asynchronous job started by async tools such as import_scrivener_sync_async, merge_scrivener_project_beta_async, or enrich_scene_characters_batch.
 
 | Parameter | Type | Required | Description |
-|-----------|------|:--------:|-------------|
-| `job_id` | `string` | ✓ | Job ID returned by an async start tool. |
-| `include_result` | `boolean` |  | If true (default), includes completed result payload when available. |
+| --- | --- | :---: | --- |
+| `job_id` | `string` | Yes | Job ID returned by an async start tool. |
+| `include_result` | `boolean` | No | If true (default), includes completed result payload when available. |
 
 ---
 
@@ -144,8 +144,8 @@ Get status and result for an asynchronous job started by async tools such as imp
 List asynchronous jobs currently known to this server.
 
 | Parameter | Type | Required | Description |
-|-----------|------|:--------:|-------------|
-| `include_results` | `boolean` |  | If true, includes completed result payloads. |
+| --- | --- | :---: | --- |
+| `include_results` | `boolean` | No | If true, includes completed result payloads. |
 
 ---
 
@@ -154,8 +154,8 @@ List asynchronous jobs currently known to this server.
 Cancel a running asynchronous job.
 
 | Parameter | Type | Required | Description |
-|-----------|------|:--------:|-------------|
-| `job_id` | `string` | ✓ | Job ID returned by an async start tool. |
+| --- | --- | :---: | --- |
+| `job_id` | `string` | Yes | Job ID returned by an async start tool. |
 
 ---
 
@@ -172,16 +172,16 @@ _No parameters._
 Find scenes by filtering on character, Save the Cat beat, tags, part, chapter, or POV. Returns ordered scene metadata only — no prose. All filters are optional and combinable. Supports pagination via page/page_size and auto-paginates large result sets with total_count. Warns if any matching scenes have stale metadata.
 
 | Parameter | Type | Required | Description |
-|-----------|------|:--------:|-------------|
-| `project_id` | `string` |  | Project ID (e.g. 'the-lamb'). Use to scope results to one project. |
-| `character` | `string` |  | A character_id (e.g. 'char-mira-nystrom'). Returns only scenes that character appears in. Use list_characters first to find valid IDs. |
-| `beat` | `string` |  | Save the Cat beat name (e.g. 'Opening Image'). Exact match. |
-| `tag` | `string` |  | Scene tag to filter by. Exact match. |
-| `part` | `integer` |  | Part number (integer, e.g. 1). Chapters are numbered globally across the whole project. |
-| `chapter` | `integer` |  | Chapter number (integer, e.g. 3). Chapters are numbered globally across the whole project — do not reset per part. |
-| `pov` | `string` |  | POV character_id. Use list_characters first to find valid IDs. |
-| `page` | `integer` |  | Optional page number for paginated responses (1-based). |
-| `page_size` | `integer` |  | Optional page size for paginated responses (default: 20, max: 200). |
+| --- | --- | :---: | --- |
+| `project_id` | `string` | No | Project ID (e.g. 'the-lamb'). Use to scope results to one project. |
+| `character` | `string` | No | A character_id (e.g. 'char-mira-nystrom'). Returns only scenes that character appears in. Use list_characters first to find valid IDs. |
+| `beat` | `string` | No | Save the Cat beat name (e.g. 'Opening Image'). Exact match. |
+| `tag` | `string` | No | Scene tag to filter by. Exact match. |
+| `part` | `integer` | No | Part number (integer, e.g. 1). Chapters are numbered globally across the whole project. |
+| `chapter` | `integer` | No | Chapter number (integer, e.g. 3). Chapters are numbered globally across the whole project — do not reset per part. |
+| `pov` | `string` | No | POV character_id. Use list_characters first to find valid IDs. |
+| `page` | `integer` | No | Optional page number for paginated responses (1-based). |
+| `page_size` | `integer` | No | Optional page size for paginated responses (default: 20, max: 200). |
 
 ---
 
@@ -190,9 +190,9 @@ Find scenes by filtering on character, Save the Cat beat, tags, part, chapter, o
 Load the full prose text of a single scene. Use this for close reading, continuity checks, or when you need the actual writing. For overview or filtering, use find_scenes instead — it is much cheaper. Optionally retrieve a past version from git history.
 
 | Parameter | Type | Required | Description |
-|-----------|------|:--------:|-------------|
-| `scene_id` | `string` | ✓ | The scene_id to retrieve (e.g. 'sc-001-prologue'). Get this from find_scenes or get_arc. |
-| `commit` | `string` |  | Optional git commit hash to retrieve a past version. Use list_snapshots to find valid hashes. If omitted, returns the current prose. |
+| --- | --- | :---: | --- |
+| `scene_id` | `string` | Yes | The scene_id to retrieve (e.g. 'sc-001-prologue'). Get this from find_scenes or get_arc. |
+| `commit` | `string` | No | Optional git commit hash to retrieve a past version. Use list_snapshots to find valid hashes. If omitted, returns the current prose. |
 
 ---
 
@@ -201,10 +201,10 @@ Load the full prose text of a single scene. Use this for close reading, continui
 Load the full prose for every scene in a chapter, concatenated in order. Expensive — only use when you need to read an entire chapter. Capped at 10 scenes. Use find_scenes first to confirm the chapter exists.
 
 | Parameter | Type | Required | Description |
-|-----------|------|:--------:|-------------|
-| `project_id` | `string` | ✓ | Project ID (e.g. 'the-lamb'). |
-| `part` | `integer` | ✓ | Part number (integer). |
-| `chapter` | `integer` | ✓ | Chapter number (integer, globally numbered across the whole project). |
+| --- | --- | :---: | --- |
+| `project_id` | `string` | Yes | Project ID (e.g. 'the-lamb'). |
+| `part` | `integer` | Yes | Part number (integer). |
+| `chapter` | `integer` | Yes | Chapter number (integer, globally numbered across the whole project). |
 
 ---
 
@@ -213,11 +213,11 @@ Load the full prose for every scene in a chapter, concatenated in order. Expensi
 Get every scene a character appears in, ordered by part/chapter/position. Returns scene metadata only — no prose. Use this to trace a character's arc through the story. Supports pagination via page/page_size and auto-paginates large result sets with total_count. Call list_characters first to get the character_id.
 
 | Parameter | Type | Required | Description |
-|-----------|------|:--------:|-------------|
-| `character_id` | `string` | ✓ | The character_id to trace (e.g. 'char-mira-nystrom'). Use list_characters to find valid IDs. |
-| `project_id` | `string` |  | Limit to a specific project (e.g. 'the-lamb'). |
-| `page` | `integer` |  | Optional page number for paginated responses (1-based). |
-| `page_size` | `integer` |  | Optional page size for paginated responses (default: 20, max: 200). |
+| --- | --- | :---: | --- |
+| `character_id` | `string` | Yes | The character_id to trace (e.g. 'char-mira-nystrom'). Use list_characters to find valid IDs. |
+| `project_id` | `string` | No | Limit to a specific project (e.g. 'the-lamb'). |
+| `page` | `integer` | No | Optional page number for paginated responses (1-based). |
+| `page_size` | `integer` | No | Optional page size for paginated responses (default: 20, max: 200). |
 
 ---
 
@@ -226,9 +226,9 @@ Get every scene a character appears in, ordered by part/chapter/position. Return
 List all indexed characters with their character_id, name, role, and arc_summary. Call this first whenever you need to filter scenes by character or look up a character sheet — it gives you the character_id values required by other tools.
 
 | Parameter | Type | Required | Description |
-|-----------|------|:--------:|-------------|
-| `project_id` | `string` |  | Limit to a specific project (e.g. 'the-lamb'). |
-| `universe_id` | `string` |  | Limit to a specific universe (if using cross-project world-building). |
+| --- | --- | :---: | --- |
+| `project_id` | `string` | No | Limit to a specific project (e.g. 'the-lamb'). |
+| `universe_id` | `string` | No | Limit to a specific universe (if using cross-project world-building). |
 
 ---
 
@@ -237,8 +237,8 @@ List all indexed characters with their character_id, name, role, and arc_summary
 Get full character details: role, arc_summary, traits, the canonical sheet content, and any adjacent support notes when the character uses a folder-based layout. Use list_characters first to get the character_id.
 
 | Parameter | Type | Required | Description |
-|-----------|------|:--------:|-------------|
-| `character_id` | `string` | ✓ | The character_id to look up (e.g. 'char-sebastian'). Use list_characters to find valid IDs. |
+| --- | --- | :---: | --- |
+| `character_id` | `string` | Yes | The character_id to look up (e.g. 'char-sebastian'). Use list_characters to find valid IDs. |
 
 ---
 
@@ -247,12 +247,12 @@ Get full character details: role, arc_summary, traits, the canonical sheet conte
 Create or reuse a canonical character sheet folder with sheet.md and sheet.meta.yaml so the character can be indexed immediately. If the folder already exists, missing canonical files are backfilled and the existing sheet is preserved.
 
 | Parameter | Type | Required | Description |
-|-----------|------|:--------:|-------------|
-| `name` | `string` | ✓ | Display name of the character (e.g. 'Mira Nystrom'). |
-| `project_id` | `string` |  | Project scope for a book-local character (e.g. 'universe-1/book-1-the-lamb' or 'test-novel'). |
-| `universe_id` | `string` |  | Universe scope for a cross-book shared character (e.g. 'universe-1'). |
-| `notes` | `string` |  | Optional starter prose content for sheet.md. |
-| `fields` | `object` |  | Optional starter metadata fields for the character sidecar. |
+| --- | --- | :---: | --- |
+| `name` | `string` | Yes | Display name of the character (e.g. 'Mira Nystrom'). |
+| `project_id` | `string` | No | Project scope for a book-local character (e.g. 'universe-1/book-1-the-lamb' or 'test-novel'). |
+| `universe_id` | `string` | No | Universe scope for a cross-book shared character (e.g. 'universe-1'). |
+| `notes` | `string` | No | Optional starter prose content for sheet.md. |
+| `fields` | `object` | No | Optional starter metadata fields for the character sidecar. |
 
 ---
 
@@ -261,9 +261,9 @@ Create or reuse a canonical character sheet folder with sheet.md and sheet.meta.
 List all indexed places with their place_id and name. Use this to find place_id values for scene filtering or to get an overview of the story's locations.
 
 | Parameter | Type | Required | Description |
-|-----------|------|:--------:|-------------|
-| `project_id` | `string` |  | Limit to a specific project (e.g. 'the-lamb'). |
-| `universe_id` | `string` |  | Limit to a specific universe. |
+| --- | --- | :---: | --- |
+| `project_id` | `string` | No | Limit to a specific project (e.g. 'the-lamb'). |
+| `universe_id` | `string` | No | Limit to a specific universe. |
 
 ---
 
@@ -272,12 +272,12 @@ List all indexed places with their place_id and name. Use this to find place_id 
 Create or reuse a canonical place sheet folder with sheet.md and sheet.meta.yaml so the place can be indexed immediately. If the folder already exists, missing canonical files are backfilled and the existing sheet is preserved.
 
 | Parameter | Type | Required | Description |
-|-----------|------|:--------:|-------------|
-| `name` | `string` | ✓ | Display name of the place (e.g. 'University Hospital'). |
-| `project_id` | `string` |  | Project scope for a book-local place (e.g. 'universe-1/book-1-the-lamb' or 'test-novel'). |
-| `universe_id` | `string` |  | Universe scope for a cross-book shared place (e.g. 'universe-1'). |
-| `notes` | `string` |  | Optional starter prose content for sheet.md. |
-| `fields` | `object` |  | Optional starter metadata fields for the place sidecar. |
+| --- | --- | :---: | --- |
+| `name` | `string` | Yes | Display name of the place (e.g. 'University Hospital'). |
+| `project_id` | `string` | No | Project scope for a book-local place (e.g. 'universe-1/book-1-the-lamb' or 'test-novel'). |
+| `universe_id` | `string` | No | Universe scope for a cross-book shared place (e.g. 'universe-1'). |
+| `notes` | `string` | No | Optional starter prose content for sheet.md. |
+| `fields` | `object` | No | Optional starter metadata fields for the place sidecar. |
 
 ---
 
@@ -286,8 +286,8 @@ Create or reuse a canonical place sheet folder with sheet.md and sheet.meta.yaml
 Get full place details: associated_characters, tags, the canonical sheet content, and any adjacent support notes when the place uses a folder-based layout. Use list_places first to get the place_id.
 
 | Parameter | Type | Required | Description |
-|-----------|------|:--------:|-------------|
-| `place_id` | `string` | ✓ | The place_id to look up (e.g. 'place-harbor-district'). Use list_places to find valid IDs. |
+| --- | --- | :---: | --- |
+| `place_id` | `string` | Yes | The place_id to look up (e.g. 'place-harbor-district'). Use list_places to find valid IDs. |
 
 ---
 
@@ -296,10 +296,10 @@ Get full place details: associated_characters, tags, the canonical sheet content
 Full-text search across scene titles, loglines (synopsis/logline text fields), and metadata keywords (tags/characters/places/versions). Use this when you don't know the exact scene_id or chapter but want to find scenes by topic, theme, or metadata keyword. Not a prose search — use get_scene_prose to read actual text. Supports pagination via page/page_size and auto-paginates large result sets with total_count.
 
 | Parameter | Type | Required | Description |
-|-----------|------|:--------:|-------------|
-| `query` | `string` | ✓ | Search terms (e.g. 'hospital' or 'Sebastian feeding'). FTS5 syntax supported. |
-| `page` | `integer` |  | Optional page number for paginated responses (1-based). |
-| `page_size` | `integer` |  | Optional page size for paginated responses (default: 20, max: 200). |
+| --- | --- | :---: | --- |
+| `query` | `string` | Yes | Search terms (e.g. 'hospital' or 'Sebastian feeding'). FTS5 syntax supported. |
+| `page` | `integer` | No | Optional page number for paginated responses (1-based). |
+| `page_size` | `integer` | No | Optional page size for paginated responses (default: 20, max: 200). |
 
 ---
 
@@ -308,10 +308,10 @@ Full-text search across scene titles, loglines (synopsis/logline text fields), a
 List all subplot/storyline threads for a project. Returns a structured JSON envelope with results and total_count. Supports pagination via page/page_size.
 
 | Parameter | Type | Required | Description |
-|-----------|------|:--------:|-------------|
-| `project_id` | `string` | ✓ | Project ID. |
-| `page` | `integer` |  | Optional page number for paginated responses (1-based). |
-| `page_size` | `integer` |  | Optional page size for paginated responses (default: 20, max: 200). |
+| --- | --- | :---: | --- |
+| `project_id` | `string` | Yes | Project ID. |
+| `page` | `integer` | No | Optional page number for paginated responses (1-based). |
+| `page_size` | `integer` | No | Optional page size for paginated responses (default: 20, max: 200). |
 
 ---
 
@@ -320,10 +320,10 @@ List all subplot/storyline threads for a project. Returns a structured JSON enve
 Get ordered scene metadata for all scenes belonging to a thread, including the per-thread beat. Returns a structured JSON envelope with thread metadata, results, and total_count. Supports pagination via page/page_size.
 
 | Parameter | Type | Required | Description |
-|-----------|------|:--------:|-------------|
-| `thread_id` | `string` | ✓ | Thread ID. |
-| `page` | `integer` |  | Optional page number for paginated responses (1-based). |
-| `page_size` | `integer` |  | Optional page size for paginated responses (default: 20, max: 200). |
+| --- | --- | :---: | --- |
+| `thread_id` | `string` | Yes | Thread ID. |
+| `page` | `integer` | No | Optional page number for paginated responses (1-based). |
+| `page_size` | `integer` | No | Optional page size for paginated responses (default: 20, max: 200). |
 
 ---
 
@@ -332,13 +332,13 @@ Get ordered scene metadata for all scenes belonging to a thread, including the p
 Create or update a thread and link it to a scene. Idempotent: if the link already exists, updates its beat. Only available when the sync dir is writable.
 
 | Parameter | Type | Required | Description |
-|-----------|------|:--------:|-------------|
-| `project_id` | `string` | ✓ | Project the thread belongs to (e.g. 'the-lamb'). |
-| `thread_id` | `string` | ✓ | Thread ID (e.g. 'thread-reconciliation'). |
-| `thread_name` | `string` | ✓ | Thread display name. |
-| `scene_id` | `string` | ✓ | Scene to link to the thread (e.g. 'sc-011-sebastian'). |
-| `beat` | `string` |  | Optional thread-specific beat label for this scene. |
-| `status` | `string` |  | Thread status (e.g. 'active', 'resolved'). Defaults to 'active'. |
+| --- | --- | :---: | --- |
+| `project_id` | `string` | Yes | Project the thread belongs to (e.g. 'the-lamb'). |
+| `thread_id` | `string` | Yes | Thread ID (e.g. 'thread-reconciliation'). |
+| `thread_name` | `string` | Yes | Thread display name. |
+| `scene_id` | `string` | Yes | Scene to link to the thread (e.g. 'sc-011-sebastian'). |
+| `beat` | `string` | No | Optional thread-specific beat label for this scene. |
+| `status` | `string` | No | Thread status (e.g. 'active', 'resolved'). Defaults to 'active'. |
 
 ---
 
@@ -347,9 +347,9 @@ Create or update a thread and link it to a scene. Idempotent: if the link alread
 Re-derive lightweight scene metadata from current prose (logline and character mentions) and clear metadata_stale for that scene. Only available when the sync dir is writable.
 
 | Parameter | Type | Required | Description |
-|-----------|------|:--------:|-------------|
-| `scene_id` | `string` | ✓ | Scene to enrich (e.g. 'sc-011-sebastian'). |
-| `project_id` | `string` |  | Project ID. Required when scene_id is duplicated across projects. |
+| --- | --- | :---: | --- |
+| `scene_id` | `string` | Yes | Scene to enrich (e.g. 'sc-011-sebastian'). |
+| `project_id` | `string` | No | Project ID. Required when scene_id is duplicated across projects. |
 
 ---
 
@@ -358,10 +358,10 @@ Re-derive lightweight scene metadata from current prose (logline and character m
 Update one or more metadata fields for a scene. Writes to the .meta.yaml sidecar — never modifies prose. Changes are immediately reflected in the index. Only available when the sync dir is writable.
 
 | Parameter | Type | Required | Description |
-|-----------|------|:--------:|-------------|
-| `scene_id` | `string` | ✓ | The scene_id to update (e.g. 'sc-011-sebastian'). |
-| `project_id` | `string` | ✓ | Project the scene belongs to (e.g. 'the-lamb'). |
-| `fields` | `object` |  | Fields to update. Only supplied keys are changed. |
+| --- | --- | :---: | --- |
+| `scene_id` | `string` | Yes | The scene_id to update (e.g. 'sc-011-sebastian'). |
+| `project_id` | `string` | Yes | Project the scene belongs to (e.g. 'the-lamb'). |
+| `fields` | `object` | No | Fields to update. Only supplied keys are changed. |
 
 ---
 
@@ -370,9 +370,9 @@ Update one or more metadata fields for a scene. Writes to the .meta.yaml sidecar
 Update structured metadata fields for a character (role, arc_summary, traits, etc). Writes to the .meta.yaml sidecar — never modifies the prose notes file. Changes are immediately reflected in the index. Only available when the sync dir is writable.
 
 | Parameter | Type | Required | Description |
-|-----------|------|:--------:|-------------|
-| `character_id` | `string` | ✓ | The character_id to update (e.g. 'char-mira-nystrom'). Use list_characters to find valid IDs. |
-| `fields` | `object` |  | Fields to update. Only supplied keys are changed. |
+| --- | --- | :---: | --- |
+| `character_id` | `string` | Yes | The character_id to update (e.g. 'char-mira-nystrom'). Use list_characters to find valid IDs. |
+| `fields` | `object` | No | Fields to update. Only supplied keys are changed. |
 
 ---
 
@@ -381,9 +381,9 @@ Update structured metadata fields for a character (role, arc_summary, traits, et
 Update structured metadata fields for a place (name, associated_characters, tags). Writes to the .meta.yaml sidecar — never modifies the prose notes file. Changes are immediately reflected in the index. Only available when the sync dir is writable.
 
 | Parameter | Type | Required | Description |
-|-----------|------|:--------:|-------------|
-| `place_id` | `string` | ✓ | The place_id to update (e.g. 'place-harbor-district'). Use list_places to find valid IDs. |
-| `fields` | `object` |  | Fields to update. Only supplied keys are changed. |
+| --- | --- | :---: | --- |
+| `place_id` | `string` | Yes | The place_id to update (e.g. 'place-harbor-district'). Use list_places to find valid IDs. |
+| `fields` | `object` | No | Fields to update. Only supplied keys are changed. |
 
 ---
 
@@ -392,10 +392,10 @@ Update structured metadata fields for a place (name, associated_characters, tags
 Attach a continuity or review note to a scene. Flags are appended to the sidecar file and accumulate over time — they are never overwritten. Use this to record continuity problems, revision notes, or questions you want to revisit.
 
 | Parameter | Type | Required | Description |
-|-----------|------|:--------:|-------------|
-| `scene_id` | `string` | ✓ | The scene_id to flag (e.g. 'sc-012-open-to-anyone'). |
-| `project_id` | `string` | ✓ | Project the scene belongs to (e.g. 'the-lamb'). |
-| `note` | `string` | ✓ | The flag note (e.g. 'Victor knows Mira’s name here, but they haven’t been introduced yet — contradicts sc-006'). |
+| --- | --- | :---: | --- |
+| `scene_id` | `string` | Yes | The scene_id to flag (e.g. 'sc-012-open-to-anyone'). |
+| `project_id` | `string` | Yes | Project the scene belongs to (e.g. 'the-lamb'). |
+| `note` | `string` | Yes | The flag note (e.g. 'Victor knows Mira’s name here, but they haven’t been introduced yet — contradicts sc-006'). |
 
 ---
 
@@ -404,10 +404,10 @@ Attach a continuity or review note to a scene. Flags are appended to the sidecar
 Show how the relationship between two characters evolves across scenes, in order. Uses explicitly recorded relationship entries — returns nothing if no entries exist yet. Use list_characters to get character_id values.
 
 | Parameter | Type | Required | Description |
-|-----------|------|:--------:|-------------|
-| `from_character` | `string` | ✓ | character_id of the first character (e.g. 'char-sebastian'). |
-| `to_character` | `string` | ✓ | character_id of the second character (e.g. 'char-mira-nystrom'). |
-| `project_id` | `string` |  | Limit to a specific project (e.g. 'the-lamb'). |
+| --- | --- | :---: | --- |
+| `from_character` | `string` | Yes | character_id of the first character (e.g. 'char-sebastian'). |
+| `to_character` | `string` | Yes | character_id of the second character (e.g. 'char-mira-nystrom'). |
+| `project_id` | `string` | No | Limit to a specific project (e.g. 'the-lamb'). |
 
 ---
 
@@ -416,10 +416,10 @@ Show how the relationship between two characters evolves across scenes, in order
 Generate a proposed revision for a scene. Returns a proposal_id and a diff preview. Nothing is written yet — you must call commit_edit to apply the change. This tool requires git to be available.
 
 | Parameter | Type | Required | Description |
-|-----------|------|:--------:|-------------|
-| `scene_id` | `string` | ✓ | The scene_id to revise (e.g. 'sc-011-sebastian'). |
-| `instruction` | `string` | ✓ | A brief instruction for the edit (e.g. 'Tighten the opening paragraph'). Used in the git commit message. |
-| `revised_prose` | `string` | ✓ | The complete revised prose text for the scene. |
+| --- | --- | :---: | --- |
+| `scene_id` | `string` | Yes | The scene_id to revise (e.g. 'sc-011-sebastian'). |
+| `instruction` | `string` | Yes | A brief instruction for the edit (e.g. 'Tighten the opening paragraph'). Used in the git commit message. |
+| `revised_prose` | `string` | Yes | The complete revised prose text for the scene. |
 
 ---
 
@@ -428,9 +428,9 @@ Generate a proposed revision for a scene. Returns a proposal_id and a diff previ
 Apply a proposed edit and commit it to git. First creates a pre-edit snapshot, then writes the revised prose and metadata back to disk. The scene metadata stale flag is cleared.
 
 | Parameter | Type | Required | Description |
-|-----------|------|:--------:|-------------|
-| `scene_id` | `string` | ✓ | The scene_id being revised. |
-| `proposal_id` | `string` | ✓ | The proposal_id returned by propose_edit. |
+| --- | --- | :---: | --- |
+| `scene_id` | `string` | Yes | The scene_id being revised. |
+| `proposal_id` | `string` | Yes | The proposal_id returned by propose_edit. |
 
 ---
 
@@ -439,8 +439,8 @@ Apply a proposed edit and commit it to git. First creates a pre-edit snapshot, t
 Discard a pending proposal without applying it. The proposal is deleted and the prose remains unchanged.
 
 | Parameter | Type | Required | Description |
-|-----------|------|:--------:|-------------|
-| `proposal_id` | `string` | ✓ | The proposal_id to discard (from propose_edit). |
+| --- | --- | :---: | --- |
+| `proposal_id` | `string` | Yes | The proposal_id to discard (from propose_edit). |
 
 ---
 
@@ -449,10 +449,10 @@ Discard a pending proposal without applying it. The proposal is deleted and the 
 Manually create a git commit (snapshot) for the current state of a scene. Use this to mark important editing checkpoints outside of the propose/commit workflow.
 
 | Parameter | Type | Required | Description |
-|-----------|------|:--------:|-------------|
-| `scene_id` | `string` | ✓ | The scene_id to snapshot. |
-| `project_id` | `string` | ✓ | Project the scene belongs to. |
-| `reason` | `string` | ✓ | A brief reason for the snapshot (e.g. 'Character arc milestone reached'). |
+| --- | --- | :---: | --- |
+| `scene_id` | `string` | Yes | The scene_id to snapshot. |
+| `project_id` | `string` | Yes | Project the scene belongs to. |
+| `reason` | `string` | Yes | A brief reason for the snapshot (e.g. 'Character arc milestone reached'). |
 
 ---
 
@@ -461,7 +461,7 @@ Manually create a git commit (snapshot) for the current state of a scene. Use th
 List git commit history for a scene, with timestamps and commit messages. Use this to find commit hashes for get_scene_prose historical retrieval.
 
 | Parameter | Type | Required | Description |
-|-----------|------|:--------:|-------------|
-| `scene_id` | `string` | ✓ | The scene_id to list snapshots for. |
+| --- | --- | :---: | --- |
+| `scene_id` | `string` | Yes | The scene_id to list snapshots for. |
 
 ---

--- a/importer.js
+++ b/importer.js
@@ -107,20 +107,32 @@ function loadYamlFile(filePath) {
   }
 }
 
+function walkSidecarFiles(dir, fileList = []) {
+  if (!fs.existsSync(dir)) return fileList;
+
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walkSidecarFiles(full, fileList);
+    } else if (entry.isFile() && entry.name.endsWith(".meta.yaml")) {
+      fileList.push(full);
+    }
+  }
+
+  return fileList;
+}
+
 function buildExistingSceneIndex(dir) {
   const byBinderId = new Map();
   if (!fs.existsSync(dir)) return byBinderId;
 
-  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-    if (!entry.isFile() || !entry.name.endsWith(".meta.yaml")) continue;
-
-    const sidecarPath = path.join(dir, entry.name);
+  for (const sidecarPath of walkSidecarFiles(dir)) {
     const proseCandidates = [
       sidecarPath.replace(/\.meta\.yaml$/, ".txt"),
       sidecarPath.replace(/\.meta\.yaml$/, ".md"),
     ];
     const prosePath = proseCandidates.find(candidate => fs.existsSync(candidate)) ?? null;
-    const proseName = prosePath ? path.basename(prosePath) : entry.name.replace(/\.meta\.yaml$/, ".txt");
+    const proseName = prosePath ? path.basename(prosePath) : path.basename(sidecarPath).replace(/\.meta\.yaml$/, ".txt");
     const parsedName = parseFilename(proseName);
     const meta = loadYamlFile(sidecarPath);
     const binderId = meta.external_source === "scrivener" && meta.external_id
@@ -342,7 +354,12 @@ export function importScrivenerSync({
     const title = cleanTitle(rawTitle);
     const existingScene = existingScenes.get(String(binderId)) ?? null;
     const sceneId = existingScene?.meta?.scene_id ?? makeSceneId(binderId, title);
-    const destFile = path.join(scenesDir, `${seq.toString().padStart(3, "0")} ${rawTitle} [${binderId}].${ext}`);
+    const targetDir = existingScene?.prosePath
+      ? path.dirname(existingScene.prosePath)
+      : existingScene?.sidecarPath
+        ? path.dirname(existingScene.sidecarPath)
+        : scenesDir;
+    const destFile = path.join(targetDir, `${seq.toString().padStart(3, "0")} ${rawTitle} [${binderId}].${ext}`);
     const sidecar = destFile.replace(/\.(txt|md)$/, ".meta.yaml");
 
     const meta = {
@@ -366,6 +383,7 @@ export function importScrivenerSync({
       }
       logger(`        scene_id: ${sceneId}, beat: ${beatCarry ?? "(none)"}`);
     } else {
+      fs.mkdirSync(path.dirname(destFile), { recursive: true });
       fs.copyFileSync(file, destFile);
       fs.writeFileSync(sidecar, yaml.dump(meta, { lineWidth: 120 }), "utf8");
 

--- a/importer.js
+++ b/importer.js
@@ -113,6 +113,9 @@ function walkSidecarFiles(dir, fileList = []) {
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
     const full = path.join(dir, entry.name);
     if (entry.isDirectory()) {
+      // Skip nested mirror trees under scenes/ (e.g. scenes/projects/... or scenes/universes/...)
+      // to avoid accidental reconciliation against duplicated sidecars.
+      if (/^(projects|universes)$/i.test(entry.name)) continue;
       walkSidecarFiles(full, fileList);
     } else if (entry.isFile() && entry.name.endsWith(".meta.yaml")) {
       fileList.push(full);

--- a/index.js
+++ b/index.js
@@ -904,8 +904,9 @@ function createMcpServer() {
       scenes_dir: z.string().optional().describe("Absolute path to the scenes directory containing .meta.yaml sidecars. Overrides the path derived from project_id. Use this for non-standard sync layouts."),
       dry_run: z.boolean().optional().describe("If true (default), reports planned merges without writing files."),
       auto_sync: z.boolean().optional().describe("If true (default), runs sync() after a non-dry-run merge."),
+      organize_by_chapters: z.boolean().optional().describe("If true (default false), relocate scene files into chapter-based folder hierarchies (e.g., chapter-7-harbor/). Chapter metadata is always extracted to sidecars regardless of this flag."),
     },
-    async ({ source_project_dir, project_id, scenes_dir, dry_run = true, auto_sync = true }) => {
+    async ({ source_project_dir, project_id, scenes_dir, dry_run = true, auto_sync = true, organize_by_chapters = false }) => {
       if (project_id !== undefined) {
         const projectIdCheck = validateProjectId(project_id);
         if (!projectIdCheck.ok) {
@@ -943,6 +944,7 @@ function createMcpServer() {
           projectId: project_id,
           scenesDir: normalizedScenesDir,
           dryRun: Boolean(dry_run),
+          organizeByChapters: Boolean(organize_by_chapters),
         });
       } catch (error) {
         return errorResponse(
@@ -973,6 +975,7 @@ function createMcpServer() {
           dry_run: mergeResult.dryRun,
           sidecar_files: mergeResult.sidecarFiles,
           updated: mergeResult.updated,
+          relocated: mergeResult.relocated,
           unchanged: mergeResult.unchanged,
           no_data: mergeResult.noData,
           field_add_counts: mergeResult.fieldAddCounts,
@@ -1099,8 +1102,9 @@ function createMcpServer() {
       scenes_dir: z.string().optional().describe("Absolute path to the scenes directory containing .meta.yaml sidecars. Overrides the path derived from project_id."),
       dry_run: z.boolean().optional().describe("If true (default), reports planned merges without writing files."),
       auto_sync: z.boolean().optional().describe("If true, runs sync() after a non-dry-run async merge finishes."),
+      organize_by_chapters: z.boolean().optional().describe("If true (default false), relocate scene files into chapter-based folder hierarchies. Chapter metadata is always extracted to sidecars."),
     },
-    async ({ source_project_dir, project_id, scenes_dir, dry_run = true, auto_sync = false }) => {
+    async ({ source_project_dir, project_id, scenes_dir, dry_run = true, auto_sync = false, organize_by_chapters = false }) => {
       if (project_id !== undefined) {
         const projectIdCheck = validateProjectId(project_id);
         if (!projectIdCheck.ok) {
@@ -1139,6 +1143,7 @@ function createMcpServer() {
             project_id,
             scenes_dir: normalizedScenesDir,
             dry_run: Boolean(dry_run),
+            organize_by_chapters: Boolean(organize_by_chapters),
           },
           context: {
             sync_dir: SYNC_DIR,
@@ -1426,7 +1431,7 @@ function createMcpServer() {
     },
     async ({ project_id, character, beat, tag, part, chapter, pov, page, page_size }) => {
       let query = `
-        SELECT DISTINCT s.scene_id, s.project_id, s.title, s.part, s.chapter, s.pov,
+        SELECT DISTINCT s.scene_id, s.project_id, s.title, s.part, s.chapter, s.chapter_title, s.pov,
                s.logline, s.scene_change, s.causality, s.stakes, s.scene_functions,
                s.save_the_cat_beat, s.timeline_position, s.story_time,
                s.word_count, s.metadata_stale
@@ -1584,7 +1589,7 @@ function createMcpServer() {
     },
     async ({ character_id, project_id, page, page_size }) => {
       let query = `
-        SELECT s.scene_id, s.project_id, s.part, s.chapter, s.title, s.logline,
+        SELECT s.scene_id, s.project_id, s.part, s.chapter, s.chapter_title, s.title, s.logline,
                s.scene_change, s.causality, s.stakes, s.scene_functions,
                s.save_the_cat_beat, s.timeline_position, s.story_time, s.pov, s.metadata_stale
         FROM scenes s
@@ -1862,7 +1867,7 @@ function createMcpServer() {
 
       if (!shouldPaginate) {
         const rows = db.prepare(`
-          SELECT f.scene_id, f.project_id, s.title, s.logline, s.part, s.chapter, s.metadata_stale
+          SELECT f.scene_id, f.project_id, s.title, s.logline, s.part, s.chapter, s.chapter_title, s.metadata_stale
           FROM scenes_fts f
           JOIN scenes s ON s.scene_id = f.scene_id AND s.project_id = f.project_id
           WHERE scenes_fts MATCH ?
@@ -1879,7 +1884,7 @@ function createMcpServer() {
       const offset = (normalizedPage - 1) * safePageSize;
 
       const rows = db.prepare(`
-        SELECT f.scene_id, f.project_id, s.title, s.logline, s.part, s.chapter, s.metadata_stale
+        SELECT f.scene_id, f.project_id, s.title, s.logline, s.part, s.chapter, s.chapter_title, s.metadata_stale
         FROM scenes_fts f
         JOIN scenes s ON s.scene_id = f.scene_id AND s.project_id = f.project_id
         WHERE scenes_fts MATCH ?
@@ -1945,7 +1950,7 @@ function createMcpServer() {
       }
 
       const rows = db.prepare(`
-        SELECT s.scene_id, s.project_id, s.part, s.chapter, s.title, s.logline,
+        SELECT s.scene_id, s.project_id, s.part, s.chapter, s.chapter_title, s.title, s.logline,
                st.beat AS thread_beat, s.timeline_position, s.story_time, s.metadata_stale
         FROM scenes s
         JOIN scene_threads st ON st.scene_id = s.scene_id AND st.thread_id = ?
@@ -2286,7 +2291,7 @@ function createMcpServer() {
       let query = `
         SELECT r.from_character, r.to_character, r.relationship_type, r.strength,
                r.scene_id, r.note,
-               s.part, s.chapter, s.timeline_position, s.title AS scene_title
+               s.part, s.chapter, s.chapter_title, s.timeline_position, s.title AS scene_title
         FROM character_relationships r
         LEFT JOIN scenes s ON s.scene_id = r.scene_id
         WHERE r.from_character = ? AND r.to_character = ?

--- a/index.js
+++ b/index.js
@@ -775,7 +775,7 @@ function createMcpServer() {
   // ---- import_scrivener_sync ----------------------------------------------
   s.tool(
     "import_scrivener_sync",
-    "Import Scrivener External Folder Sync Draft files into this server's WRITING_SYNC_DIR by generating scene sidecars and reconciling by Scrivener binder ID. Use this for first-time setup before sync().",
+    "[STABLE] Import Scrivener External Folder Sync Draft files into this server's WRITING_SYNC_DIR by generating scene sidecars and reconciling by Scrivener binder ID. This is the recommended default path for first-time setup before sync().",
     {
       source_dir: z.string().describe("Path to Scrivener external sync folder (the folder that contains Draft/, or Draft/ itself)."),
       project_id: z.string().optional().describe("Project ID override (e.g. 'the-lamb'). Defaults to a slug derived from WRITING_SYNC_DIR."),
@@ -897,7 +897,7 @@ function createMcpServer() {
   // ---- merge_scrivener_project_beta --------------------------------------
   s.tool(
     "merge_scrivener_project_beta",
-    "[BETA] Merge metadata directly from a Scrivener .scriv project into existing scene sidecars. This path is opt-in and may be sensitive to Scrivener internal format changes. Requires scenes sidecars to already exist (for example, from import_scrivener_sync).",
+    "[BETA] Merge metadata directly from a Scrivener .scriv project into existing scene sidecars. This path is opt-in, requires sidecars to already exist (for example, from import_scrivener_sync), and may be sensitive to Scrivener internal format changes.",
     {
       source_project_dir: z.string().describe("Path to a Scrivener .scriv bundle directory."),
       project_id: z.string().optional().describe("Project ID containing existing sidecars (e.g. 'the-lamb' or 'universe-1/book-1-the-lamb'). Defaults to a slug derived from WRITING_SYNC_DIR."),
@@ -977,6 +977,8 @@ function createMcpServer() {
           no_data: mergeResult.noData,
           field_add_counts: mergeResult.fieldAddCounts,
           preview_changes: mergeResult.previewChanges,
+          warnings: mergeResult.warnings,
+          warning_summary: mergeResult.warningSummary,
           stats: {
             sync_map_entries: mergeResult.stats.syncMapEntries,
             keyword_map_entries: mergeResult.stats.keywordMapEntries,
@@ -1009,7 +1011,7 @@ function createMcpServer() {
   // ---- async import/merge jobs --------------------------------------------
   s.tool(
     "import_scrivener_sync_async",
-    "Start an asynchronous Scrivener External Folder Sync import job. Returns immediately with a job_id to poll via get_async_job_status.",
+    "[STABLE] Start an asynchronous Scrivener External Folder Sync import job. This is the recommended default import path when the sync tree is large. Returns immediately with a job_id to poll via get_async_job_status.",
     {
       source_dir: z.string().describe("Path to Scrivener external sync folder (the folder that contains Draft/, or Draft/ itself)."),
       project_id: z.string().optional().describe("Project ID override (e.g. 'the-lamb' or 'universe-1/book-1-the-lamb')."),
@@ -1089,7 +1091,7 @@ function createMcpServer() {
 
   s.tool(
     "merge_scrivener_project_beta_async",
-    "Start an asynchronous beta Scrivener metadata merge job. Returns immediately with a job_id to poll via get_async_job_status.",
+    "[BETA] Start an asynchronous Scrivener metadata merge job from a `.scriv` project into existing scene sidecars. Use this only after the stable import path has created sidecars. Returns immediately with a job_id to poll via get_async_job_status.",
     {
       source_project_dir: z.string().describe("Path to a Scrivener .scriv bundle directory."),
       project_id: z.string().optional().describe("Project ID containing existing sidecars (e.g. 'the-lamb' or 'universe-1/book-1-the-lamb')."),

--- a/index.js
+++ b/index.js
@@ -978,6 +978,7 @@ function createMcpServer() {
           field_add_counts: mergeResult.fieldAddCounts,
           preview_changes: mergeResult.previewChanges,
           warnings: mergeResult.warnings,
+          warnings_truncated: mergeResult.warningsTruncated,
           warning_summary: mergeResult.warningSummary,
           stats: {
             sync_map_entries: mergeResult.stats.syncMapEntries,

--- a/metadata-lint.js
+++ b/metadata-lint.js
@@ -32,6 +32,7 @@ const sceneSchema = z.object({
   title: z.string().min(1).optional(),
   part: z.number().int().positive().optional(),
   chapter: z.number().int().positive().optional(),
+  chapter_title: z.string().min(1).optional(),
   pov: z.string().min(1).optional(),
   logline: z.string().min(1).optional(),
   save_the_cat_beat: z.string().min(1).optional(),

--- a/scripts/async-job-runner.mjs
+++ b/scripts/async-job-runner.mjs
@@ -61,6 +61,7 @@ function normalizeMergeResult(mergeResult) {
       dry_run: mergeResult.dryRun,
       sidecar_files: mergeResult.sidecarFiles,
       updated: mergeResult.updated,
+      relocated: mergeResult.relocated,
       unchanged: mergeResult.unchanged,
       no_data: mergeResult.noData,
       field_add_counts: mergeResult.fieldAddCounts,
@@ -121,6 +122,7 @@ async function main() {
       projectId: request.args?.project_id,
       scenesDir: request.args?.scenes_dir,
       dryRun: Boolean(request.args?.dry_run),
+      organizeByChapters: Boolean(request.args?.organize_by_chapters),
     });
     writeResult(resultPath, normalizeMergeResult(result));
     return;

--- a/scripts/async-job-runner.mjs
+++ b/scripts/async-job-runner.mjs
@@ -66,6 +66,9 @@ function normalizeMergeResult(mergeResult) {
       no_data: mergeResult.noData,
       field_add_counts: mergeResult.fieldAddCounts,
       preview_changes: mergeResult.previewChanges,
+      warnings: mergeResult.warnings,
+      warnings_truncated: mergeResult.warningsTruncated,
+      warning_summary: mergeResult.warningSummary,
       stats: {
         sync_map_entries: mergeResult.stats.syncMapEntries,
         keyword_map_entries: mergeResult.stats.keywordMapEntries,

--- a/scripts/generate-tool-docs.mjs
+++ b/scripts/generate-tool-docs.mjs
@@ -425,9 +425,9 @@ function generateMarkdown(tools) {
       lines.push('_No parameters._');
     } else {
       lines.push('| Parameter | Type | Required | Description |');
-      lines.push('|-----------|------|:--------:|-------------|');
+      lines.push('| --- | --- | :---: | --- |');
       for (const p of tool.params) {
-        const req  = p.optional ? '' : '✓';
+        const req  = p.optional ? 'No' : 'Yes';
         const desc = p.description.replace(/\|/g, '\\|'); // escape pipes
         lines.push(`| \`${p.name}\` | \`${p.type}\` | ${req} | ${desc} |`);
       }

--- a/scripts/merge-scrivx.js
+++ b/scripts/merge-scrivx.js
@@ -11,6 +11,7 @@
  * Options:
  *   --project <id>    Project ID (default: derived from mcp-sync-dir name)
  *   --dry-run         Show what would change without writing anything
+ *   --organize-by-chapters  Relocate scene files into part/chapter folders
  *
  * What it merges into scene sidecars:
  *   synopsis          - from Files/Data/<UUID>/synopsis.txt
@@ -34,13 +35,14 @@ import { mergeScrivenerProjectMetadata } from "../scrivener-direct.js";
 // ---------------------------------------------------------------------------
 const args = process.argv.slice(2);
 if (args.length < 2 || args[0] === "--help") {
-  console.log("Usage: node scripts/merge-scrivx.js <path-to.scriv> <mcp-sync-dir> [--project <id>] [--dry-run]");
+  console.log("Usage: node scripts/merge-scrivx.js <path-to.scriv> <mcp-sync-dir> [--project <id>] [--dry-run] [--organize-by-chapters]");
   process.exit(args[0] === "--help" ? 0 : 1);
 }
 
 const scrivPath  = path.resolve(args[0]);
 const mcpSyncDir = path.resolve(args[1]);
 const dryRun     = args.includes("--dry-run");
+const organizeByChapters = args.includes("--organize-by-chapters");
 const projectIdx = args.indexOf("--project");
 const projectId  = projectIdx !== -1
   ? args[projectIdx + 1]
@@ -58,6 +60,7 @@ try {
     mcpSyncDir,
     projectId,
     dryRun,
+    organizeByChapters,
     logger: line => console.log(line),
   });
 } catch (err) {

--- a/scrivener-direct.js
+++ b/scrivener-direct.js
@@ -72,7 +72,29 @@ function findProsePathForSidecar(sidecarPath) {
 function moveFileIfNeeded(fromPath, toPath) {
   if (!fromPath || fromPath === toPath) return;
   fs.mkdirSync(path.dirname(toPath), { recursive: true });
-  fs.renameSync(fromPath, toPath);
+  if (fs.existsSync(toPath)) {
+    return {
+      moved: false,
+      warning: {
+        code: "relocate_destination_exists",
+        message: "Skipped moving prose file because destination already exists.",
+        from_path: fromPath,
+        to_path: toPath,
+      },
+    };
+  }
+
+  try {
+    fs.renameSync(fromPath, toPath);
+  } catch (error) {
+    if (!error || typeof error !== "object" || error.code !== "EXDEV") {
+      throw error;
+    }
+    fs.copyFileSync(fromPath, toPath);
+    fs.unlinkSync(fromPath);
+  }
+
+  return { moved: true };
 }
 
 const KNOWN_CUSTOM_FIELD_IDS = new Set([
@@ -496,11 +518,21 @@ export function mergeScrivenerProjectMetadata({
     } else {
       fs.mkdirSync(targetDir, { recursive: true });
       fs.writeFileSync(targetSidecarPath, yaml.dump(effective, { lineWidth: 120 }), "utf8");
-      if (sidecarPath !== targetSidecarPath && fs.existsSync(sidecarPath)) {
+      if (path.resolve(sidecarPath) !== path.resolve(targetSidecarPath) && fs.existsSync(sidecarPath)) {
         fs.unlinkSync(sidecarPath);
       }
       if (prosePath && targetProsePath) {
-        moveFileIfNeeded(prosePath, targetProsePath);
+        const moveResult = moveFileIfNeeded(prosePath, targetProsePath);
+        if (moveResult?.warning) {
+          warningsTruncated = pushWarning(
+            warnings,
+            warningSummary,
+            {
+              ...moveResult.warning,
+              file: filename,
+            }
+          ) || warningsTruncated;
+        }
       }
       const changes = [];
       if (newKeys.length) changes.push(`+${newKeys.join(", ")}`);

--- a/scrivener-direct.js
+++ b/scrivener-direct.js
@@ -485,8 +485,10 @@ export function mergeScrivenerProjectMetadata({
       effective.chapter_title ?? null,
       organizeByChapters,
     );
-    const targetSidecarPath = path.join(targetDir, filename);
-    const targetProsePath = prosePath ? path.join(targetDir, path.basename(prosePath)) : null;
+    const targetSidecarPath = organizeByChapters ? path.join(targetDir, filename) : sidecarPath;
+    const targetProsePath = prosePath
+      ? (organizeByChapters ? path.join(targetDir, path.basename(prosePath)) : prosePath)
+      : null;
     const needsMove = path.resolve(sidecarPath) !== path.resolve(targetSidecarPath)
       || (prosePath && targetProsePath && path.resolve(prosePath) !== path.resolve(targetProsePath));
 
@@ -520,9 +522,28 @@ export function mergeScrivenerProjectMetadata({
       didRelocate = needsMove;
     } else {
       let proseMoveWarning = null;
-      let shouldRelocateSidecar = true;
+      let shouldRelocateSidecar = organizeByChapters;
 
-      if (prosePath && targetProsePath) {
+      if (
+        shouldRelocateSidecar
+        && path.resolve(sidecarPath) !== path.resolve(targetSidecarPath)
+        && fs.existsSync(targetSidecarPath)
+      ) {
+        shouldRelocateSidecar = false;
+        warningsTruncated = pushWarning(
+          warnings,
+          warningSummary,
+          {
+            code: "relocate_sidecar_destination_exists",
+            message: "Skipped relocating sidecar because destination already exists.",
+            from_path: sidecarPath,
+            to_path: targetSidecarPath,
+            file: filename,
+          }
+        ) || warningsTruncated;
+      }
+
+      if (shouldRelocateSidecar && prosePath && targetProsePath) {
         const moveResult = moveFileIfNeeded(prosePath, targetProsePath);
         if (moveResult?.warning) {
           proseMoveWarning = moveResult.warning;

--- a/scrivener-direct.js
+++ b/scrivener-direct.js
@@ -34,6 +34,47 @@ function isPlainObject(value) {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
+function slugifyPathSegment(value) {
+  return String(value ?? "")
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 50);
+}
+
+function chapterFolderName(chapter, chapterTitle) {
+  if (chapter === null || chapter === undefined) return null;
+  const suffix = slugifyPathSegment(chapterTitle);
+  return suffix ? `chapter-${chapter}-${suffix}` : `chapter-${chapter}`;
+}
+
+function sceneContainerDir(scenesDir, part, chapter, chapterTitle, organizeByChapters = true) {
+  const segments = [scenesDir];
+  if (!organizeByChapters) {
+    return path.join(...segments);
+  }
+  if (part !== null && part !== undefined) segments.push(`part-${part}`);
+  const chapterDir = chapterFolderName(chapter, chapterTitle);
+  if (chapterDir) segments.push(chapterDir);
+  return path.join(...segments);
+}
+
+function findProsePathForSidecar(sidecarPath) {
+  const proseCandidates = [
+    sidecarPath.replace(/\.meta\.yaml$/, ".md"),
+    sidecarPath.replace(/\.meta\.yaml$/, ".txt"),
+  ];
+  return proseCandidates.find(candidate => fs.existsSync(candidate)) ?? null;
+}
+
+function moveFileIfNeeded(fromPath, toPath) {
+  if (!fromPath || fromPath === toPath) return;
+  fs.mkdirSync(path.dirname(toPath), { recursive: true });
+  fs.renameSync(fromPath, toPath);
+}
+
 const KNOWN_CUSTOM_FIELD_IDS = new Set([
   "savethecat!",
   "causality",
@@ -77,13 +118,14 @@ function pushWarning(warnings, warningSummary, warning) {
 }
 
 function buildMergeDataFromProject(projectData, uuid) {
-  const { metaByUUID, partByUUID, chapterByUUID } = projectData;
+  const { metaByUUID, partByUUID, chapterByUUID, chapterTitleByUUID } = projectData;
   const { customFields, characters, versions, synopsis } = metaByUUID[uuid] ?? {};
   const part = partByUUID[uuid] ?? null;
   const chapter = chapterByUUID[uuid] ?? null;
+  const chapterTitle = chapterTitleByUUID[uuid] ?? null;
   const warnings = [];
 
-  if (!customFields && !characters && !versions && !synopsis && part === null && chapter === null) {
+  if (!customFields && !characters && !versions && !synopsis && part === null && chapter === null && !chapterTitle) {
     return { mergeData: null, warnings };
   }
 
@@ -91,6 +133,7 @@ function buildMergeDataFromProject(projectData, uuid) {
 
   if (part !== null) out.part = part;
   if (chapter !== null) out.chapter = chapter;
+  if (chapterTitle) out.chapter_title = chapterTitle;
   if (synopsis) out.synopsis = synopsis;
   if (characters?.length) out.characters = characters;
   if (versions?.length) out.versions = versions;
@@ -248,6 +291,7 @@ export function loadScrivenerProjectData(scrivPath) {
 
   const partByUUID = {};
   const chapterByUUID = {};
+  const chapterTitleByUUID = {};
   let partNum = 0;
   let chapterNum = 0;
 
@@ -256,21 +300,29 @@ export function loadScrivenerProjectData(scrivPath) {
       const uuid = attr(child, "UUID");
       const type = attr(child, "Type");
       const childrenEl = children(child, "Children")[0];
+      const title = text(children(child, "Title")[0]);
 
       if (type === "Folder" && currentPart === null) {
         partNum++;
-        if (childrenEl) walkHierarchy(childrenEl, partNum, null);
+        if (childrenEl) walkHierarchy(childrenEl, { number: partNum, title }, null);
       } else if (type === "Folder") {
         chapterNum++;
+        const nextChapter = { number: chapterNum, title };
         if (uuid) {
-          partByUUID[uuid] = currentPart;
+          if (currentPart?.number !== null && currentPart?.number !== undefined) {
+            partByUUID[uuid] = currentPart.number;
+          }
           chapterByUUID[uuid] = chapterNum;
+          if (title) chapterTitleByUUID[uuid] = title;
         }
-        if (childrenEl) walkHierarchy(childrenEl, currentPart, chapterNum);
+        if (childrenEl) walkHierarchy(childrenEl, currentPart, nextChapter);
       } else if (type === "Text") {
-        if (uuid && currentChapter !== null) {
-          partByUUID[uuid] = currentPart;
-          chapterByUUID[uuid] = currentChapter;
+        if (uuid && currentChapter?.number !== null && currentChapter?.number !== undefined) {
+          if (currentPart?.number !== null && currentPart?.number !== undefined) {
+            partByUUID[uuid] = currentPart.number;
+          }
+          chapterByUUID[uuid] = currentChapter.number;
+          if (currentChapter.title) chapterTitleByUUID[uuid] = currentChapter.title;
         }
       }
     }
@@ -294,6 +346,7 @@ export function loadScrivenerProjectData(scrivPath) {
     metaByUUID,
     partByUUID,
     chapterByUUID,
+    chapterTitleByUUID,
   };
 }
 
@@ -303,6 +356,7 @@ export function mergeScrivenerProjectMetadata({
   projectId,
   scenesDir: scenesDirOverride,
   dryRun = false,
+  organizeByChapters = false,
   logger = () => {},
 }) {
   const mcpSyncDirAbs = path.resolve(mcpSyncDir);
@@ -348,6 +402,7 @@ export function mergeScrivenerProjectMetadata({
   let unchanged = 0;
   let noData = 0;
   let skippedNoBracketId = 0;
+  let relocated = 0;
   const fieldAddCounts = {};
   const previewChanges = [];
   const warnings = [];
@@ -356,6 +411,7 @@ export function mergeScrivenerProjectMetadata({
 
   for (const sidecarPath of sidecarFiles) {
     const filename = path.basename(sidecarPath);
+    const prosePath = findProsePathForSidecar(sidecarPath);
     const match = filename.match(/\[(\d+)\]\.meta\.yaml$/);
     if (!match) {
       logger(`  SKIP  (no bracket ID) ${filename}`);
@@ -398,8 +454,20 @@ export function mergeScrivenerProjectMetadata({
     }
     const existing = existingRaw ?? {};
     const { merged, changed, newKeys } = mergeSidecarData(existing, mergeData);
+    const effective = changed ? merged : existing;
+    const targetDir = sceneContainerDir(
+      scenesDir,
+      effective.part ?? null,
+      effective.chapter ?? null,
+      effective.chapter_title ?? null,
+      organizeByChapters,
+    );
+    const targetSidecarPath = path.join(targetDir, filename);
+    const targetProsePath = prosePath ? path.join(targetDir, path.basename(prosePath)) : null;
+    const needsMove = path.resolve(sidecarPath) !== path.resolve(targetSidecarPath)
+      || (prosePath && targetProsePath && path.resolve(prosePath) !== path.resolve(targetProsePath));
 
-    if (!changed) {
+    if (!changed && !needsMove) {
       unchanged++;
       continue;
     }
@@ -409,7 +477,11 @@ export function mergeScrivenerProjectMetadata({
     }
 
     if (previewChanges.length < 25) {
-      previewChanges.push({ file: filename, added_keys: [...newKeys] });
+      previewChanges.push({
+        file: filename,
+        added_keys: [...newKeys],
+        ...(needsMove ? { moved_to: path.relative(scenesDir, targetSidecarPath) || filename } : {}),
+      });
     }
 
     if (dryRun) {
@@ -417,15 +489,30 @@ export function mergeScrivenerProjectMetadata({
       for (const key of newKeys) {
         logger(`        + ${key}: ${JSON.stringify(mergeData[key]).slice(0, 80)}`);
       }
+      if (needsMove) {
+        logger(`        -> ${path.relative(scenesDir, targetSidecarPath) || filename}`);
+      }
     } else {
-      fs.writeFileSync(sidecarPath, yaml.dump(merged, { lineWidth: 120 }), "utf8");
-      logger(`  OK    ${filename}  [+${newKeys.join(", ")}]`);
+      fs.mkdirSync(targetDir, { recursive: true });
+      fs.writeFileSync(targetSidecarPath, yaml.dump(effective, { lineWidth: 120 }), "utf8");
+      if (sidecarPath !== targetSidecarPath && fs.existsSync(sidecarPath)) {
+        fs.unlinkSync(sidecarPath);
+      }
+      if (prosePath && targetProsePath) {
+        moveFileIfNeeded(prosePath, targetProsePath);
+      }
+      const changes = [];
+      if (newKeys.length) changes.push(`+${newKeys.join(", ")}`);
+      if (needsMove) changes.push(`moved to ${path.relative(scenesDir, targetSidecarPath) || filename}`);
+      logger(`  OK    ${filename}${changes.length ? `  [${changes.join("; ")}]` : ""}`);
     }
+    if (needsMove) relocated++;
     updated++;
   }
 
   logger(`\n${"─".repeat(50)}`);
   logger(`Updated:   ${updated} sidecars${dryRun ? " (dry run)" : ""}`);
+  if (relocated) logger(`Relocated: ${relocated} scene file pair(s)`);
   logger(`Unchanged: ${unchanged} (already complete or no new data)`);
   if (skippedNoBracketId) logger(`Skipped:   ${skippedNoBracketId} (no bracket ID in filename)`);
   if (noData) logger(`No data:   ${noData} (no matching binder entry)`);
@@ -438,6 +525,7 @@ export function mergeScrivenerProjectMetadata({
     dryRun: Boolean(dryRun),
     sidecarFiles: sidecarFiles.length,
     updated,
+    relocated,
     unchanged,
     skippedNoBracketId,
     noData,

--- a/scrivener-direct.js
+++ b/scrivener-direct.js
@@ -23,6 +23,9 @@ function children(el, tag) {
 
 function walkYamls(dir, list = []) {
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory() && /^(projects|universes)$/i.test(entry.name)) {
+      continue;
+    }
     const full = path.join(dir, entry.name);
     if (entry.isDirectory()) walkYamls(full, list);
     else if (entry.name.endsWith(".meta.yaml")) list.push(full);
@@ -119,7 +122,7 @@ function recordWarning(summary, warning) {
 
   if (entry.examples.length < 5) {
     const example = { message: warning.message };
-    for (const key of ["file", "sync_number", "field_id", "value", "uuid"]) {
+    for (const key of ["file", "sync_number", "field_id", "value", "uuid", "from_path", "to_path", "moved_to"]) {
       if (warning[key] !== undefined && warning[key] !== null) {
         example[key] = warning[key];
       }

--- a/scrivener-direct.js
+++ b/scrivener-direct.js
@@ -119,13 +119,13 @@ function pushWarning(warnings, warningSummary, warning) {
 
 function buildMergeDataFromProject(projectData, uuid) {
   const { metaByUUID, partByUUID, chapterByUUID, chapterTitleByUUID } = projectData;
-  const { customFields, characters, versions, synopsis } = metaByUUID[uuid] ?? {};
+  const { customFields, tags, synopsis } = metaByUUID[uuid] ?? {};
   const part = partByUUID[uuid] ?? null;
   const chapter = chapterByUUID[uuid] ?? null;
   const chapterTitle = chapterTitleByUUID[uuid] ?? null;
   const warnings = [];
 
-  if (!customFields && !characters && !versions && !synopsis && part === null && chapter === null && !chapterTitle) {
+  if (!customFields && !tags && !synopsis && part === null && chapter === null && !chapterTitle) {
     return { mergeData: null, warnings };
   }
 
@@ -135,8 +135,7 @@ function buildMergeDataFromProject(projectData, uuid) {
   if (chapter !== null) out.chapter = chapter;
   if (chapterTitle) out.chapter_title = chapterTitle;
   if (synopsis) out.synopsis = synopsis;
-  if (characters?.length) out.characters = characters;
-  if (versions?.length) out.versions = versions;
+  if (tags?.length) out.tags = tags;
 
   for (const [fieldId, value] of Object.entries(customFields ?? {})) {
     if (!KNOWN_CUSTOM_FIELD_IDS.has(fieldId) && String(value ?? "").trim()) {
@@ -267,15 +266,13 @@ export function loadScrivenerProjectData(scrivPath) {
       }
     }
 
-    const characters = [];
-    const versions = [];
+    const tags = [];
     const kwEl = children(item, "Keywords")[0];
     if (kwEl) {
       for (const kwId of children(kwEl, "KeywordID")) {
         const name = keywordMap[text(kwId)];
         if (!name) continue;
-        if (/^v\d[\d.a-z]*$/i.test(name)) versions.push(name);
-        else characters.push(name);
+        tags.push(name);
       }
     }
 
@@ -286,7 +283,11 @@ export function loadScrivenerProjectData(scrivPath) {
       if (candidate) synopsis = candidate;
     }
 
-    metaByUUID[uuid] = { customFields, characters, versions, synopsis };
+    metaByUUID[uuid] = {
+      customFields,
+      tags: [...new Set(tags)],
+      synopsis,
+    };
   }
 
   const partByUUID = {};

--- a/scrivener-direct.js
+++ b/scrivener-direct.js
@@ -34,15 +34,52 @@ function isPlainObject(value) {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
+function summarizeWarnings(warnings) {
+  const summary = {};
+
+  for (const warning of warnings) {
+    if (!summary[warning.code]) {
+      summary[warning.code] = { count: 0, examples: [] };
+    }
+
+    const entry = summary[warning.code];
+    entry.count++;
+
+    if (entry.examples.length < 5) {
+      const example = { message: warning.message };
+      for (const key of ["file", "sync_number", "field_id", "value", "uuid"]) {
+        if (warning[key] !== undefined && warning[key] !== null) {
+          example[key] = warning[key];
+        }
+      }
+      entry.examples.push(example);
+    }
+  }
+
+  return summary;
+}
+
 function buildMergeDataFromProject(projectData, uuid) {
   const { metaByUUID, partByUUID, chapterByUUID } = projectData;
   const { customFields, characters, versions, synopsis } = metaByUUID[uuid] ?? {};
   const part = partByUUID[uuid] ?? null;
   const chapter = chapterByUUID[uuid] ?? null;
+  const warnings = [];
 
-  if (!customFields && !characters && !versions && !synopsis && part === null && chapter === null) return null;
+  if (!customFields && !characters && !versions && !synopsis && part === null && chapter === null) {
+    return { mergeData: null, warnings };
+  }
 
   const out = {};
+  const knownCustomFieldIds = new Set([
+    "savethecat!",
+    "causality",
+    "stakes",
+    "change",
+    "f:character",
+    "f:mood",
+    "f:theme",
+  ]);
 
   if (part !== null) out.part = part;
   if (chapter !== null) out.chapter = chapter;
@@ -50,13 +87,45 @@ function buildMergeDataFromProject(projectData, uuid) {
   if (characters?.length) out.characters = characters;
   if (versions?.length) out.versions = versions;
 
+  for (const [fieldId, value] of Object.entries(customFields ?? {})) {
+    if (!knownCustomFieldIds.has(fieldId) && String(value ?? "").trim()) {
+      warnings.push({
+        code: "ignored_custom_field",
+        message: `Ignored unsupported Scrivener custom field '${fieldId}'.`,
+        field_id: fieldId,
+        value: String(value),
+        uuid,
+      });
+    }
+  }
+
   const stcBeat = customFields?.["savethecat!"];
   if (stcBeat && typeof stcBeat === "string" && stcBeat.trim()) {
     out.save_the_cat_beat = stcBeat.trim();
   }
 
-  const causality = Number(customFields?.["causality"] ?? 0);
-  const stakes = Number(customFields?.["stakes"] ?? 0);
+  const causalityRaw = customFields?.["causality"];
+  const stakesRaw = customFields?.["stakes"];
+  const causality = Number(causalityRaw ?? 0);
+  const stakes = Number(stakesRaw ?? 0);
+  if (causalityRaw !== undefined && String(causalityRaw).trim() && Number.isNaN(causality)) {
+    warnings.push({
+      code: "invalid_custom_field_value",
+      message: "Ignored non-numeric Scrivener custom field value for 'causality'.",
+      field_id: "causality",
+      value: String(causalityRaw),
+      uuid,
+    });
+  }
+  if (stakesRaw !== undefined && String(stakesRaw).trim() && Number.isNaN(stakes)) {
+    warnings.push({
+      code: "invalid_custom_field_value",
+      message: "Ignored non-numeric Scrivener custom field value for 'stakes'.",
+      field_id: "stakes",
+      value: String(stakesRaw),
+      uuid,
+    });
+  }
   if (causality) out.causality = causality;
   if (stakes) out.stakes = stakes;
 
@@ -69,7 +138,10 @@ function buildMergeDataFromProject(projectData, uuid) {
   if (customFields?.["f:theme"] === "Yes" || customFields?.["f:theme"] === true) fnFlags.push("theme");
   if (fnFlags.length) out.scene_functions = fnFlags;
 
-  return Object.keys(out).length ? out : null;
+  return {
+    mergeData: Object.keys(out).length ? out : null,
+    warnings,
+  };
 }
 
 export function mergeSidecarData(existing, mergeData) {
@@ -270,6 +342,7 @@ export function mergeScrivenerProjectMetadata({
   let skippedNoBracketId = 0;
   const fieldAddCounts = {};
   const previewChanges = [];
+  const warnings = [];
 
   for (const sidecarPath of sidecarFiles) {
     const filename = path.basename(sidecarPath);
@@ -277,6 +350,11 @@ export function mergeScrivenerProjectMetadata({
     if (!match) {
       logger(`  SKIP  (no bracket ID) ${filename}`);
       skippedNoBracketId++;
+      warnings.push({
+        code: "missing_bracket_id",
+        message: "Skipped sidecar because filename does not include a Scrivener sync number in brackets.",
+        file: filename,
+      });
       continue;
     }
 
@@ -285,10 +363,20 @@ export function mergeScrivenerProjectMetadata({
     if (!uuid) {
       logger(`  SKIP  (no UUID for [${syncNum}]) ${filename}`);
       noData++;
+      warnings.push({
+        code: "missing_uuid_mapping",
+        message: `Skipped sidecar because Scrivener sync number [${syncNum}] has no UUID mapping in the project.`,
+        file: filename,
+        sync_number: syncNum,
+      });
       continue;
     }
 
-    const mergeData = buildMergeDataFromProject(projectData, uuid);
+    const { mergeData, warnings: mergeWarnings } = buildMergeDataFromProject(projectData, uuid);
+    for (const warning of mergeWarnings) {
+      warnings.push({ ...warning, file: filename });
+    }
+
     if (!mergeData) {
       unchanged++;
       continue;
@@ -345,6 +433,8 @@ export function mergeScrivenerProjectMetadata({
     noData,
     fieldAddCounts,
     previewChanges,
+    warnings,
+    warningSummary: summarizeWarnings(warnings),
     stats: {
       syncMapEntries: Object.keys(projectData.syncNumToUUID).length,
       keywordMapEntries: Object.keys(projectData.keywordMap).length,

--- a/scrivener-direct.js
+++ b/scrivener-direct.js
@@ -507,6 +507,8 @@ export function mergeScrivenerProjectMetadata({
       });
     }
 
+    let didRelocate = false;
+
     if (dryRun) {
       logger(`  DRY   ${filename}`);
       for (const key of newKeys) {
@@ -515,15 +517,16 @@ export function mergeScrivenerProjectMetadata({
       if (needsMove) {
         logger(`        -> ${path.relative(scenesDir, targetSidecarPath) || filename}`);
       }
+      didRelocate = needsMove;
     } else {
-      fs.mkdirSync(targetDir, { recursive: true });
-      fs.writeFileSync(targetSidecarPath, yaml.dump(effective, { lineWidth: 120 }), "utf8");
-      if (path.resolve(sidecarPath) !== path.resolve(targetSidecarPath) && fs.existsSync(sidecarPath)) {
-        fs.unlinkSync(sidecarPath);
-      }
+      let proseMoveWarning = null;
+      let shouldRelocateSidecar = true;
+
       if (prosePath && targetProsePath) {
         const moveResult = moveFileIfNeeded(prosePath, targetProsePath);
         if (moveResult?.warning) {
+          proseMoveWarning = moveResult.warning;
+          shouldRelocateSidecar = false;
           warningsTruncated = pushWarning(
             warnings,
             warningSummary,
@@ -534,12 +537,30 @@ export function mergeScrivenerProjectMetadata({
           ) || warningsTruncated;
         }
       }
+
+      const finalSidecarPath = shouldRelocateSidecar ? targetSidecarPath : sidecarPath;
+      fs.mkdirSync(path.dirname(finalSidecarPath), { recursive: true });
+      fs.writeFileSync(finalSidecarPath, yaml.dump(effective, { lineWidth: 120 }), "utf8");
+      if (
+        shouldRelocateSidecar
+        && path.resolve(sidecarPath) !== path.resolve(targetSidecarPath)
+        && fs.existsSync(sidecarPath)
+      ) {
+        fs.unlinkSync(sidecarPath);
+      }
+
       const changes = [];
       if (newKeys.length) changes.push(`+${newKeys.join(", ")}`);
-      if (needsMove) changes.push(`moved to ${path.relative(scenesDir, targetSidecarPath) || filename}`);
+      if (needsMove && shouldRelocateSidecar) {
+        changes.push(`moved to ${path.relative(scenesDir, targetSidecarPath) || filename}`);
+      }
+      if (proseMoveWarning) {
+        changes.push("sidecar kept in place (prose move skipped)");
+      }
       logger(`  OK    ${filename}${changes.length ? `  [${changes.join("; ")}]` : ""}`);
+      didRelocate = needsMove && shouldRelocateSidecar;
     }
-    if (needsMove) relocated++;
+    if (didRelocate) relocated++;
     updated++;
   }
 

--- a/scrivener-direct.js
+++ b/scrivener-direct.js
@@ -34,29 +34,46 @@ function isPlainObject(value) {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
-function summarizeWarnings(warnings) {
-  const summary = {};
+const KNOWN_CUSTOM_FIELD_IDS = new Set([
+  "savethecat!",
+  "causality",
+  "stakes",
+  "change",
+  "f:character",
+  "f:mood",
+  "f:theme",
+]);
 
-  for (const warning of warnings) {
-    if (!summary[warning.code]) {
-      summary[warning.code] = { count: 0, examples: [] };
-    }
+const MAX_RETURNED_WARNINGS = 25;
 
-    const entry = summary[warning.code];
-    entry.count++;
-
-    if (entry.examples.length < 5) {
-      const example = { message: warning.message };
-      for (const key of ["file", "sync_number", "field_id", "value", "uuid"]) {
-        if (warning[key] !== undefined && warning[key] !== null) {
-          example[key] = warning[key];
-        }
-      }
-      entry.examples.push(example);
-    }
+function recordWarning(summary, warning) {
+  if (!summary[warning.code]) {
+    summary[warning.code] = { count: 0, examples: [] };
   }
 
-  return summary;
+  const entry = summary[warning.code];
+  entry.count++;
+
+  if (entry.examples.length < 5) {
+    const example = { message: warning.message };
+    for (const key of ["file", "sync_number", "field_id", "value", "uuid"]) {
+      if (warning[key] !== undefined && warning[key] !== null) {
+        example[key] = warning[key];
+      }
+    }
+    entry.examples.push(example);
+  }
+}
+
+function pushWarning(warnings, warningSummary, warning) {
+  recordWarning(warningSummary, warning);
+
+  if (warnings.length < MAX_RETURNED_WARNINGS) {
+    warnings.push(warning);
+    return false;
+  }
+
+  return true;
 }
 
 function buildMergeDataFromProject(projectData, uuid) {
@@ -71,15 +88,6 @@ function buildMergeDataFromProject(projectData, uuid) {
   }
 
   const out = {};
-  const knownCustomFieldIds = new Set([
-    "savethecat!",
-    "causality",
-    "stakes",
-    "change",
-    "f:character",
-    "f:mood",
-    "f:theme",
-  ]);
 
   if (part !== null) out.part = part;
   if (chapter !== null) out.chapter = chapter;
@@ -88,7 +96,7 @@ function buildMergeDataFromProject(projectData, uuid) {
   if (versions?.length) out.versions = versions;
 
   for (const [fieldId, value] of Object.entries(customFields ?? {})) {
-    if (!knownCustomFieldIds.has(fieldId) && String(value ?? "").trim()) {
+    if (!KNOWN_CUSTOM_FIELD_IDS.has(fieldId) && String(value ?? "").trim()) {
       warnings.push({
         code: "ignored_custom_field",
         message: `Ignored unsupported Scrivener custom field '${fieldId}'.`,
@@ -343,6 +351,8 @@ export function mergeScrivenerProjectMetadata({
   const fieldAddCounts = {};
   const previewChanges = [];
   const warnings = [];
+  const warningSummary = {};
+  let warningsTruncated = false;
 
   for (const sidecarPath of sidecarFiles) {
     const filename = path.basename(sidecarPath);
@@ -350,11 +360,11 @@ export function mergeScrivenerProjectMetadata({
     if (!match) {
       logger(`  SKIP  (no bracket ID) ${filename}`);
       skippedNoBracketId++;
-      warnings.push({
+      warningsTruncated = pushWarning(warnings, warningSummary, {
         code: "missing_bracket_id",
         message: "Skipped sidecar because filename does not include a Scrivener sync number in brackets.",
         file: filename,
-      });
+      }) || warningsTruncated;
       continue;
     }
 
@@ -363,18 +373,18 @@ export function mergeScrivenerProjectMetadata({
     if (!uuid) {
       logger(`  SKIP  (no UUID for [${syncNum}]) ${filename}`);
       noData++;
-      warnings.push({
+      warningsTruncated = pushWarning(warnings, warningSummary, {
         code: "missing_uuid_mapping",
         message: `Skipped sidecar because Scrivener sync number [${syncNum}] has no UUID mapping in the project.`,
         file: filename,
         sync_number: syncNum,
-      });
+      }) || warningsTruncated;
       continue;
     }
 
     const { mergeData, warnings: mergeWarnings } = buildMergeDataFromProject(projectData, uuid);
     for (const warning of mergeWarnings) {
-      warnings.push({ ...warning, file: filename });
+      warningsTruncated = pushWarning(warnings, warningSummary, { ...warning, file: filename }) || warningsTruncated;
     }
 
     if (!mergeData) {
@@ -434,7 +444,8 @@ export function mergeScrivenerProjectMetadata({
     fieldAddCounts,
     previewChanges,
     warnings,
-    warningSummary: summarizeWarnings(warnings),
+    warningsTruncated,
+    warningSummary,
     stats: {
       syncMapEntries: Object.keys(projectData.syncNumToUUID).length,
       keywordMapEntries: Object.keys(projectData.keywordMap).length,

--- a/sync.js
+++ b/sync.js
@@ -107,8 +107,8 @@ const UNIVERSE_PROJECT_ROOT_CACHE = new Map();
 function isProjectStructuralDir(name) {
   const normalized = String(name ?? "").toLowerCase();
   return PROJECT_STRUCTURAL_DIRS.has(normalized)
-    || /^part-\d+$/.test(normalized)
-    || /^chapter-\d+$/.test(normalized);
+    || /^part-\d+(?:-.+)?$/.test(normalized)
+    || /^chapter-\d+(?:-.+)?$/.test(normalized);
 }
 
 function isBookSlug(name) {

--- a/sync.js
+++ b/sync.js
@@ -69,10 +69,10 @@ export function inferScenePositionFromPath(syncDir, filePath) {
   let chapter = null;
 
   for (const segment of parts) {
-    const partMatch = segment.match(/^part-(\d+)$/i);
+    const partMatch = segment.match(/^part-(\d+)(?:-.+)?$/i);
     if (partMatch) part = parseInt(partMatch[1], 10);
 
-    const chapterMatch = segment.match(/^chapter-(\d+)$/i);
+    const chapterMatch = segment.match(/^chapter-(\d+)(?:-.+)?$/i);
     if (chapterMatch) chapter = parseInt(chapterMatch[1], 10);
   }
 
@@ -480,15 +480,16 @@ export function indexSceneFile(db, syncDir, file, meta, prose) {
 
   db.prepare(`
     INSERT INTO scenes (
-      scene_id, project_id, title, part, chapter, pov, logline, scene_change,
+      scene_id, project_id, title, part, chapter, chapter_title, pov, logline, scene_change,
       causality, stakes, scene_functions,
       save_the_cat_beat, timeline_position, story_time, word_count,
       file_path, prose_checksum, metadata_stale, updated_at
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     ON CONFLICT (scene_id, project_id) DO UPDATE SET
       title = excluded.title,
       part = excluded.part,
       chapter = excluded.chapter,
+      chapter_title = excluded.chapter_title,
       pov = excluded.pov,
       logline = excluded.logline,
       scene_change = excluded.scene_change,
@@ -505,7 +506,7 @@ export function indexSceneFile(db, syncDir, file, meta, prose) {
       updated_at = excluded.updated_at
   `).run(
     meta.scene_id, project_id,
-    meta.title ?? null, meta.part ?? null, meta.chapter ?? null,
+    meta.title ?? null, meta.part ?? null, meta.chapter ?? null, meta.chapter_title ?? null,
     meta.pov ?? null, meta.logline ?? meta.synopsis ?? null,
     meta.scene_change ?? meta.change ?? null,
     meta.causality ?? null, meta.stakes ?? null,

--- a/test/integration.test.mjs
+++ b/test/integration.test.mjs
@@ -421,8 +421,10 @@ function createScrivenerProjectBundleFixture(baseDir) {
     <BinderItem Type="DraftFolder" UUID="draft-root">
       <Children>
         <BinderItem Type="Folder" UUID="part-1">
+          <Title>Part One</Title>
           <Children>
             <BinderItem Type="Folder" UUID="chapter-1">
+              <Title>Arrival</Title>
               <Children>
                 <BinderItem Type="Text" UUID="UUID-10">
                   <Keywords>
@@ -791,6 +793,88 @@ describe("merge_scrivener_project_beta tool", () => {
     assert.equal(secondParsed.merge.unchanged, secondParsed.merge.sidecar_files);
     assert.deepEqual(secondParsed.merge.field_add_counts, {});
     assert.deepEqual(secondParsed.merge.preview_changes, []);
+  });
+
+  test("non-dry-run beta merge relocates scenes into chapter folders and indexes chapter_title", async () => {
+    const projectId = "direct-beta-relocate";
+
+    await callWriteTool("import_scrivener_sync", {
+      source_dir: scrivenerImportDir,
+      project_id: projectId,
+      dry_run: false,
+      auto_sync: false,
+    });
+
+    const mergeText = await callWriteTool("merge_scrivener_project_beta", {
+      source_project_dir: scrivenerProjectDir,
+      project_id: projectId,
+      dry_run: false,
+      auto_sync: true,
+      organize_by_chapters: true,
+    });
+    const mergeParsed = JSON.parse(mergeText);
+
+    assert.equal(mergeParsed.ok, true);
+    assert.ok(mergeParsed.merge.relocated >= 2);
+
+    const relocatedScenePath = path.join(
+      writeSyncDir,
+      "projects",
+      projectId,
+      "scenes",
+      "part-1",
+      "chapter-1-arrival",
+      "001 Scene Arrival [10].txt"
+    );
+    const relocatedMetaPath = relocatedScenePath.replace(/\.txt$/, ".meta.yaml");
+    assert.equal(fs.existsSync(relocatedScenePath), true);
+    assert.equal(fs.existsSync(relocatedMetaPath), true);
+
+    const scenesText = await callWriteTool("find_scenes", { project_id: projectId });
+    const scenes = JSON.parse(scenesText);
+    assert.equal(Array.isArray(scenes), true);
+    assert.equal(scenes[0].chapter, 1);
+    assert.equal(scenes[0].chapter_title, "Arrival");
+  });
+
+  test("merge_scrivener_project_beta with organize_by_chapters: false keeps scenes in place", async () => {
+    const projectId = "direct-beta-no-organize";
+
+    await callWriteTool("import_scrivener_sync", {
+      source_dir: scrivenerImportDir,
+      project_id: projectId,
+      dry_run: false,
+      auto_sync: false,
+    });
+
+    const mergeText = await callWriteTool("merge_scrivener_project_beta", {
+      source_project_dir: scrivenerProjectDir,
+      project_id: projectId,
+      dry_run: false,
+      auto_sync: true,
+      organize_by_chapters: false,
+    });
+    const mergeParsed = JSON.parse(mergeText);
+
+    assert.equal(mergeParsed.ok, true);
+    assert.equal(mergeParsed.merge.relocated, 0, "No scenes should be relocated when organize_by_chapters is false");
+
+    const originalScenePath = path.join(
+      writeSyncDir,
+      "projects",
+      projectId,
+      "scenes",
+      "001 Scene Arrival [10].txt"
+    );
+    const originalMetaPath = originalScenePath.replace(/\.txt$/, ".meta.yaml");
+    assert.equal(fs.existsSync(originalScenePath), true, "Scene should remain in original scenes directory");
+    assert.equal(fs.existsSync(originalMetaPath), true, "Sidecar should remain in original scenes directory");
+
+    const scenesText = await callWriteTool("find_scenes", { project_id: projectId });
+    const scenes = JSON.parse(scenesText);
+    assert.equal(Array.isArray(scenes), true);
+    assert.equal(scenes[0].chapter, 1, "Chapter metadata should still be added");
+    assert.equal(scenes[0].chapter_title, "Arrival", "Chapter title should still be added");
   });
 });
 

--- a/test/integration.test.mjs
+++ b/test/integration.test.mjs
@@ -720,6 +720,78 @@ describe("merge_scrivener_project_beta tool", () => {
     assert.equal(parsed.merge.scenes_dir, actualScenesDir);
     assert.equal(parsed.merge.sidecar_files, 2);
   });
+
+  test("returns structured warning summary for skipped beta merge sidecars", async () => {
+    const projectId = "direct-beta-warnings";
+
+    await callWriteTool("import_scrivener_sync", {
+      source_dir: scrivenerImportDir,
+      project_id: projectId,
+      dry_run: false,
+      auto_sync: false,
+    });
+
+    const scenesDir = path.join(writeSyncDir, "projects", projectId, "scenes");
+    fs.writeFileSync(
+      path.join(scenesDir, "Loose Notes.meta.yaml"),
+      "scene_id: sc-loose\n",
+      "utf8"
+    );
+    fs.writeFileSync(
+      path.join(scenesDir, "999 Missing Mapping [999].meta.yaml"),
+      "scene_id: sc-999\n",
+      "utf8"
+    );
+
+    const text = await callWriteTool("merge_scrivener_project_beta", {
+      source_project_dir: scrivenerProjectDir,
+      project_id: projectId,
+      dry_run: true,
+      auto_sync: false,
+    });
+    const parsed = JSON.parse(text);
+
+    assert.equal(parsed.ok, true);
+    assert.equal(parsed.merge.warning_summary.missing_bracket_id.count, 1);
+    assert.equal(parsed.merge.warning_summary.missing_uuid_mapping.count, 1);
+    assert.ok(parsed.merge.warnings.some(w => w.code === "missing_bracket_id"));
+    assert.ok(parsed.merge.warnings.some(w => w.code === "missing_uuid_mapping" && w.sync_number === "999"));
+  });
+
+  test("second beta merge run is idempotent after fields have been written", async () => {
+    const projectId = "direct-beta-idempotent";
+
+    await callWriteTool("import_scrivener_sync", {
+      source_dir: scrivenerImportDir,
+      project_id: projectId,
+      dry_run: false,
+      auto_sync: false,
+    });
+
+    const firstText = await callWriteTool("merge_scrivener_project_beta", {
+      source_project_dir: scrivenerProjectDir,
+      project_id: projectId,
+      dry_run: false,
+      auto_sync: false,
+    });
+    const firstParsed = JSON.parse(firstText);
+    assert.equal(firstParsed.ok, true);
+    assert.equal(firstParsed.merge.updated, 2);
+
+    const secondText = await callWriteTool("merge_scrivener_project_beta", {
+      source_project_dir: scrivenerProjectDir,
+      project_id: projectId,
+      dry_run: true,
+      auto_sync: false,
+    });
+    const secondParsed = JSON.parse(secondText);
+
+    assert.equal(secondParsed.ok, true);
+    assert.equal(secondParsed.merge.updated, 0);
+    assert.equal(secondParsed.merge.unchanged, secondParsed.merge.sidecar_files);
+    assert.deepEqual(secondParsed.merge.field_add_counts, {});
+    assert.deepEqual(secondParsed.merge.preview_changes, []);
+  });
 });
 
 describe("async import/merge job tools", () => {

--- a/test/unit.test.mjs
+++ b/test/unit.test.mjs
@@ -271,6 +271,11 @@ describe("inferScenePositionFromPath", () => {
     assert.deepEqual(result, { part: 2, chapter: 7 });
   });
 
+  test("extracts chapter numbers from named chapter directories", () => {
+    const result = inferScenePositionFromPath(syncDir, "/sync/projects/novel/scenes/part-2/chapter-7-the-harbor/scene.md");
+    assert.deepEqual(result, { part: 2, chapter: 7 });
+  });
+
   test("returns nulls when the path has no part/chapter segments", () => {
     const result = inferScenePositionFromPath(syncDir, "/sync/projects/novel/scenes/scene.md");
     assert.deepEqual(result, { part: null, chapter: null });
@@ -1214,6 +1219,7 @@ describe("Scrivener direct metadata merge", () => {
       extraMetaDataItems = "",
       synopsisText = "Elena returns to the harbor.",
       includeSynopsis = true,
+      chapterTitle = "Arrival",
     } = options;
     const scrivDir = fs.mkdtempSync(path.join(os.tmpdir(), "scrivener-project-"));
     const scrivxPath = path.join(scrivDir, "Novel.scrivx");
@@ -1231,8 +1237,10 @@ describe("Scrivener direct metadata merge", () => {
     <BinderItem Type="DraftFolder" UUID="draft-root">
       <Children>
         <BinderItem Type="Folder" UUID="part-1">
+          <Title>Part One</Title>
           <Children>
             <BinderItem Type="Folder" UUID="chapter-1">
+              <Title>${chapterTitle}</Title>
               <Children>
                 <BinderItem Type="Text" UUID="UUID-1">
                   <Keywords>
@@ -1311,8 +1319,75 @@ describe("Scrivener direct metadata merge", () => {
       assert.deepEqual(data.metaByUUID["UUID-1"].versions, ["v1.2"]);
       assert.equal(data.chapterByUUID["UUID-1"], 1);
       assert.equal(data.partByUUID["UUID-1"], 1);
+      assert.equal(data.chapterTitleByUUID["UUID-1"], "Arrival");
     } finally {
       fs.rmSync(scrivDir, { recursive: true, force: true });
+    }
+  });
+
+  test("mergeScrivenerProjectMetadata relocates scene files into named chapter folders", () => {
+    const scrivDir = createScrivenerProjectFixture({ chapterTitle: "Harbor Arrival" });
+    const { syncRoot, scenesDir } = createSyncSidecarFixture();
+    const prosePath = path.join(scenesDir, "001 Scene Arrival [1].txt");
+    fs.writeFileSync(prosePath, "Scene prose.\n", "utf8");
+
+    try {
+      const result = mergeScrivenerProjectMetadata({
+        scrivPath: scrivDir,
+        mcpSyncDir: syncRoot,
+        projectId: "test-import",
+        dryRun: false,
+        organizeByChapters: true,
+      });
+
+      const targetDir = path.join(scenesDir, "part-1", "chapter-1-harbor-arrival");
+      const relocatedSidecar = path.join(targetDir, "001 Scene Arrival [1].meta.yaml");
+      const relocatedProse = path.join(targetDir, "001 Scene Arrival [1].txt");
+      const sidecar = yaml.load(fs.readFileSync(relocatedSidecar, "utf8"));
+
+      assert.equal(result.updated, 1);
+      assert.equal(result.relocated, 1);
+      assert.equal(fs.existsSync(relocatedSidecar), true);
+      assert.equal(fs.existsSync(relocatedProse), true);
+      assert.equal(fs.existsSync(path.join(scenesDir, "001 Scene Arrival [1].meta.yaml")), false);
+      assert.equal(fs.existsSync(prosePath), false);
+      assert.equal(sidecar.chapter, 1);
+      assert.equal(sidecar.chapter_title, "Harbor Arrival");
+    } finally {
+      fs.rmSync(scrivDir, { recursive: true, force: true });
+      fs.rmSync(syncRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("mergeScrivenerProjectMetadata with organize_by_chapters: false keeps scenes in place and only updates sidecar metadata", () => {
+    const scrivDir = createScrivenerProjectFixture({ chapterTitle: "Harbor Arrival" });
+    const { syncRoot, scenesDir } = createSyncSidecarFixture();
+    const prosePath = path.join(scenesDir, "001 Scene Arrival [1].txt");
+    fs.writeFileSync(prosePath, "Scene prose.\n", "utf8");
+
+    try {
+      const result = mergeScrivenerProjectMetadata({
+        scrivPath: scrivDir,
+        mcpSyncDir: syncRoot,
+        projectId: "test-import",
+        dryRun: false,
+        organizeByChapters: false,
+      });
+
+      const sidecarPath = path.join(scenesDir, "001 Scene Arrival [1].meta.yaml");
+      const relocatedSidecar = path.join(scenesDir, "part-1", "chapter-1-harbor-arrival", "001 Scene Arrival [1].meta.yaml");
+      const sidecar = yaml.load(fs.readFileSync(sidecarPath, "utf8"));
+
+      assert.equal(result.updated, 1);
+      assert.equal(result.relocated, 0, "No files should be relocated when organize_by_chapters is false");
+      assert.equal(fs.existsSync(sidecarPath), true, "Sidecar should remain in original location");
+      assert.equal(fs.existsSync(prosePath), true, "Prose should remain in original location");
+      assert.equal(fs.existsSync(relocatedSidecar), false, "No relocated sidecar should exist");
+      assert.equal(sidecar.chapter, 1, "Chapter metadata should still be added to sidecar");
+      assert.equal(sidecar.chapter_title, "Harbor Arrival", "Chapter title should still be added to sidecar");
+    } finally {
+      fs.rmSync(scrivDir, { recursive: true, force: true });
+      fs.rmSync(syncRoot, { recursive: true, force: true });
     }
   });
 
@@ -1431,19 +1506,20 @@ describe("Scrivener direct metadata merge", () => {
     try {
       const result = spawnSync(
         process.execPath,
-        [path.join(process.cwd(), "scripts", "merge-scrivx.js"), scrivDir, syncRoot, "--project", "test-import"],
+        [path.join(process.cwd(), "scripts", "merge-scrivx.js"), scrivDir, syncRoot, "--project", "test-import", "--organize-by-chapters"],
         { encoding: "utf8" }
       );
 
       assert.equal(result.status, 0, result.stderr || result.stdout);
       const sidecar = yaml.load(
-        fs.readFileSync(path.join(scenesDir, "001 Scene Arrival [1].meta.yaml"), "utf8")
+        fs.readFileSync(path.join(scenesDir, "part-1", "chapter-1-arrival", "001 Scene Arrival [1].meta.yaml"), "utf8")
       );
 
       assert.equal(sidecar.scene_id, "sc-001-arrival");
       assert.equal(sidecar.logline, "Preserve this existing value.");
       assert.equal(sidecar.part, 1);
       assert.equal(sidecar.chapter, 1);
+      assert.equal(sidecar.chapter_title, "Arrival");
       assert.equal(sidecar.synopsis, "Elena returns to the harbor.");
       assert.deepEqual(sidecar.characters, ["Elena Voss"]);
       assert.deepEqual(sidecar.versions, ["v1.2"]);

--- a/test/unit.test.mjs
+++ b/test/unit.test.mjs
@@ -1209,7 +1209,12 @@ describe("Scrivener importer", () => {
 // scripts/merge-scrivx.js and scrivener-direct.js
 // ---------------------------------------------------------------------------
 describe("Scrivener direct metadata merge", () => {
-  function createScrivenerProjectFixture() {
+  function createScrivenerProjectFixture(options = {}) {
+    const {
+      extraMetaDataItems = "",
+      synopsisText = "Elena returns to the harbor.",
+      includeSynopsis = true,
+    } = options;
     const scrivDir = fs.mkdtempSync(path.join(os.tmpdir(), "scrivener-project-"));
     const scrivxPath = path.join(scrivDir, "Novel.scrivx");
 
@@ -1241,6 +1246,7 @@ describe("Scrivener direct metadata merge", () => {
                     <MetaDataItem><FieldID>change</FieldID><Value>Escalates conflict</Value></MetaDataItem>
                     <MetaDataItem><FieldID>f:character</FieldID><Value>Yes</Value></MetaDataItem>
                     <MetaDataItem><FieldID>f:mood</FieldID><Value>Yes</Value></MetaDataItem>
+                    ${extraMetaDataItems}
                   </MetaData>
                 </BinderItem>
               </Children>
@@ -1254,16 +1260,18 @@ describe("Scrivener direct metadata merge", () => {
 
     fs.writeFileSync(scrivxPath, xml, "utf8");
     fs.mkdirSync(path.join(scrivDir, "Files", "Data", "UUID-1"), { recursive: true });
-    fs.writeFileSync(
-      path.join(scrivDir, "Files", "Data", "UUID-1", "synopsis.txt"),
-      "Elena returns to the harbor.",
-      "utf8"
-    );
+    if (includeSynopsis) {
+      fs.writeFileSync(
+        path.join(scrivDir, "Files", "Data", "UUID-1", "synopsis.txt"),
+        synopsisText,
+        "utf8"
+      );
+    }
 
     return scrivDir;
   }
 
-  function createSyncSidecarFixture(projectId = "test-import") {
+  function createSyncSidecarFixture(projectId = "test-import", extraSidecars = []) {
     const syncRoot = fs.mkdtempSync(path.join(os.tmpdir(), "scriv-merge-sync-"));
     const scenesDir = path.join(syncRoot, "projects", projectId, "scenes");
     fs.mkdirSync(scenesDir, { recursive: true });
@@ -1272,6 +1280,10 @@ describe("Scrivener direct metadata merge", () => {
       yaml.dump({ scene_id: "sc-001-arrival", logline: "Preserve this existing value." }),
       "utf8"
     );
+
+    for (const extraSidecar of extraSidecars) {
+      fs.writeFileSync(path.join(scenesDir, extraSidecar.name), yaml.dump(extraSidecar.data), "utf8");
+    }
 
     return { syncRoot, scenesDir };
   }
@@ -1326,6 +1338,40 @@ describe("Scrivener direct metadata merge", () => {
       assert.equal(sidecar.chapter, undefined);
       assert.equal(sidecar.synopsis, undefined);
       assert.equal(sidecar.logline, "Preserve this existing value.");
+    } finally {
+      fs.rmSync(scrivDir, { recursive: true, force: true });
+      fs.rmSync(syncRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("mergeScrivenerProjectMetadata returns structured warnings for skipped and normalized inputs", () => {
+    const scrivDir = createScrivenerProjectFixture({
+      extraMetaDataItems: [
+        "<MetaDataItem><FieldID>mood-color</FieldID><Value>Blue</Value></MetaDataItem>",
+        "<MetaDataItem><FieldID>stakes</FieldID><Value>high</Value></MetaDataItem>",
+      ].join(""),
+      includeSynopsis: false,
+    });
+    const { syncRoot } = createSyncSidecarFixture("test-import", [
+      { name: "002 Missing Mapping [99].meta.yaml", data: { scene_id: "sc-099" } },
+      { name: "Loose Scene.meta.yaml", data: { scene_id: "sc-loose" } },
+    ]);
+
+    try {
+      const result = mergeScrivenerProjectMetadata({
+        scrivPath: scrivDir,
+        mcpSyncDir: syncRoot,
+        projectId: "test-import",
+        dryRun: true,
+      });
+
+      assert.equal(result.warningSummary.missing_uuid_mapping.count, 1);
+      assert.equal(result.warningSummary.missing_bracket_id.count, 1);
+      assert.equal(result.warningSummary.ignored_custom_field.count, 1);
+      assert.equal(result.warningSummary.invalid_custom_field_value.count, 1);
+      assert.ok(result.warnings.some(w => w.code === "ignored_custom_field" && w.field_id === "mood-color"));
+      assert.ok(result.warnings.some(w => w.code === "invalid_custom_field_value" && w.field_id === "stakes"));
+      assert.ok(!("missing_synopsis" in result.warningSummary));
     } finally {
       fs.rmSync(scrivDir, { recursive: true, force: true });
       fs.rmSync(syncRoot, { recursive: true, force: true });

--- a/test/unit.test.mjs
+++ b/test/unit.test.mjs
@@ -365,6 +365,20 @@ describe("inferProjectAndUniverse", () => {
       fs.rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  test("projects/ two-segment layout supports named part/chapter structural dirs", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "infer-structural-named-"));
+    try {
+      fs.mkdirSync(path.join(dir, "universes", "universe-1", "book-1", "chapter-1-arrival"), { recursive: true });
+      const result = inferProjectAndUniverse(
+        dir,
+        path.join(dir, "projects", "universe-1", "book-1", "chapter-1-arrival", "sc-001.txt")
+      );
+      assert.deepEqual(result, { universe_id: "universe-1", project_id: "universe-1/book-1" });
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -1458,6 +1472,9 @@ describe("Scrivener direct metadata merge", () => {
       assert.equal(fs.existsSync(originalSidecarPath), true, "Original sidecar should be kept in place");
       assert.equal(fs.existsSync(prosePath), true, "Original prose should be kept in place");
       assert.equal(result.warningSummary.relocate_sidecar_destination_exists.count, 1);
+      const relocateExample = result.warningSummary.relocate_sidecar_destination_exists.examples[0];
+      assert.equal(relocateExample.from_path, originalSidecarPath);
+      assert.equal(relocateExample.to_path, targetSidecarPath);
       assert.equal(originalSidecar.chapter, 1);
       assert.equal(originalSidecar.chapter_title, "Harbor Arrival");
       assert.equal(targetSidecar.scene_id, "sc-existing-target", "Existing destination sidecar must not be overwritten");
@@ -1549,6 +1566,33 @@ describe("Scrivener direct metadata merge", () => {
       assert.equal(result.warnings.length, 25);
       assert.equal(result.warningsTruncated, true);
       assert.ok(result.warnings.every(w => w.code === "missing_uuid_mapping"));
+    } finally {
+      fs.rmSync(scrivDir, { recursive: true, force: true });
+      fs.rmSync(syncRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("mergeScrivenerProjectMetadata skips nested projects/universes mirror directories", () => {
+    const scrivDir = createScrivenerProjectFixture();
+    const { syncRoot, scenesDir } = createSyncSidecarFixture();
+    const mirrorProjectsDir = path.join(scenesDir, "projects", "mirror", "scenes");
+    const mirrorUniversesDir = path.join(scenesDir, "universes", "mirror", "book", "scenes");
+    fs.mkdirSync(mirrorProjectsDir, { recursive: true });
+    fs.mkdirSync(mirrorUniversesDir, { recursive: true });
+    fs.writeFileSync(path.join(mirrorProjectsDir, "Loose Mirror.meta.yaml"), "scene_id: sc-mirror-1\n", "utf8");
+    fs.writeFileSync(path.join(mirrorUniversesDir, "999 Mirror Missing [999].meta.yaml"), "scene_id: sc-mirror-2\n", "utf8");
+
+    try {
+      const result = mergeScrivenerProjectMetadata({
+        scrivPath: scrivDir,
+        mcpSyncDir: syncRoot,
+        projectId: "test-import",
+        dryRun: true,
+      });
+
+      assert.equal(result.updated, 1);
+      assert.ok(!("missing_bracket_id" in result.warningSummary));
+      assert.ok(!("missing_uuid_mapping" in result.warningSummary));
     } finally {
       fs.rmSync(scrivDir, { recursive: true, force: true });
       fs.rmSync(syncRoot, { recursive: true, force: true });

--- a/test/unit.test.mjs
+++ b/test/unit.test.mjs
@@ -1378,6 +1378,32 @@ describe("Scrivener direct metadata merge", () => {
     }
   });
 
+  test("mergeScrivenerProjectMetadata caps returned warnings but keeps full summary counts", () => {
+    const scrivDir = createScrivenerProjectFixture();
+    const extraSidecars = Array.from({ length: 30 }, (_, index) => ({
+      name: `${String(index + 2).padStart(3, "0")} Missing Mapping [${index + 100}].meta.yaml`,
+      data: { scene_id: `sc-${index + 100}` },
+    }));
+    const { syncRoot } = createSyncSidecarFixture("test-import", extraSidecars);
+
+    try {
+      const result = mergeScrivenerProjectMetadata({
+        scrivPath: scrivDir,
+        mcpSyncDir: syncRoot,
+        projectId: "test-import",
+        dryRun: true,
+      });
+
+      assert.equal(result.warningSummary.missing_uuid_mapping.count, 30);
+      assert.equal(result.warnings.length, 25);
+      assert.equal(result.warningsTruncated, true);
+      assert.ok(result.warnings.every(w => w.code === "missing_uuid_mapping"));
+    } finally {
+      fs.rmSync(scrivDir, { recursive: true, force: true });
+      fs.rmSync(syncRoot, { recursive: true, force: true });
+    }
+  });
+
   test("mergeScrivenerProjectMetadata rejects invalid project_id shape", () => {
     const scrivDir = createScrivenerProjectFixture();
     const { syncRoot } = createSyncSidecarFixture();

--- a/test/unit.test.mjs
+++ b/test/unit.test.mjs
@@ -1315,8 +1315,7 @@ describe("Scrivener direct metadata merge", () => {
       assert.equal(data.syncNumToUUID["1"], "UUID-1");
       assert.equal(data.keywordMap["kw-character"], "Elena Voss");
       assert.equal(data.metaByUUID["UUID-1"].synopsis, "Elena returns to the harbor.");
-      assert.deepEqual(data.metaByUUID["UUID-1"].characters, ["Elena Voss"]);
-      assert.deepEqual(data.metaByUUID["UUID-1"].versions, ["v1.2"]);
+      assert.deepEqual(data.metaByUUID["UUID-1"].tags, ["Elena Voss", "v1.2"]);
       assert.equal(data.chapterByUUID["UUID-1"], 1);
       assert.equal(data.partByUUID["UUID-1"], 1);
       assert.equal(data.chapterTitleByUUID["UUID-1"], "Arrival");
@@ -1353,6 +1352,7 @@ describe("Scrivener direct metadata merge", () => {
       assert.equal(fs.existsSync(prosePath), false);
       assert.equal(sidecar.chapter, 1);
       assert.equal(sidecar.chapter_title, "Harbor Arrival");
+      assert.deepEqual(sidecar.tags, ["Elena Voss", "v1.2"]);
     } finally {
       fs.rmSync(scrivDir, { recursive: true, force: true });
       fs.rmSync(syncRoot, { recursive: true, force: true });
@@ -1521,8 +1521,7 @@ describe("Scrivener direct metadata merge", () => {
       assert.equal(sidecar.chapter, 1);
       assert.equal(sidecar.chapter_title, "Arrival");
       assert.equal(sidecar.synopsis, "Elena returns to the harbor.");
-      assert.deepEqual(sidecar.characters, ["Elena Voss"]);
-      assert.deepEqual(sidecar.versions, ["v1.2"]);
+      assert.deepEqual(sidecar.tags, ["Elena Voss", "v1.2"]);
       assert.equal(sidecar.save_the_cat_beat, "Setup");
       assert.equal(sidecar.causality, 2);
       assert.equal(sidecar.stakes, 3);

--- a/test/unit.test.mjs
+++ b/test/unit.test.mjs
@@ -1391,6 +1391,82 @@ describe("Scrivener direct metadata merge", () => {
     }
   });
 
+  test("mergeScrivenerProjectMetadata with organize_by_chapters: false does not flatten nested scene paths", () => {
+    const scrivDir = createScrivenerProjectFixture({ chapterTitle: "Harbor Arrival" });
+    const { syncRoot, scenesDir } = createSyncSidecarFixture();
+
+    const nestedDir = path.join(scenesDir, "legacy", "nested");
+    fs.mkdirSync(nestedDir, { recursive: true });
+
+    const originalSidecarPath = path.join(scenesDir, "001 Scene Arrival [1].meta.yaml");
+    const nestedSidecarPath = path.join(nestedDir, "001 Scene Arrival [1].meta.yaml");
+    fs.renameSync(originalSidecarPath, nestedSidecarPath);
+
+    const nestedProsePath = path.join(nestedDir, "001 Scene Arrival [1].txt");
+    fs.writeFileSync(nestedProsePath, "Scene prose.\n", "utf8");
+
+    try {
+      const result = mergeScrivenerProjectMetadata({
+        scrivPath: scrivDir,
+        mcpSyncDir: syncRoot,
+        projectId: "test-import",
+        dryRun: false,
+        organizeByChapters: false,
+      });
+
+      const sidecar = yaml.load(fs.readFileSync(nestedSidecarPath, "utf8"));
+
+      assert.equal(result.updated, 1);
+      assert.equal(result.relocated, 0, "No relocation should occur when organize_by_chapters is false");
+      assert.equal(fs.existsSync(nestedSidecarPath), true, "Nested sidecar should remain in place");
+      assert.equal(fs.existsSync(nestedProsePath), true, "Nested prose should remain in place");
+      assert.equal(fs.existsSync(path.join(scenesDir, "001 Scene Arrival [1].meta.yaml")), false, "Sidecar should not be flattened back to scenes root");
+      assert.equal(sidecar.chapter, 1);
+      assert.equal(sidecar.chapter_title, "Harbor Arrival");
+    } finally {
+      fs.rmSync(scrivDir, { recursive: true, force: true });
+      fs.rmSync(syncRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("mergeScrivenerProjectMetadata keeps sidecar in place when relocation destination exists", () => {
+    const scrivDir = createScrivenerProjectFixture({ chapterTitle: "Harbor Arrival" });
+    const { syncRoot, scenesDir } = createSyncSidecarFixture();
+    const prosePath = path.join(scenesDir, "001 Scene Arrival [1].txt");
+    fs.writeFileSync(prosePath, "Scene prose.\n", "utf8");
+
+    const targetDir = path.join(scenesDir, "part-1", "chapter-1-harbor-arrival");
+    fs.mkdirSync(targetDir, { recursive: true });
+    const targetSidecarPath = path.join(targetDir, "001 Scene Arrival [1].meta.yaml");
+    fs.writeFileSync(targetSidecarPath, yaml.dump({ scene_id: "sc-existing-target", title: "Existing" }), "utf8");
+
+    try {
+      const result = mergeScrivenerProjectMetadata({
+        scrivPath: scrivDir,
+        mcpSyncDir: syncRoot,
+        projectId: "test-import",
+        dryRun: false,
+        organizeByChapters: true,
+      });
+
+      const originalSidecarPath = path.join(scenesDir, "001 Scene Arrival [1].meta.yaml");
+      const originalSidecar = yaml.load(fs.readFileSync(originalSidecarPath, "utf8"));
+      const targetSidecar = yaml.load(fs.readFileSync(targetSidecarPath, "utf8"));
+
+      assert.ok(result.updated >= 1, "At least one sidecar should be updated");
+      assert.equal(result.relocated, 0, "Sidecar should not relocate when destination exists");
+      assert.equal(fs.existsSync(originalSidecarPath), true, "Original sidecar should be kept in place");
+      assert.equal(fs.existsSync(prosePath), true, "Original prose should be kept in place");
+      assert.equal(result.warningSummary.relocate_sidecar_destination_exists.count, 1);
+      assert.equal(originalSidecar.chapter, 1);
+      assert.equal(originalSidecar.chapter_title, "Harbor Arrival");
+      assert.equal(targetSidecar.scene_id, "sc-existing-target", "Existing destination sidecar must not be overwritten");
+    } finally {
+      fs.rmSync(scrivDir, { recursive: true, force: true });
+      fs.rmSync(syncRoot, { recursive: true, force: true });
+    }
+  });
+
   test("mergeScrivenerProjectMetadata dry run reports updates without writing", () => {
     const scrivDir = createScrivenerProjectFixture();
     const { syncRoot, scenesDir } = createSyncSidecarFixture();


### PR DESCRIPTION
## Summary
- make chapter-based scene relocation opt-in via organize_by_chapters (default false)
- add chapter_title extraction/indexing and surface it in query responses
- preserve Scrivener keywords as raw tags (no semantic interpretation into characters/versions)
- update beta docs/PRD language for explicit keyword fidelity and opt-in relocation
- add/adjust unit+integration coverage for opt-in relocation and raw-tag behavior

## Validation
- targeted unit tests for Scrivener direct merge paths
- targeted integration tests for merge_scrivener_project_beta tool

## Notes
- stable import path remains unchanged
- beta path remains explicitly opt-in