### PR TITLE
fix: add async-progress.js to package files allowlist

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": "index.js",
   "files": [
     "index.js",
+    "async-progress.js",
     "scrivener-direct.js",
     "importer.js",
     "db.js",

--- a/test/unit.test.mjs
+++ b/test/unit.test.mjs
@@ -1934,3 +1934,35 @@ describe("walkFiles symlink support", () => {
     fs.rmSync(dir, { recursive: true });
   });
 });
+
+// ---------------------------------------------------------------------------
+// package.json files allowlist — regression guard
+// ---------------------------------------------------------------------------
+describe("package.json files allowlist", () => {
+  const root = path.resolve(import.meta.dirname, "..");
+  const pkg = JSON.parse(fs.readFileSync(path.join(root, "package.json"), "utf8"));
+  const allowlist = pkg.files ?? [];
+
+  test("every file listed in files exists on disk", () => {
+    for (const entry of allowlist) {
+      const full = path.join(root, entry);
+      assert.ok(
+        fs.existsSync(full),
+        `package.json files entry "${entry}" does not exist on disk`
+      );
+    }
+  });
+
+  test("every local JS module imported by index.js is in the files allowlist", () => {
+    const indexSrc = fs.readFileSync(path.join(root, "index.js"), "utf8");
+    const localImports = [...indexSrc.matchAll(/^import\s+.+?\s+from\s+["'](\.\/[^"']+)["']/gm)]
+      .map((m) => m[1].replace(/^\.\//, ""));
+
+    for (const file of localImports) {
+      assert.ok(
+        allowlist.includes(file),
+        `"${file}" is imported by index.js but missing from package.json files allowlist`
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Problem

async-progress.js was absent from all published tarballs (1.11.0, 1.11.1, 1.11.2) because it was never included in the files allowlist in package.json. Rolling back versions would not have helped — the omission predates all affected releases.

## Fix

Added async-progress.js to the files array in package.json so it is included in future npm publishes.