### PR TITLE
feat(scrivener-direct): ambiguity warning taxonomy (PR-3b)

### DIFF
--- a/docs/prd/in-progress/scrivener-direct-extraction-beta-implementation.md
+++ b/docs/prd/in-progress/scrivener-direct-extraction-beta-implementation.md
@@ -9,7 +9,7 @@ This document translates the beta PRD into execution-ready tasks. It is intentio
 - M1: Parser and merge core extracted from legacy script ✅
 - M2: Official beta entrypoints (MCP + CLI) ✅
 - M2.5: Large-project UX (async jobs, warning aggregation, scoped parsing) ✅
-- M3: Safety and parity hardening (ownership enforcement ✅, ambiguity conflicts pending)
+- M3: Safety and parity hardening ✅
 - M4: Docs, compatibility posture, and beta operations ✅ (baseline docs slice)
 
 ## Recommended Execution Order
@@ -48,12 +48,23 @@ Exit signal:
   - Ownership-safe merge policy implementation
   - `walkYamls` mirror-path guard parity with `walkSidecarFiles`
 
-### PR-3b: Ambiguity Conflicts + Warning Taxonomy
+### PR-3b: Ambiguity Conflicts + Warning Taxonomy ✅
 
 Scope:
 - Define and document ambiguous mapping conditions (e.g., unresolved identity ties, contradictory source metadata, ambiguous folder-derived structure).
 - Add dedicated conflict/warning codes for each condition.
 - Ensure warnings are stable, summarized, and test-covered.
+
+Warning taxonomy (implemented):
+- `ambiguous_identity_tie`:
+  Trigger: sidecar identity context conflicts with Scrivener mapping assumptions (for example, existing `external_source` is non-`scrivener`, or `external_source: scrivener` is missing `external_id`).
+  Behavior: keep existing sidecar identity fields; emit warning with `reason` details.
+- `ambiguous_structure_mapping`:
+  Trigger: existing sidecar `part`/`chapter`/`chapter_title` differs from Scrivener-derived structure for the same mapped scene.
+  Behavior: keep existing sidecar structure field; emit warning with `field`, `existing_value`, `scrivener_value`.
+- `ambiguous_metadata_mapping`:
+  Trigger: existing non-structure sidecar metadata field differs from Scrivener-extracted metadata for the same mapped scene.
+  Behavior: keep existing sidecar field; emit warning with `field`, `existing_value`, `scrivener_value`.
 
 Acceptance checks:
 - Warning taxonomy documented in this file and reflected in tool/runtime outputs.
@@ -194,19 +205,19 @@ This phase was identified during manual testing against a real 430+ file project
 - [x] Enforce importer-authoritative field boundaries during merge
 - [x] Ensure non-authoritative sidecar fields are preserved
 - [x] Align `walkYamls` (in `scrivener-direct.js`) to skip `projects/`/`universes/` mirror subdirectories, consistent with `walkSidecarFiles` in `importer.js`
-- [ ] Normalize handling for:
+- [x] Normalize handling for:
   - [x] missing UUID mappings
   - [x] missing synopsis files
   - [x] unknown custom fields
   - [x] malformed metadata values
-- [ ] Add conflict/warning reporting for ambiguous mappings
+- [x] Add conflict/warning reporting for ambiguous mappings
 - [x] Preserve scene identity and reconciliation assumptions from current importer model
 
 ### Phase C Acceptance Criteria
 
 - [x] No duplicate logical scenes created due to ordering or path changes in source
 - [x] No silent overwrite of agent-authoritative fields
-- [ ] Warning taxonomy is stable and documented
+- [x] Warning taxonomy is stable and documented
 
 ### Phase C Deliverables
 
@@ -286,10 +297,12 @@ For each fixture:
 - Missing UUID mappings are skipped with structured warning payloads, and missing synopsis files are tolerated without failing the merge.
 - Unknown Scrivener custom fields are ignored unless explicitly mapped into supported sidecar fields.
 - Invalid numeric Scrivener custom field values are ignored with structured warnings rather than hard-failing the merge.
-- Remaining Phase C work is concentrated in explicit ownership policy and conflict reporting for ambiguous mappings.
 - Ownership boundaries are enforced via `IMPORTER_AUTHORITATIVE_FIELDS` (exported from `scrivener-direct.js`). Fields in this set (`scene_id`, `external_source`, `external_id`, `title`, `timeline_position`) are silently skipped by beta merge and reported as `blockedKeys` in the `mergeSidecarData` return value.
 - `save_the_cat_beat` is intentionally **not** importer-authoritative. It can be written by the beta path (from the `savethecat!` Scrivener custom metadata field) or by the importer (from beat marker filenames). Additive-only semantics mean whichever runs first wins. A future docs task (PR-4) should explain how to set up the `savethecat!` custom metadata field in Scrivener to benefit from this mapping.
-- Remaining Phase C work is concentrated in conflict reporting for ambiguous mappings (PR-3b).
+- PR-3b ambiguity taxonomy is now implemented and surfaced in `warningSummary` / `warnings` outputs with deterministic codes:
+  - `ambiguous_identity_tie`
+  - `ambiguous_structure_mapping`
+  - `ambiguous_metadata_mapping`
 - Phase D baseline docs slice is complete: setup guidance, troubleshooting, stability-tier tool descriptions, and generated tool reference are in place.
 - Remaining docs work is now mostly depth expansion (broader tested-version matrix and fixture coverage), not baseline guidance.
 

--- a/scrivener-direct.js
+++ b/scrivener-direct.js
@@ -126,6 +126,73 @@ const KNOWN_CUSTOM_FIELD_IDS = new Set([
 ]);
 
 const MAX_RETURNED_WARNINGS = 25;
+const STRUCTURE_MAPPING_FIELDS = new Set(["part", "chapter", "chapter_title"]);
+
+function normalizeComparisonValue(key, value) {
+  if ((key === "tags" || key === "scene_functions") && Array.isArray(value)) {
+    return [...new Set(value.map(item => String(item)))].sort();
+  }
+  return value;
+}
+
+function valuesEquivalentForMerge(key, a, b) {
+  return JSON.stringify(normalizeComparisonValue(key, a)) === JSON.stringify(normalizeComparisonValue(key, b));
+}
+
+function collectAmbiguityWarnings(existing, mergeData, { file, uuid }) {
+  const out = [];
+
+  const externalSource = existing?.external_source;
+  if (externalSource !== undefined && externalSource !== null && externalSource !== "scrivener") {
+    out.push({
+      code: "ambiguous_identity_tie",
+      message: "Existing sidecar identity source conflicts with Scrivener mapping; keeping existing sidecar identity.",
+      reason: "external_source_conflict",
+      external_source: String(externalSource),
+      file,
+      uuid,
+    });
+  }
+  if (externalSource === "scrivener" && (existing?.external_id === undefined || existing?.external_id === null || String(existing.external_id).trim() === "")) {
+    out.push({
+      code: "ambiguous_identity_tie",
+      message: "Existing sidecar identity is marked as Scrivener but missing external_id; keeping existing sidecar identity.",
+      reason: "missing_external_id",
+      file,
+      uuid,
+    });
+  }
+
+  for (const [key, scrivenerValue] of Object.entries(mergeData)) {
+    if (!Object.hasOwn(existing, key)) continue;
+    if (valuesEquivalentForMerge(key, existing[key], scrivenerValue)) continue;
+
+    if (STRUCTURE_MAPPING_FIELDS.has(key)) {
+      out.push({
+        code: "ambiguous_structure_mapping",
+        message: `Existing sidecar field '${key}' conflicts with Scrivener-derived structure; keeping existing value.`,
+        field: key,
+        existing_value: existing[key],
+        scrivener_value: scrivenerValue,
+        file,
+        uuid,
+      });
+      continue;
+    }
+
+    out.push({
+      code: "ambiguous_metadata_mapping",
+      message: `Existing sidecar field '${key}' conflicts with Scrivener metadata; keeping existing value.`,
+      field: key,
+      existing_value: existing[key],
+      scrivener_value: scrivenerValue,
+      file,
+      uuid,
+    });
+  }
+
+  return out;
+}
 
 function recordWarning(summary, warning) {
   if (!summary[warning.code]) {
@@ -137,7 +204,21 @@ function recordWarning(summary, warning) {
 
   if (entry.examples.length < 5) {
     const example = { message: warning.message };
-    for (const key of ["file", "sync_number", "field_id", "value", "uuid", "from_path", "to_path", "moved_to"]) {
+    for (const key of [
+      "file",
+      "sync_number",
+      "field",
+      "field_id",
+      "value",
+      "reason",
+      "external_source",
+      "existing_value",
+      "scrivener_value",
+      "uuid",
+      "from_path",
+      "to_path",
+      "moved_to",
+    ]) {
       if (warning[key] !== undefined && warning[key] !== null) {
         example[key] = warning[key];
       }
@@ -500,6 +581,11 @@ export function mergeScrivenerProjectMetadata({
       throw new Error(`Invalid sidecar YAML mapping at ${sidecarPath}`);
     }
     const existing = existingRaw ?? {};
+    const ambiguityWarnings = collectAmbiguityWarnings(existing, mergeData, { file: filename, uuid });
+    for (const warning of ambiguityWarnings) {
+      warningsTruncated = pushWarning(warnings, warningSummary, warning) || warningsTruncated;
+    }
+
     const { merged, changed, newKeys } = mergeSidecarData(existing, mergeData);
     const effective = changed ? merged : existing;
     const targetDir = sceneContainerDir(

--- a/test/integration.test.mjs
+++ b/test/integration.test.mjs
@@ -11,6 +11,7 @@ import { fileURLToPath } from "node:url";
 import path from "node:path";
 import fs from "node:fs";
 import os from "node:os";
+import yaml from "js-yaml";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, "..");
@@ -724,6 +725,53 @@ describe("merge_scrivener_project_beta tool", () => {
     assert.equal(done.job.result.merge.warning_summary.missing_uuid_mapping.count, 1);
     assert.ok(done.job.result.merge.warnings.some(w => w.code === "missing_bracket_id"));
     assert.ok(done.job.result.merge.warnings.some(w => w.code === "missing_uuid_mapping" && w.sync_number === "999"));
+  });
+
+  test("returns ambiguity warning taxonomy for conflicting sidecar mappings", async () => {
+    const projectId = "direct-beta-ambiguity";
+
+    await callWriteTool("import_scrivener_sync", {
+      source_dir: scrivenerImportDir,
+      project_id: projectId,
+      dry_run: false,
+      auto_sync: false,
+    });
+
+    const scenesDir = path.join(writeSyncDir, "projects", projectId, "scenes");
+    const primarySidecarFilename = fs.readdirSync(scenesDir).find(name => /\[\d+\]\.meta\.yaml$/.test(name));
+    assert.ok(primarySidecarFilename, "Expected imported sidecar with bracketed sync marker");
+    const primarySidecarPath = path.join(scenesDir, primarySidecarFilename);
+    const primarySidecar = yaml.load(fs.readFileSync(primarySidecarPath, "utf8"));
+    fs.writeFileSync(
+      primarySidecarPath,
+      yaml.dump(
+        {
+          ...primarySidecar,
+          chapter: 9,
+          synopsis: "Conflicting sidecar synopsis",
+          external_source: "manual",
+        },
+        { lineWidth: 120 }
+      ),
+      "utf8"
+    );
+
+    const startText = await callWriteTool("merge_scrivener_project_beta", {
+      source_project_dir: scrivenerProjectDir,
+      project_id: projectId,
+      dry_run: true,
+      auto_sync: false,
+    });
+    const started = JSON.parse(startText);
+    assert.equal(started.ok, true);
+
+    const done = await waitForAsyncJob(started.job.job_id);
+    assert.equal(done.ok, true);
+    assert.equal(done.job.status, "completed");
+    assert.equal(done.job.result.ok, true);
+    assert.equal(done.job.result.merge.warning_summary.ambiguous_identity_tie.count, 1);
+    assert.equal(done.job.result.merge.warning_summary.ambiguous_structure_mapping.count, 1);
+    assert.equal(done.job.result.merge.warning_summary.ambiguous_metadata_mapping.count, 1);
   });
 
   test("scenes_dir override uses explicit path instead of project_id-derived path", async () => {

--- a/test/unit.test.mjs
+++ b/test/unit.test.mjs
@@ -1643,6 +1643,56 @@ describe("Scrivener direct metadata merge", () => {
     }
   });
 
+  test("mergeScrivenerProjectMetadata emits deterministic ambiguity warning codes", () => {
+    const scrivDir = createScrivenerProjectFixture();
+    const { syncRoot, scenesDir } = createSyncSidecarFixture();
+    const sidecarPath = path.join(scenesDir, "001 Scene Arrival [1].meta.yaml");
+    const existing = yaml.load(fs.readFileSync(sidecarPath, "utf8"));
+    fs.writeFileSync(
+      sidecarPath,
+      yaml.dump(
+        {
+          ...existing,
+          chapter: 9,
+          synopsis: "Conflicting synopsis from sidecar.",
+          external_source: "manual",
+        },
+        { lineWidth: 120 }
+      ),
+      "utf8"
+    );
+
+    try {
+      const result = mergeScrivenerProjectMetadata({
+        scrivPath: scrivDir,
+        mcpSyncDir: syncRoot,
+        projectId: "test-import",
+        dryRun: true,
+      });
+
+      assert.equal(result.warningSummary.ambiguous_identity_tie.count, 1);
+      assert.equal(result.warningSummary.ambiguous_structure_mapping.count, 1);
+      assert.equal(result.warningSummary.ambiguous_metadata_mapping.count, 1);
+
+      const identityWarning = result.warnings.find(w => w.code === "ambiguous_identity_tie");
+      assert.equal(identityWarning.reason, "external_source_conflict");
+      assert.equal(identityWarning.external_source, "manual");
+
+      const structureWarning = result.warnings.find(w => w.code === "ambiguous_structure_mapping");
+      assert.equal(structureWarning.field, "chapter");
+      assert.equal(structureWarning.existing_value, 9);
+      assert.equal(structureWarning.scrivener_value, 1);
+
+      const metadataWarning = result.warnings.find(w => w.code === "ambiguous_metadata_mapping");
+      assert.equal(metadataWarning.field, "synopsis");
+      assert.equal(metadataWarning.existing_value, "Conflicting synopsis from sidecar.");
+      assert.equal(metadataWarning.scrivener_value, "Elena returns to the harbor.");
+    } finally {
+      fs.rmSync(scrivDir, { recursive: true, force: true });
+      fs.rmSync(syncRoot, { recursive: true, force: true });
+    }
+  });
+
   test("mergeScrivenerProjectMetadata caps returned warnings but keeps full summary counts", () => {
     const scrivDir = createScrivenerProjectFixture();
     const extraSidecars = Array.from({ length: 30 }, (_, index) => ({


### PR DESCRIPTION
## Ambiguity Conflicts + Warning Taxonomy (PR-3b)

**What changed:**
Implements PR-3b ambiguity conflict reporting for Scrivener Direct beta merge.

- [scrivener-direct.js](scrivener-direct.js):
  - Adds deterministic ambiguity warning taxonomy:
    - `ambiguous_identity_tie`
    - `ambiguous_structure_mapping`
    - `ambiguous_metadata_mapping`
  - Detects and reports identity conflicts (e.g. non-`scrivener` `external_source`), structure conflicts (`part`/`chapter`/`chapter_title`), and metadata conflicts where existing sidecar values differ from Scrivener-derived values.
  - Preserves existing additive-only merge behavior (existing sidecar values are kept; warnings are emitted rather than overwriting).
  - Extends warning example payload fields for stable diagnostics (`field`, `reason`, `existing_value`, `scrivener_value`, etc.).
- [test/unit.test.mjs](test/unit.test.mjs): adds unit coverage for all new ambiguity codes and deterministic summary behavior.
- [test/integration.test.mjs](test/integration.test.mjs): adds integration coverage via `merge_scrivener_project_beta` tool output warning summary.
- [docs/prd/in-progress/scrivener-direct-extraction-beta-implementation.md](docs/prd/in-progress/scrivener-direct-extraction-beta-implementation.md): documents taxonomy and marks PR-3b/Phase C ambiguity checklist items complete.

**Why:**
PR-3b requires explicit, deterministic ambiguity/conflict reporting instead of implicit no-op merges when sidecar values contradict Scrivener-derived mapping. This improves operator clarity and makes warning outputs stable and testable, while maintaining safety (no destructive overwrite).

**Review focus:**
- Taxonomy boundaries and triggers in [scrivener-direct.js](scrivener-direct.js): identity vs structure vs metadata ambiguity classification.
- Warning payload stability and summarization behavior (`warningSummary` + `warnings`) in [scrivener-direct.js](scrivener-direct.js).
- Coverage for each ambiguity code in [test/unit.test.mjs](test/unit.test.mjs) and [test/integration.test.mjs](test/integration.test.mjs).
- Checklist/status consistency updates in [docs/prd/in-progress/scrivener-direct-extraction-beta-implementation.md](docs/prd/in-progress/scrivener-direct-extraction-beta-implementation.md).

**Testing:**
- Focused unit suite: `node --experimental-sqlite --test test/unit.test.mjs --test-name-pattern="Scrivener direct metadata merge"`
- Focused integration suite: `node --experimental-sqlite --test test/integration.test.mjs --test-name-pattern="merge_scrivener_project_beta tool"`
- Full suite: `npm test`
- Result: 211 passed, 0 failed.
