### PR TITLE
feat(scrivener-direct): graduate from beta to stable

### DIFF
--- a/docs/prd/done/scrivener-direct-extraction-beta-implementation.md
+++ b/docs/prd/done/scrivener-direct-extraction-beta-implementation.md
@@ -1,6 +1,6 @@
 # Scrivener Direct Extraction (Beta) — Implementation Checklist
 
-**Status:** 🚧 In Progress
+**Status:** ✅ Complete
 
 This document translates the beta PRD into execution-ready tasks. It is intentionally checklist-first to limit scope creep.
 
@@ -11,7 +11,7 @@ This document translates the beta PRD into execution-ready tasks. It is intentio
 - M2.5: Large-project UX (async jobs, warning aggregation, scoped parsing) ✅
 - M3: Safety and parity hardening ✅
 - M4: Docs, compatibility posture, and beta operations ✅
-- M5: Data safety hardening (critical fixes) 🚧
+- M5: Data safety hardening (critical fixes) ✅
 
 ## Recommended Execution Order
 
@@ -22,7 +22,7 @@ Use focused PRs with one concern each. Do not combine milestones unless explicit
 3. PR-2.5: Large-project UX hardening ✅
 4. PR-3: Ownership and parity hardening ✅
 5. PR-4: Docs, compatibility matrix, and beta operational guidance ✅
-6. PR-5: Data safety hardening (critical fixes) 🚧
+6. PR-5: Data safety hardening (critical fixes) ✅
 
 ## Next PR Sequence (Concrete)
 
@@ -385,7 +385,7 @@ All must be true before proposing graduation from beta status.
   - [x] Non-atomic file move operations handled safely
   - [x] Sidecar orphan detection and warning
   - [x] XML size check and memory guardrail
-- [ ] Zero unresolved high-severity data-loss issues
+- [x] Zero unresolved high-severity data-loss issues
 - [x] Compatibility matrix has representative coverage (fixtures A–D)
 - [x] Fallback path to stable importer validated in automated tests
 

--- a/docs/prd/done/scrivener-direct-extraction-beta.md
+++ b/docs/prd/done/scrivener-direct-extraction-beta.md
@@ -1,6 +1,6 @@
 # Scrivener Direct Extraction (Beta)
 
-**Status:** 🚧 In Progress (Beta track)
+**Status:** ✅ Complete
 
 ## Goal
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -64,7 +64,7 @@ Once this is working, you can come back to:
 - **[docs/tools.md](tools.md)** for the full tool catalog
 - **[README.md](../README.md#usage-scenarios)** for workflow ideas
 
-If you later want richer metadata from a full `.scriv` bundle, add the **Direct Scrivener project merge (beta)** step after the stable import has already created your scene sidecars.
+If you later want richer metadata from a full `.scriv` bundle, add the **Direct Scrivener project merge** step after the stable import has already created your scene sidecars.
 
 ---
 
@@ -75,13 +75,13 @@ There are two supported Scrivener ingestion paths, and they are not equally stab
 | Path | Stability | Use when | Tooling |
 | --- | --- | --- | --- |
 | External Folder Sync export | Stable default | First-time setup, routine imports, safest long-term path | `import_scrivener_sync`, `import_scrivener_sync_async` |
-| Direct `.scriv` project merge | Beta / opt-in | You already imported scenes and want extra metadata from Scrivener internals | `merge_scrivener_project_beta` (async) |
+| Direct `.scriv` project merge | Opt-in | You already imported scenes and want extra metadata from Scrivener internals | `merge_scrivener_project_beta` (async) |
 
 Recommendation:
 
 1. Start with the stable External Folder Sync path.
 2. Confirm your scene sidecars and indexing are correct.
-3. Use the beta direct-merge path only if you need metadata that plain-text sync cannot provide, such as Scrivener keywords, synopsis files, or selected custom fields.
+3. Use the direct-merge path only if you need metadata that plain-text sync cannot provide, such as Scrivener keywords, synopsis files, or selected custom fields.
 
 ---
 
@@ -167,11 +167,11 @@ This exits with a non-zero code if it finds errors. Warnings (for example `UNKNO
 
 ---
 
-## Direct Scrivener project merge (beta)
+## Direct Scrivener project merge
 
 Use this only after the stable import path has already created your scene sidecars.
 
-What this beta path is for:
+What this path is for:
 
 - pull Scrivener keywords into sidecars
 - merge synopsis text from `Files/Data/<UUID>/synopsis.txt`
@@ -181,12 +181,11 @@ What it is not for:
 
 - first-time scene creation
 - replacing `import_scrivener_sync` as the default path
-- broad compatibility guarantees across all Scrivener schema variations
 
-Recommended beta flow:
+Recommended flow:
 
 1. Run the stable `import_scrivener_sync` flow first.
-2. Run the beta merge as a dry run.
+2. Run the merge as a dry run.
 3. Inspect `merge.preview_changes`, `merge.warnings`, and `merge.warning_summary`.
 4. Re-run with `dry_run: false` only if the preview looks correct.
 
@@ -216,36 +215,30 @@ Use `scenes_dir` instead of `project_id` when your sidecars live in a non-standa
 
 ---
 
-## Beta compatibility and fallback
+## Compatibility notes and fallback
 
-Current beta posture:
+Current posture:
 
 - Runtime requirement: Node.js 22.6.0 or newer
 - Stable fallback remains: Scrivener External Folder Sync plus `import_scrivener_sync`
-- Current automated bundle coverage includes a baseline `.scriv` fixture with:
-  - `.scrivx` sync-number mapping
-  - Scrivener keywords
-  - synopsis files
-  - selected custom metadata fields
-  - `scenes_dir` override coverage
-- Not yet declared as broadly compatible:
-  - historical Scrivener versions as a published matrix
-  - custom-metadata-heavy projects
-  - reordered binder hierarchies beyond current fixture coverage
+- Validated fixture coverage:
+  - Baseline `.scriv` project (`.scrivx` sync-number mapping, Scrivener keywords, synopsis files, selected custom metadata fields, `scenes_dir` override)
+  - Projects with missing optional metadata files
+  - Custom-metadata-heavy projects
+  - Reordered binder hierarchies
+- Historical Scrivener version compatibility is not published as a formal matrix; report regressions if you encounter them.
 
-Treat direct `.scriv` parsing as version-fragile until the beta coverage matrix expands.
-
-If the beta merge fails:
+If the merge fails:
 
 1. Confirm `source_project_dir` points to the `.scriv` bundle directory itself, not the `.scrivx` file.
 2. Re-run with `dry_run: true` first.
 3. If you get `SCRIVENER_DIRECT_BETA_FAILED`, fall back to `import_scrivener_sync` from an External Folder Sync export.
 
-If the beta merge returns warnings:
+If the merge returns warnings:
 
 1. `missing_bracket_id`: the sidecar filename does not contain a Scrivener sync number like `[123]`; re-import via the stable path if needed.
 2. `missing_uuid_mapping`: the sidecar sync number is not present in the `.scrivx` sync map; confirm the sidecars came from the same Scrivener project/export lineage.
-3. `ignored_custom_field`: the Scrivener project contains custom metadata that this beta path does not map yet.
+3. `ignored_custom_field`: the Scrivener project contains custom metadata that this tool does not map.
 4. `invalid_custom_field_value`: the source custom field value could not be normalized into the supported sidecar type and was ignored.
 
 ---

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -5,8 +5,8 @@
 - [First-time setup path (recommended)](#first-time-setup-path-recommended)
 - [Choosing a Scrivener path](#choosing-a-scrivener-path)
 - [Quick start with Scrivener (stable default)](#quick-start-with-scrivener-stable-default)
-- [Direct Scrivener project merge (beta)](#direct-scrivener-project-merge-beta)
-- [Beta compatibility and fallback](#beta-compatibility-and-fallback)
+- [Direct Scrivener project merge](#direct-scrivener-project-merge)
+- [Compatibility notes and fallback](#compatibility-notes-and-fallback)
 - [Advanced: Native sync format](#advanced-native-sync-format)
 - [Data ownership model](data-ownership.md)
 
@@ -232,7 +232,7 @@ If the merge fails:
 
 1. Confirm `source_project_dir` points to the `.scriv` bundle directory itself, not the `.scrivx` file.
 2. Re-run with `dry_run: true` first.
-3. If you get `SCRIVENER_DIRECT_BETA_FAILED`, fall back to `import_scrivener_sync` from an External Folder Sync export.
+3. If you get `SCRIVENER_DIRECT_BETA_FAILED` (legacy error code name), fall back to `import_scrivener_sync` from an External Folder Sync export.
 
 If the merge returns warnings:
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -82,7 +82,7 @@ _No parameters._
 
 ## merge_scrivener_project_beta
 
-[BETA] Merge metadata directly from a Scrivener .scriv project into existing scene sidecars by starting a background job. This path is opt-in, requires sidecars to already exist (for example, from import_scrivener_sync), and may be sensitive to Scrivener internal format changes. Returns immediately with a job_id to poll via get_async_job_status.
+Merge metadata directly from a Scrivener .scriv project into existing scene sidecars by starting a background job. This path is opt-in and requires sidecars to already exist (for example, from import_scrivener_sync). Returns immediately with a job_id to poll via get_async_job_status.
 
 | Parameter | Type | Required | Description |
 | --- | --- | :---: | --- |

--- a/index.js
+++ b/index.js
@@ -980,7 +980,7 @@ function createMcpServer() {
 
   s.tool(
     "merge_scrivener_project_beta",
-    "[BETA] Merge metadata directly from a Scrivener .scriv project into existing scene sidecars by starting a background job. This path is opt-in, requires sidecars to already exist (for example, from import_scrivener_sync), and may be sensitive to Scrivener internal format changes. Returns immediately with a job_id to poll via get_async_job_status.",
+    "Merge metadata directly from a Scrivener .scriv project into existing scene sidecars by starting a background job. This path is opt-in and requires sidecars to already exist (for example, from import_scrivener_sync). Returns immediately with a job_id to poll via get_async_job_status.",
     {
       source_project_dir: z.string().describe("Path to a Scrivener .scriv bundle directory."),
       project_id: z.string().optional().describe("Project ID containing existing sidecars (e.g. 'the-lamb' or 'universe-1/book-1-the-lamb')."),
@@ -1052,7 +1052,6 @@ function createMcpServer() {
       return jsonResponse({
         ok: true,
         async: true,
-        beta: true,
         job: toPublicJob(job, false),
         next_step: "Call get_async_job_status with job_id until status is 'completed' or 'failed'.",
       });

--- a/scripts/async-job-runner.mjs
+++ b/scripts/async-job-runner.mjs
@@ -52,7 +52,6 @@ function normalizeImportResult(importResult) {
 function normalizeMergeResult(mergeResult) {
   return {
     ok: true,
-    beta: true,
     merge: {
       source_project_dir: mergeResult.scrivPath,
       sync_dir: mergeResult.mcpSyncDir,
@@ -77,10 +76,7 @@ function normalizeMergeResult(mergeResult) {
       },
     },
     sync: null,
-    warnings: [
-      "BETA_FEATURE: Direct Scrivener project parsing may be sensitive to Scrivener internal format changes.",
-      "If this fails, use import_scrivener_sync with an External Folder Sync export as the stable fallback.",
-    ],
+    warnings: [],
   };
 }
 

--- a/test/integration.test.mjs
+++ b/test/integration.test.mjs
@@ -652,6 +652,7 @@ describe("merge_scrivener_project_beta tool", () => {
     assert.equal(done.ok, true);
     assert.equal(done.job.status, "completed");
     assert.equal(done.job.result.ok, true);
+    assert.equal(done.job.result.beta, undefined);
     assert.equal(done.job.result.merge.project_id, projectId);
     assert.equal(done.job.result.merge.dry_run, true);
     assert.equal(done.job.result.merge.sidecar_files, 2);

--- a/test/integration.test.mjs
+++ b/test/integration.test.mjs
@@ -645,7 +645,7 @@ describe("merge_scrivener_project_beta tool", () => {
 
     assert.equal(started.ok, true);
     assert.equal(started.async, true);
-    assert.equal(started.beta, true);
+    assert.equal(started.beta, undefined);
     assert.equal(typeof started.job.job_id, "string");
 
     const done = await waitForAsyncJob(started.job.job_id);


### PR DESCRIPTION
## feat(scrivener-direct): graduate from beta to stable

**What changed:**
- `index.js`: Removed `[BETA]` prefix from `merge_scrivener_project_beta` tool description; removed `beta: true` from response payload. Tool name unchanged for backwards compatibility.
- `scripts/async-job-runner.mjs`: Removed lingering async merge `beta` marker and beta warning text from normalized merge result payload.
- `docs/setup.md`: Removed beta-fragile framing; updated stability label from `Beta / opt-in` to `Opt-in`; fixed TOC anchors to match renamed sections; retained legacy error-code note for compatibility (`SCRIVENER_DIRECT_BETA_FAILED`).
- `docs/tools.md`: Regenerated from updated `index.js` descriptions.
- PRD: Marked all exit criteria complete; moved both `scrivener-direct-extraction-beta*.md` files from `in-progress/` to `done/`.
- `test/integration.test.mjs`: Updated async merge integration assertions to expect no `beta` field in start/result payloads.

**Why:**
All graduation criteria defined in the PRD are met:
- Milestones M1–M5 complete (Phases A–E including data safety hardening from #71)
- Zero unresolved high-severity data-loss issues
- Compatibility matrix covers fixtures A–D (baseline, missing-optional, custom-metadata-heavy, reordered binder)
- Fallback path to stable importer validated in automated tests

**Review focus:**
- `index.js` and `scripts/async-job-runner.mjs`: verify `beta: true` is removed consistently from merge start/result payload surfaces.
- `docs/setup.md`: confirm TOC anchors and section headings align, and compatibility wording is accurate.
- `test/integration.test.mjs`: verify assertion updates correctly lock the graduated payload shape.

**Testing:**
- Integration tests (local): `node --experimental-sqlite --test test/integration.test.mjs` -> 103 passed, 0 failed.
- Full test suite (prior CI/local baseline): 115 passed, 0 failed.
- `npm run docs` regenerated `docs/tools.md` cleanly (34 tools).
