### PR TITLE
feat(scrivener-direct): ownership enforcement (PR-3a)

### DIFF
--- a/docs/prd/in-progress/scrivener-direct-extraction-beta-implementation.md
+++ b/docs/prd/in-progress/scrivener-direct-extraction-beta-implementation.md
@@ -10,6 +10,7 @@ This document translates the beta PRD into execution-ready tasks. It is intentio
 - M2: Official beta entrypoints (MCP + CLI) ✅
 - M2.5: Large-project UX (async jobs, warning aggregation, scoped parsing) ✅
 - M3: Safety and parity hardening
+- M3: Safety and parity hardening (ownership enforcement ✅, ambiguity conflicts pending)
 - M4: Docs, compatibility posture, and beta operations ✅ (baseline docs slice)
 
 ## Recommended Execution Order
@@ -191,9 +192,9 @@ This phase was identified during manual testing against a real 430+ file project
 
 ### Phase C Tasks
 
-- [ ] Enforce importer-authoritative field boundaries during merge
+- [x] Enforce importer-authoritative field boundaries during merge
 - [x] Ensure non-authoritative sidecar fields are preserved
-- [ ] Align `walkYamls` (in `scrivener-direct.js`) to skip `projects/`/`universes/` mirror subdirectories, consistent with `walkSidecarFiles` in `importer.js`
+- [x] Align `walkYamls` (in `scrivener-direct.js`) to skip `projects/`/`universes/` mirror subdirectories, consistent with `walkSidecarFiles` in `importer.js`
 - [ ] Normalize handling for:
   - [x] missing UUID mappings
   - [x] missing synopsis files
@@ -205,12 +206,12 @@ This phase was identified during manual testing against a real 430+ file project
 ### Phase C Acceptance Criteria
 
 - [x] No duplicate logical scenes created due to ordering or path changes in source
-- [ ] No silent overwrite of agent-authoritative fields
+- [x] No silent overwrite of agent-authoritative fields
 - [ ] Warning taxonomy is stable and documented
 
 ### Phase C Deliverables
 
-- [ ] Ownership-safe merge policy implementation
+- [x] Ownership-safe merge policy implementation
 - [x] Structured warnings and error codes
 
 ---
@@ -287,6 +288,9 @@ For each fixture:
 - Unknown Scrivener custom fields are ignored unless explicitly mapped into supported sidecar fields.
 - Invalid numeric Scrivener custom field values are ignored with structured warnings rather than hard-failing the merge.
 - Remaining Phase C work is concentrated in explicit ownership policy and conflict reporting for ambiguous mappings.
+- Ownership boundaries are enforced via `IMPORTER_AUTHORITATIVE_FIELDS` (exported from `scrivener-direct.js`). Fields in this set (`scene_id`, `external_source`, `external_id`, `title`, `timeline_position`) are silently skipped by beta merge and reported as `blockedKeys` in the `mergeSidecarData` return value.
+- `save_the_cat_beat` is intentionally **not** importer-authoritative. It can be written by the beta path (from the `savethecat!` Scrivener custom metadata field) or by the importer (from beat marker filenames). Additive-only semantics mean whichever runs first wins. A future docs task (PR-4) should explain how to set up the `savethecat!` custom metadata field in Scrivener to benefit from this mapping.
+- Remaining Phase C work is concentrated in conflict reporting for ambiguous mappings (PR-3b).
 - Phase D baseline docs slice is complete: setup guidance, troubleshooting, stability-tier tool descriptions, and generated tool reference are in place.
 - Remaining docs work is now mostly depth expansion (broader tested-version matrix and fixture coverage), not baseline guidance.
 

--- a/docs/prd/in-progress/scrivener-direct-extraction-beta-implementation.md
+++ b/docs/prd/in-progress/scrivener-direct-extraction-beta-implementation.md
@@ -9,7 +9,6 @@ This document translates the beta PRD into execution-ready tasks. It is intentio
 - M1: Parser and merge core extracted from legacy script ✅
 - M2: Official beta entrypoints (MCP + CLI) ✅
 - M2.5: Large-project UX (async jobs, warning aggregation, scoped parsing) ✅
-- M3: Safety and parity hardening
 - M3: Safety and parity hardening (ownership enforcement ✅, ambiguity conflicts pending)
 - M4: Docs, compatibility posture, and beta operations ✅ (baseline docs slice)
 

--- a/scrivener-direct.js
+++ b/scrivener-direct.js
@@ -105,13 +105,15 @@ function moveFileIfNeeded(fromPath, toPath) {
 // importer derives them from the source filename and project structure in ways
 // the beta merge path cannot reliably replicate (e.g. scene_id slug, timeline
 // position from file sequence, external identity).
-export const IMPORTER_AUTHORITATIVE_FIELDS = new Set([
+export const IMPORTER_AUTHORITATIVE_FIELDS = Object.freeze([
   "scene_id",
   "external_source",
   "external_id",
   "title",
   "timeline_position",
 ]);
+
+const IMPORTER_AUTHORITATIVE_FIELD_SET = new Set(IMPORTER_AUTHORITATIVE_FIELDS);
 
 const KNOWN_CUSTOM_FIELD_IDS = new Set([
   "savethecat!",
@@ -238,7 +240,7 @@ export function mergeSidecarData(existing, mergeData) {
   const blockedKeys = [];
 
   for (const [key, value] of Object.entries(mergeData)) {
-    if (IMPORTER_AUTHORITATIVE_FIELDS.has(key)) {
+    if (IMPORTER_AUTHORITATIVE_FIELD_SET.has(key)) {
       blockedKeys.push(key);
       continue;
     }

--- a/scrivener-direct.js
+++ b/scrivener-direct.js
@@ -100,6 +100,19 @@ function moveFileIfNeeded(fromPath, toPath) {
   return { moved: true };
 }
 
+// Fields that are exclusively owned by the stable Scrivener sync-folder importer.
+// The beta merge must never write these fields, even additively, because the
+// importer derives them from the source filename and project structure in ways
+// the beta merge path cannot reliably replicate (e.g. scene_id slug, timeline
+// position from file sequence, external identity).
+export const IMPORTER_AUTHORITATIVE_FIELDS = new Set([
+  "scene_id",
+  "external_source",
+  "external_id",
+  "title",
+  "timeline_position",
+]);
+
 const KNOWN_CUSTOM_FIELD_IDS = new Set([
   "savethecat!",
   "causality",
@@ -222,8 +235,13 @@ function buildMergeDataFromProject(projectData, uuid) {
 export function mergeSidecarData(existing, mergeData) {
   const merged = { ...existing };
   const newKeys = [];
+  const blockedKeys = [];
 
   for (const [key, value] of Object.entries(mergeData)) {
+    if (IMPORTER_AUTHORITATIVE_FIELDS.has(key)) {
+      blockedKeys.push(key);
+      continue;
+    }
     if (!(key in merged)) {
       merged[key] = value;
       newKeys.push(key);
@@ -234,6 +252,7 @@ export function mergeSidecarData(existing, mergeData) {
     merged,
     changed: newKeys.length > 0,
     newKeys,
+    blockedKeys,
   };
 }
 

--- a/test/unit.test.mjs
+++ b/test/unit.test.mjs
@@ -27,12 +27,10 @@ import { lintMetadataInSyncDir, validateMetadataObject } from "../metadata-lint.
 import { openDb } from "../db.js";
 import { importScrivenerSync } from "../importer.js";
 import {
+  IMPORTER_AUTHORITATIVE_FIELDS,
   loadScrivenerProjectData,
   mergeScrivenerProjectMetadata,
   mergeSidecarData,
-} from "../scrivener-direct.js";
-import {
-  IMPORTER_AUTHORITATIVE_FIELDS,
 } from "../scrivener-direct.js";
 import { runSceneCharacterBatch } from "../scene-character-batch.js";
 
@@ -1375,11 +1373,12 @@ describe("Scrivener direct metadata merge", () => {
 
   test("IMPORTER_AUTHORITATIVE_FIELDS contains expected identity fields", () => {
     for (const field of ["scene_id", "external_source", "external_id", "title", "timeline_position"]) {
-      assert.ok(IMPORTER_AUTHORITATIVE_FIELDS.has(field), `Expected ${field} to be authoritative`);
+      assert.ok(IMPORTER_AUTHORITATIVE_FIELDS.includes(field), `Expected ${field} to be authoritative`);
     }
-    assert.ok(!IMPORTER_AUTHORITATIVE_FIELDS.has("chapter"), "chapter should not be authoritative");
-    assert.ok(!IMPORTER_AUTHORITATIVE_FIELDS.has("synopsis"), "synopsis should not be authoritative");
-    assert.ok(!IMPORTER_AUTHORITATIVE_FIELDS.has("save_the_cat_beat"), "save_the_cat_beat should not be authoritative");
+    assert.ok(!IMPORTER_AUTHORITATIVE_FIELDS.includes("chapter"), "chapter should not be authoritative");
+    assert.ok(!IMPORTER_AUTHORITATIVE_FIELDS.includes("synopsis"), "synopsis should not be authoritative");
+    assert.ok(!IMPORTER_AUTHORITATIVE_FIELDS.includes("save_the_cat_beat"), "save_the_cat_beat should not be authoritative");
+    assert.ok(Object.isFrozen(IMPORTER_AUTHORITATIVE_FIELDS), "authoritative field list should be immutable");
   });
 
   test("walkYamls skips projects/ and universes/ mirror subdirectories", () => {
@@ -1399,19 +1398,22 @@ describe("Scrivener direct metadata merge", () => {
       // mergeScrivenerProjectMetadata reports sidecarFiles: the count of files walkYamls found.
       // If mirror dirs leaked through, sidecarFiles would be 3 instead of 1.
       const scrivDir = createScrivenerProjectFixture();
-      const result = mergeScrivenerProjectMetadata({
-        scrivPath: scrivDir,
-        mcpSyncDir: root,
-        projectId: "my-novel",
-        scenesDir: root,
-        dryRun: true,
-      });
-      fs.rmSync(scrivDir, { recursive: true, force: true });
+      try {
+        const result = mergeScrivenerProjectMetadata({
+          scrivPath: scrivDir,
+          mcpSyncDir: root,
+          projectId: "my-novel",
+          scenesDir: root,
+          dryRun: true,
+        });
 
-      // Only the single real sidecar should be seen (no bracket → skippedNoBracketId=1).
-      // If mirror dirs leaked through, sidecarFiles would be 3 instead of 1.
-      assert.equal(result.sidecarFiles, 1, "Mirror subdirectory sidecars must not be visited by walkYamls");
-      assert.equal(result.skippedNoBracketId, 1, "The one sidecar with no bracket ID should be reported");
+        // Only the single real sidecar should be seen (no bracket → skippedNoBracketId=1).
+        // If mirror dirs leaked through, sidecarFiles would be 3 instead of 1.
+        assert.equal(result.sidecarFiles, 1, "Mirror subdirectory sidecars must not be visited by walkYamls");
+        assert.equal(result.skippedNoBracketId, 1, "The one sidecar with no bracket ID should be reported");
+      } finally {
+        fs.rmSync(scrivDir, { recursive: true, force: true });
+      }
     } finally {
       fs.rmSync(root, { recursive: true, force: true });
     }

--- a/test/unit.test.mjs
+++ b/test/unit.test.mjs
@@ -31,6 +31,9 @@ import {
   mergeScrivenerProjectMetadata,
   mergeSidecarData,
 } from "../scrivener-direct.js";
+import {
+  IMPORTER_AUTHORITATIVE_FIELDS,
+} from "../scrivener-direct.js";
 import { runSceneCharacterBatch } from "../scene-character-batch.js";
 
 // ---------------------------------------------------------------------------
@@ -1320,6 +1323,98 @@ describe("Scrivener direct metadata merge", () => {
     assert.deepEqual(result.newKeys, ["chapter", "characters"]);
     assert.equal(result.merged.title, "Keep title");
     assert.equal(result.merged.chapter, 2);
+  });
+
+  test("mergeSidecarData blocks importer-authoritative fields and reports them", () => {
+    const existing = {};
+    const mergeData = {
+      scene_id: "sc-should-not-write",
+      external_source: "scrivener",
+      external_id: "42",
+      title: "Should not write",
+      timeline_position: 5,
+      chapter: 2,
+    };
+
+    const result = mergeSidecarData(existing, mergeData);
+
+    assert.equal(result.changed, true);
+    assert.deepEqual(result.newKeys, ["chapter"]);
+    assert.deepEqual(result.blockedKeys.sort(), ["external_id", "external_source", "scene_id", "timeline_position", "title"]);
+    assert.equal("scene_id" in result.merged, false);
+    assert.equal("external_source" in result.merged, false);
+    assert.equal("external_id" in result.merged, false);
+    assert.equal("title" in result.merged, false);
+    assert.equal("timeline_position" in result.merged, false);
+    assert.equal(result.merged.chapter, 2);
+  });
+
+  test("mergeSidecarData returns empty blockedKeys when no authoritative fields attempted", () => {
+    const existing = { chapter: 1 };
+    const mergeData = { synopsis: "A new synopsis", tags: ["action"] };
+
+    const result = mergeSidecarData(existing, mergeData);
+
+    assert.deepEqual(result.blockedKeys, []);
+    assert.equal(result.changed, true);
+    assert.deepEqual(result.newKeys, ["synopsis", "tags"]);
+  });
+
+  test("mergeSidecarData no-op when all fields already present and none blocked", () => {
+    const existing = { chapter: 1, synopsis: "Keep this" };
+    const mergeData = { chapter: 99, synopsis: "New synopsis" };
+
+    const result = mergeSidecarData(existing, mergeData);
+
+    assert.equal(result.changed, false);
+    assert.deepEqual(result.newKeys, []);
+    assert.deepEqual(result.blockedKeys, []);
+    assert.equal(result.merged.chapter, 1);
+    assert.equal(result.merged.synopsis, "Keep this");
+  });
+
+  test("IMPORTER_AUTHORITATIVE_FIELDS contains expected identity fields", () => {
+    for (const field of ["scene_id", "external_source", "external_id", "title", "timeline_position"]) {
+      assert.ok(IMPORTER_AUTHORITATIVE_FIELDS.has(field), `Expected ${field} to be authoritative`);
+    }
+    assert.ok(!IMPORTER_AUTHORITATIVE_FIELDS.has("chapter"), "chapter should not be authoritative");
+    assert.ok(!IMPORTER_AUTHORITATIVE_FIELDS.has("synopsis"), "synopsis should not be authoritative");
+    assert.ok(!IMPORTER_AUTHORITATIVE_FIELDS.has("save_the_cat_beat"), "save_the_cat_beat should not be authoritative");
+  });
+
+  test("walkYamls skips projects/ and universes/ mirror subdirectories", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "walkyamls-mirror-"));
+    try {
+      // Real sidecar in scenes/
+      fs.writeFileSync(path.join(root, "no-bracket.meta.yaml"), "scene_id: sc-001\n", "utf8");
+
+      // Mirror subdirectories that should be skipped
+      const projectsMirror = path.join(root, "projects", "my-novel", "scenes");
+      const universesMirror = path.join(root, "universes", "aether", "book-one", "scenes");
+      fs.mkdirSync(projectsMirror, { recursive: true });
+      fs.mkdirSync(universesMirror, { recursive: true });
+      fs.writeFileSync(path.join(projectsMirror, "no-bracket.meta.yaml"), "scene_id: sc-001\n", "utf8");
+      fs.writeFileSync(path.join(universesMirror, "no-bracket.meta.yaml"), "scene_id: sc-001\n", "utf8");
+
+      // mergeScrivenerProjectMetadata reports sidecarFiles: the count of files walkYamls found.
+      // If mirror dirs leaked through, sidecarFiles would be 3 instead of 1.
+      const scrivDir = createScrivenerProjectFixture();
+      const result = mergeScrivenerProjectMetadata({
+        scrivPath: scrivDir,
+        mcpSyncDir: root,
+        projectId: "my-novel",
+        scenesDir: root,
+        dryRun: true,
+      });
+      fs.rmSync(scrivDir, { recursive: true, force: true });
+
+      // Only the single real sidecar should be seen (no bracket → skippedNoBracketId=1).
+      // If mirror dirs leaked through, sidecarFiles would be 3 instead of 1.
+      assert.equal(result.sidecarFiles, 1, "Mirror subdirectory sidecars must not be visited by walkYamls");
+      assert.equal(result.skippedNoBracketId, 1, "The one sidecar with no bracket ID should be reported");
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
   });
 
   test("loadScrivenerProjectData parses sync map and metadata", () => {


### PR DESCRIPTION
## Ownership Enforcement (PR-3a)

**What changed:**
Implements the PR-3a ownership-enforcement slice for Scrivener Direct Extraction beta. [scrivener-direct.js](scrivener-direct.js) now exports `IMPORTER_AUTHORITATIVE_FIELDS` and `mergeSidecarData` reports blocked writes via `blockedKeys` while preserving additive-only behavior for non-authoritative fields. [test/unit.test.mjs](test/unit.test.mjs) adds blocked-write, allowed-write, no-op, authoritative-field membership, and mirror-skip coverage. [docs/prd/in-progress/scrivener-direct-extraction-beta-implementation.md](docs/prd/in-progress/scrivener-direct-extraction-beta-implementation.md) marks the ownership tasks complete and records the `save_the_cat_beat` policy.

**Why:**
This closes the ownership-enforcement scope defined in the Scrivener Direct Extraction beta implementation checklist for PR-3a. The beta merge path should never write importer-owned identity fields because the stable sync-folder importer derives those fields from filename and project-structure context that the beta path cannot reliably reconstruct. `save_the_cat_beat` remains intentionally outside the authoritative set because it is project-specific custom metadata rather than a universally derivable importer field.

**Review focus:**
- Review the ownership boundary in [scrivener-direct.js](scrivener-direct.js): the exact `IMPORTER_AUTHORITATIVE_FIELDS` set and the `blockedKeys` behavior in `mergeSidecarData`.
- Review the test coverage in [test/unit.test.mjs](test/unit.test.mjs), especially the blocked-write assertions and the mirror-directory regression coverage.
- Review the checklist updates in [docs/prd/in-progress/scrivener-direct-extraction-beta-implementation.md](docs/prd/in-progress/scrivener-direct-extraction-beta-implementation.md) to confirm the implementation notes match intended product behavior and PR-3a scope.

**Testing:**
- Added unit tests for blocked writes, allowed writes, no-op merges, authoritative field membership, and mirror-directory skipping.
- Full test suite passes: `npm test` -> 209 passed, 0 failed.
- No separate manual verification was needed beyond automated coverage for this slice.
