### PR TITLE
feat: add review bundle preview planner tool

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -113,6 +113,16 @@ Index and search world-building notes, research, and continuity scratchpads.
 
 ---
 
+### 🧾 [Review Bundles for Editorial Workflows](docs/prd/todo/review-bundles.md) 📋
+
+Generate collaboration-focused bundles for conceptual discussion, detailed editorial reading, and personalized beta-reader feedback without expanding into typesetting/final-distribution scope.
+
+**Example:** "Create an outline-only chapter packet for story discussion" or "Generate a beta-reader draft with non-distribution notice and feedback form."
+
+**Status:** Proposed for Phase 4A. Scoped as review artifacts only (not publishing output).
+
+---
+
 ### 🚀 [OpenClaw Integration](docs/prd/in-progress/openclaw-integration.md) 🚧
 
 Deploy writing-mcp as a service in the OpenClaw runtime with the Writing World agent.
@@ -191,7 +201,7 @@ See [ideas-and-questions.md](docs/prd/inbox/ideas-and-questions.md) for:
 - **Phase 1** ✅ — Ask questions about your project (all tools implemented)
 - **Phase 2** ✅ — Answers stay accurate (metadata staleness, sidecar migration, enrichment)
 - **Phase 3** ✅ — AI helps edit prose (two-step proposals, git history, snapshots)
-- **Phase 4** 📋 — Semantic search & reference docs (pending evaluation)
+- **Phase 4** 📋 — Semantic search, reference docs, and review bundles (pending evaluation/scoping)
 - **Phase 5** 🚧 — OpenClaw integration (active planning and integration work underway)
 
 ---

--- a/docs/prd/todo/review-bundles-implementation.md
+++ b/docs/prd/todo/review-bundles-implementation.md
@@ -1,0 +1,180 @@
+# Review Bundles — Phase 4A.1 Implementation Checklist
+
+**Status:** 📋 Planned
+
+This checklist scopes only the first delivery slice:
+- `outline_discussion`
+- `editor_detailed`
+- markdown output
+- deterministic planning and generation
+
+Out of scope for this slice:
+- `beta_reader_personalized`
+- DOCX adapters
+- multi-project/universe bundle generation
+
+## Milestone
+
+- M1: Dry-run planning + markdown bundle generation for project-scoped editorial workflows
+
+## Deliverables
+
+1. `preview_review_bundle` tool (dry-run planner)
+2. `create_review_bundle` tool (artifact writer)
+3. markdown renderer for two profiles
+4. bundle manifest output
+5. integration tests for ordering, filters, strictness, and exclusions
+6. docs update for tool behavior and safety guarantees
+
+## Proposed Tool Contracts
+
+### `preview_review_bundle`
+
+Purpose: resolve scope, ordering, and warnings without writing artifacts.
+
+Input:
+- `project_id` (string, required)
+- `profile` (enum, required): `outline_discussion` | `editor_detailed`
+- `part` (int, optional)
+- `chapter` (int, optional)
+- `tag` (string, optional)
+- `scene_ids` (string[], optional)
+- `strictness` (enum, optional): `warn` (default) | `fail`
+- `include_scene_ids` (boolean, optional, default true)
+- `include_metadata_sidebar` (boolean, optional, default false)
+- `include_paragraph_anchors` (boolean, optional, default false)
+
+Output:
+- `ok` (boolean)
+- `profile`
+- `resolved_scope`:
+  - `project_id`
+  - applied filters
+- `ordering`:
+  - ordered scene references with `scene_id`, `part`, `chapter`, `timeline_position`
+- `summary`:
+  - `scene_count`
+  - `estimated_word_count`
+  - `excluded_scene_ids`
+- `warnings`:
+  - warning list and warning summary buckets
+- `strictness_result`:
+  - `can_proceed` boolean
+  - blocker reasons when `strictness=fail`
+- `planned_outputs`:
+  - output filenames that would be generated
+
+No disk writes are allowed.
+
+### `create_review_bundle`
+
+Purpose: generate markdown review artifacts from the same planning logic.
+
+Input:
+- all `preview_review_bundle` inputs
+- `output_dir` (string, required)
+- `bundle_name` (string, optional)
+- `source_commit` (string, optional): explicit commit hash; if omitted, resolve current HEAD for provenance
+
+Output:
+- `ok` (boolean)
+- `bundle_id` (string)
+- `output_paths`:
+  - `bundle_markdown`
+  - `manifest_json`
+- `summary`:
+  - scene count
+  - profile
+  - applied filters
+- `warnings` and warning summary
+- `provenance`:
+  - commit hash used
+  - generation timestamp
+
+Write behavior:
+- write artifacts only under `output_dir`
+- never modify prose or sidecar source files
+
+## Rendering Rules (M1)
+
+### Shared
+
+1. Deterministic ordering: `part`, `chapter`, `timeline_position`, fallback stable `scene_id` sort.
+2. Header includes profile, project, generation timestamp, and source commit.
+3. Each scene block gets a stable anchor heading.
+4. Absolute local paths are excluded from rendered output.
+
+### `outline_discussion`
+
+1. Include chapter and scene headings.
+2. Include metadata summary line with POV, beat, tags when available.
+3. Include logline by default.
+4. Exclude full prose by default.
+
+### `editor_detailed`
+
+1. Include full prose.
+2. Include optional scene IDs in headings.
+3. Include optional paragraph anchors for comment targeting.
+4. Exclude internal diagnostics and private notes by default.
+
+## Strictness Behavior (M1)
+
+`warn` mode:
+- Generate outputs even with non-fatal issues.
+- Return warnings in response and manifest.
+
+`fail` mode:
+- Abort generation on blockers such as:
+  - stale metadata when profile requires structural reliability
+  - unresolved ordering collisions that cannot be deterministically resolved
+  - missing project scope
+
+## Acceptance Criteria
+
+1. Same input + same source commit produces stable ordering and equivalent markdown structure.
+2. `preview_review_bundle` and `create_review_bundle` share planning logic and return consistent scene resolution.
+3. `outline_discussion` excludes full prose by default.
+4. `editor_detailed` includes full prose and stable section anchors.
+5. `create_review_bundle` never writes outside `output_dir`.
+6. `strictness=fail` blocks and returns actionable reasons.
+7. Manifest always includes commit provenance and warning summary.
+
+## Test Plan
+
+### Unit Tests
+
+1. Filter resolution precedence when `scene_ids` and chapter/part filters are both supplied.
+2. Deterministic ordering fallback behavior.
+3. Profile-level inclusion/exclusion defaults.
+4. Strictness evaluation (`warn` vs `fail`).
+
+### Integration Tests
+
+1. Preview returns expected scene count and planned filenames for a known fixture project.
+2. Create writes exactly expected files under temp output directory.
+3. Outline bundle contains no prose body paragraphs from fixture scenes.
+4. Editor bundle contains prose and scene anchors.
+5. Fail mode blocks generation when fixture is marked metadata-stale.
+6. Manifest captures commit hash and warning summary.
+
+## Risks and Mitigations
+
+1. Risk: implicit scope drift into publishing features.
+   - Mitigation: enforce profile enum and markdown-only output in M1.
+2. Risk: unstable ordering from incomplete metadata.
+   - Mitigation: explicit fallback order + warnings + fail mode.
+3. Risk: leakage of internal notes.
+   - Mitigation: explicit exclusion defaults and regression tests.
+
+## Follow-up Milestones (Not in M1)
+
+1. M2: `beta_reader_personalized` templates (`notice.md`, `feedback-form.md`).
+2. M3: optional async generation for large projects.
+3. M4: optional DOCX adapter.
+
+## Related
+
+- [review-bundles.md](review-bundles.md)
+- [editing.md](../done/editing.md)
+- [search-analysis.md](../done/search-analysis.md)

--- a/docs/prd/todo/review-bundles.md
+++ b/docs/prd/todo/review-bundles.md
@@ -1,0 +1,215 @@
+# Review Bundles for Editorial Workflows
+
+**Status:** 📋 Proposed (Phase 4A)
+
+## Goal
+
+Add deterministic, collaboration-focused manuscript bundle generation for editing workflows without turning mcp-writing into a publishing or typesetting system.
+
+This feature is intentionally scoped to:
+- conceptual discussion bundles (outline-level, low prose density)
+- detailed editorial reading bundles (proofreading/copyediting)
+- personalized beta-reader bundles (with explicit non-distribution framing)
+
+## Product Boundary
+
+This is **not** a final-distribution compiler.
+
+Out of scope:
+- print-ready typography and trim/bleed control
+- retail EPUB optimization
+- full publishing layout controls and style engines
+- replacing Scrivener Compile, Vellum, InDesign, or similar tools
+
+In scope:
+- deterministic assembly from existing scene metadata/prose
+- review-oriented packaging and provenance
+- explicit privacy and sharing controls for editorial circulation
+
+## User Problems
+
+### 1) Conceptual Discussion Without Full Prose
+
+Users need a high-level package of a part or full book for story conversations (structure, pacing, thematic progression) without including all scene prose.
+
+Desired outcome:
+- narrative shape is discussable in meetings/workshops
+- discussion can reference stable scene/chapter anchors
+- prose context is minimized by design
+
+### 2) Detailed Editorial Reading Draft
+
+Users need a prose-heavy editing packet for proofread/copyedit passes with stable references for comments.
+
+Desired outcome:
+- editors can annotate specific sections consistently
+- authors can map feedback back to scene IDs and source files
+- output stays reproducible across revisions
+
+### 3) Personalized Beta-Reader Draft
+
+Users need a targeted bundle for a specific beta reader with explicit "not for distribution" framing and an attached feedback form.
+
+Desired outcome:
+- each recipient gets a context-appropriate packet
+- distribution intent is clear
+- collected feedback is structured and easy to ingest
+
+## Bundle Profiles (Initial)
+
+### `outline_discussion`
+
+Purpose: conceptual discussions.
+
+Default content:
+- chapter/scene ordering
+- titles, loglines, beats, tags, POV, and optional thread markers
+- optional short excerpts (configurable, off by default)
+
+Default exclusions:
+- full scene prose
+- internal diagnostics unless explicitly requested
+
+### `editor_detailed`
+
+Purpose: proofreading/copyediting passes.
+
+Default content:
+- full scene prose in deterministic order
+- chapter and scene anchors (`part/chapter/scene_id`)
+- optional paragraph anchors or line indices
+- optional scene-level metadata sidebar
+
+Default exclusions:
+- private operational notes unless explicitly enabled
+
+### `beta_reader_personalized`
+
+Purpose: guided feedback from a named individual.
+
+Default content:
+- selected prose scope (full project or filtered)
+- cover page with recipient name and usage notice
+- non-distribution notice template (NDA-style language, informational only)
+- attached feedback form template
+
+Default exclusions:
+- internal continuity flags, debug metadata, and process notes
+
+## Functional Requirements (Phase 4A)
+
+1. Generate a bundle from an explicit scope:
+   - `project_id` (required)
+   - optional filters (`part`, `chapter`, `tag`, `scene_ids`)
+2. Require explicit profile selection:
+   - `outline_discussion`, `editor_detailed`, or `beta_reader_personalized`
+3. Produce deterministic ordering based on indexed scene structure.
+4. Emit a manifest with provenance:
+   - source commit hash/snapshot reference
+   - applied filters and profile
+   - included and excluded scene IDs
+   - warnings (for stale metadata, missing ordering fields, etc.)
+5. Support strictness mode:
+   - `warn` (default): produce output with warnings
+   - `fail`: abort when blockers are detected (for example stale metadata)
+6. Keep source files read-only during bundle generation.
+7. Write all artifacts to an output folder outside indexed prose files.
+
+## Output Format (Phase 4A)
+
+Primary output:
+- Markdown bundle (single-file default)
+
+Companion outputs:
+- `manifest.json`
+- `feedback-form.md` (for beta profile)
+- `notice.md` (for beta profile)
+
+Potential extension (not required in Phase 4A):
+- optional DOCX adapter built from the same intermediate representation
+
+## Tool Surface (Proposed)
+
+### `preview_review_bundle`
+
+Dry-run planning tool.
+
+Returns:
+- resolved scene count and ordering
+- inclusion/exclusion summary
+- warnings and strictness impact
+- planned output filenames
+
+### `create_review_bundle`
+
+Execution tool.
+
+Returns:
+- output paths
+- manifest summary
+- warning summary
+- provenance metadata
+
+Optional async counterpart for large projects may be added if generation time becomes significant.
+
+## Privacy, Legal, and Safety Notes
+
+1. Personalized beta bundles must include clear non-distribution language.
+2. NDA text should be template-based and user-editable, with explicit disclaimer that this is not legal advice.
+3. Internal process metadata (`flags`, private notes, diagnostics) is excluded by default.
+4. Bundle generation should avoid embedding machine-local absolute paths in exported files.
+
+## Tradeoffs
+
+### Why this scope is valuable
+
+- closes the loop from editing to shareable review packets
+- improves collaboration without forcing users into external compile tools for every iteration
+- preserves current product identity (reasoning + editing)
+
+### Why this scope is constrained
+
+- avoids becoming a publishing/typesetting surface
+- keeps maintenance burden manageable
+- reduces format-specific rendering regressions
+
+## Edge Cases and Concerns
+
+1. Missing/ambiguous ordering metadata (`part`, `chapter`, `timeline_position`).
+2. Scene sets containing alternates, placeholders, or intentionally hidden draft material.
+3. Metadata staleness: whether to block compile in strict mode.
+4. Multi-project universe exports: keep Phase 4A project-scoped by default.
+5. Anchor stability when prose changes between review rounds.
+6. Accidental leakage of internal notes in beta-reader packets.
+7. Large bundles that exceed practical reviewer consumption size.
+
+## Implementation Path
+
+1. Define intermediate bundle model (ordered sections + rendering metadata).
+2. Implement `preview_review_bundle` (dry-run only).
+3. Implement markdown renderer + manifest writer.
+4. Add profile presets and exclusion defaults.
+5. Add beta profile templates (notice + feedback form).
+6. Add integration tests for deterministic ordering, exclusion rules, and strictness behavior.
+7. Evaluate optional async execution based on observed runtime.
+
+## Rollout
+
+- Phase 4A.1: `outline_discussion` + `editor_detailed` in markdown only
+- Phase 4A.2: `beta_reader_personalized` (notice + feedback form templates)
+- Phase 4A.3: optional DOCX adapter if markdown adoption is strong
+
+## Open Questions
+
+1. Should we support multi-file chapter bundles in Phase 4A, or only single-file output?
+2. Should paragraph anchors be generated as deterministic IDs or positional counters?
+3. Should `fail` strictness block on stale metadata only, or also on missing ordering fields?
+4. How much profile customization is allowed before this becomes a template system?
+5. Should feedback form schema be fixed, or profile-configurable with limited fields?
+
+## Related
+
+- [editing.md](../done/editing.md) — Prose editing and git-backed provenance
+- [search-analysis.md](../done/search-analysis.md) — Metadata-first retrieval model
+- [reference-docs.md](reference-docs.md) — Adjacent Phase 4 querying work
+- [review-bundles-implementation.md](review-bundles-implementation.md) — Phase 4A.1 implementation checklist and tool contracts

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -14,6 +14,7 @@
 - [`list_async_jobs`](#list_async_jobs)
 - [`cancel_async_job`](#cancel_async_job)
 - [`get_runtime_config`](#get_runtime_config)
+- [`preview_review_bundle`](#preview_review_bundle)
 - [`find_scenes`](#find_scenes)
 - [`get_scene_prose`](#get_scene_prose)
 - [`get_chapter_prose`](#get_chapter_prose)
@@ -150,6 +151,26 @@ Cancel a running asynchronous job. Use this when an import/merge/batch run was s
 Show the active runtime paths and capabilities for this server instance (sync dir, database path, writability, permission diagnostics, and git availability). Use this to verify which manuscript location is currently connected.
 
 _No parameters._
+
+---
+
+## preview_review_bundle
+
+Dry-run planning tool for review bundles. Resolves scene scope, deterministic ordering, warnings, and planned output filenames without writing files.
+
+| Parameter | Type | Required | Description |
+| --- | --- | :---: | --- |
+| `project_id` | `string` | Yes | Project ID to scope the review bundle (e.g. 'test-novel'). |
+| `profile` | `enum` | Yes | Bundle profile: outline_discussion or editor_detailed. |
+| `part` | `integer` | No | Optional part filter. |
+| `chapter` | `integer` | No | Optional chapter filter. |
+| `tag` | `string` | No | Optional tag filter (exact match). |
+| `scene_ids` | `string[]` | No | Optional explicit scene_id allowlist. Intersects with other filters. |
+| `strictness` | `enum` | No | Strictness mode: warn (default) or fail. |
+| `include_scene_ids` | `boolean` | No | Include scene IDs in planned output structure (default true). |
+| `include_metadata_sidebar` | `boolean` | No | Include metadata sidebar in profile-aware output planning (default false). |
+| `include_paragraph_anchors` | `boolean` | No | Include paragraph anchors in profile-aware output planning (default false). |
+| `bundle_name` | `string` | No | Optional output bundle base name override (slugified in planned outputs). |
 
 ---
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -156,7 +156,7 @@ _No parameters._
 
 ## preview_review_bundle
 
-Dry-run planning tool for review bundles. Resolves scene scope, deterministic ordering, warnings, and planned output filenames without writing files.
+Dry-run planning tool for review bundles. Resolves scene scope, deterministic ordering, warnings, and planned output filenames without writing files. Note: include_scene_ids/include_metadata_sidebar/include_paragraph_anchors are advisory placeholders in Phase 4A.1 and do not alter planning semantics yet.
 
 | Parameter | Type | Required | Description |
 | --- | --- | :---: | --- |
@@ -167,9 +167,9 @@ Dry-run planning tool for review bundles. Resolves scene scope, deterministic or
 | `tag` | `string` | No | Optional tag filter (exact match). |
 | `scene_ids` | `string[]` | No | Optional explicit scene_id allowlist. Intersects with other filters. |
 | `strictness` | `enum` | No | Strictness mode: warn (default) or fail. |
-| `include_scene_ids` | `boolean` | No | Include scene IDs in planned output structure (default true). |
-| `include_metadata_sidebar` | `boolean` | No | Include metadata sidebar in profile-aware output planning (default false). |
-| `include_paragraph_anchors` | `boolean` | No | Include paragraph anchors in profile-aware output planning (default false). |
+| `include_scene_ids` | `boolean` | No | Advisory placeholder for later rendering behavior (default true). Included in preview output options, but does not change planning results in Phase 4A.1. |
+| `include_metadata_sidebar` | `boolean` | No | Advisory placeholder for later rendering behavior (default false). Included in preview output options, but does not change planning results in Phase 4A.1. |
+| `include_paragraph_anchors` | `boolean` | No | Advisory placeholder for later rendering behavior (default false). Included in preview output options, but does not change planning results in Phase 4A.1. |
 | `bundle_name` | `string` | No | Optional output bundle base name override (slugified in planned outputs). |
 
 ---

--- a/index.js
+++ b/index.js
@@ -17,6 +17,12 @@ import { isGitAvailable, isGitRepository, initGitRepository, createSnapshot, lis
 import { renderCharacterArcTemplate, renderCharacterSheetTemplate, renderPlaceSheetTemplate, slugifyEntityName } from "./world-entity-templates.js";
 import { importScrivenerSync, validateProjectId } from "./importer.js";
 import { ASYNC_PROGRESS_PREFIX } from "./async-progress.js";
+import {
+  REVIEW_BUNDLE_PROFILES,
+  REVIEW_BUNDLE_STRICTNESS,
+  ReviewBundlePlanError,
+  buildReviewBundlePlan,
+} from "./review-bundles.js";
 
 const SYNC_DIR = process.env.WRITING_SYNC_DIR ?? "./sync";
 const DB_PATH = process.env.DB_PATH ?? "./writing.db";
@@ -1295,6 +1301,68 @@ function createMcpServer() {
         runtime_warnings: RUNTIME_DIAGNOSTICS.warnings,
         setup_recommendations: RUNTIME_DIAGNOSTICS.recommendations,
       });
+    }
+  );
+
+  // ---- preview_review_bundle ----------------------------------------------
+  s.tool(
+    "preview_review_bundle",
+    "Dry-run planning tool for review bundles. Resolves scene scope, deterministic ordering, warnings, and planned output filenames without writing files.",
+    {
+      project_id: z.string().describe("Project ID to scope the review bundle (e.g. 'test-novel')."),
+      profile: z.enum(REVIEW_BUNDLE_PROFILES).describe("Bundle profile: outline_discussion or editor_detailed."),
+      part: z.number().int().optional().describe("Optional part filter."),
+      chapter: z.number().int().optional().describe("Optional chapter filter."),
+      tag: z.string().optional().describe("Optional tag filter (exact match)."),
+      scene_ids: z.array(z.string()).optional().describe("Optional explicit scene_id allowlist. Intersects with other filters."),
+      strictness: z.enum(REVIEW_BUNDLE_STRICTNESS).optional().describe("Strictness mode: warn (default) or fail."),
+      include_scene_ids: z.boolean().optional().describe("Include scene IDs in planned output structure (default true)."),
+      include_metadata_sidebar: z.boolean().optional().describe("Include metadata sidebar in profile-aware output planning (default false)."),
+      include_paragraph_anchors: z.boolean().optional().describe("Include paragraph anchors in profile-aware output planning (default false)."),
+      bundle_name: z.string().optional().describe("Optional output bundle base name override (slugified in planned outputs)."),
+    },
+    async ({
+      project_id,
+      profile,
+      part,
+      chapter,
+      tag,
+      scene_ids,
+      strictness = "warn",
+      include_scene_ids = true,
+      include_metadata_sidebar = false,
+      include_paragraph_anchors = false,
+      bundle_name,
+    }) => {
+      const projectIdCheck = validateProjectId(project_id);
+      if (!projectIdCheck.ok) {
+        return errorResponse("INVALID_PROJECT_ID", projectIdCheck.reason, { project_id });
+      }
+
+      try {
+        const plan = buildReviewBundlePlan(db, {
+          project_id,
+          profile,
+          part,
+          chapter,
+          tag,
+          scene_ids,
+          strictness,
+          include_scene_ids,
+          include_metadata_sidebar,
+          include_paragraph_anchors,
+          bundle_name,
+        });
+        return jsonResponse(plan);
+      } catch (error) {
+        if (error instanceof ReviewBundlePlanError) {
+          return errorResponse(error.code, error.message, error.details);
+        }
+        return errorResponse(
+          "PREVIEW_FAILED",
+          error instanceof Error ? error.message : "Failed to generate review bundle preview."
+        );
+      }
     }
   );
 

--- a/index.js
+++ b/index.js
@@ -1307,7 +1307,7 @@ function createMcpServer() {
   // ---- preview_review_bundle ----------------------------------------------
   s.tool(
     "preview_review_bundle",
-    "Dry-run planning tool for review bundles. Resolves scene scope, deterministic ordering, warnings, and planned output filenames without writing files.",
+    "Dry-run planning tool for review bundles. Resolves scene scope, deterministic ordering, warnings, and planned output filenames without writing files. Note: include_scene_ids/include_metadata_sidebar/include_paragraph_anchors are advisory placeholders in Phase 4A.1 and do not alter planning semantics yet.",
     {
       project_id: z.string().describe("Project ID to scope the review bundle (e.g. 'test-novel')."),
       profile: z.enum(REVIEW_BUNDLE_PROFILES).describe("Bundle profile: outline_discussion or editor_detailed."),
@@ -1316,9 +1316,9 @@ function createMcpServer() {
       tag: z.string().optional().describe("Optional tag filter (exact match)."),
       scene_ids: z.array(z.string()).optional().describe("Optional explicit scene_id allowlist. Intersects with other filters."),
       strictness: z.enum(REVIEW_BUNDLE_STRICTNESS).optional().describe("Strictness mode: warn (default) or fail."),
-      include_scene_ids: z.boolean().optional().describe("Include scene IDs in planned output structure (default true)."),
-      include_metadata_sidebar: z.boolean().optional().describe("Include metadata sidebar in profile-aware output planning (default false)."),
-      include_paragraph_anchors: z.boolean().optional().describe("Include paragraph anchors in profile-aware output planning (default false)."),
+      include_scene_ids: z.boolean().optional().describe("Advisory placeholder for later rendering behavior (default true). Included in preview output options, but does not change planning results in Phase 4A.1."),
+      include_metadata_sidebar: z.boolean().optional().describe("Advisory placeholder for later rendering behavior (default false). Included in preview output options, but does not change planning results in Phase 4A.1."),
+      include_paragraph_anchors: z.boolean().optional().describe("Advisory placeholder for later rendering behavior (default false). Included in preview output options, but does not change planning results in Phase 4A.1."),
       bundle_name: z.string().optional().describe("Optional output bundle base name override (slugified in planned outputs)."),
     },
     async ({

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "git.js",
     "world-entity-templates.js",
     "metadata-lint.js",
+    "review-bundles.js",
     "scripts/",
     "README.md",
     "CHANGELOG.md"

--- a/review-bundles.js
+++ b/review-bundles.js
@@ -1,0 +1,290 @@
+const MAX_SORT_VALUE = Number.MAX_SAFE_INTEGER;
+
+export const REVIEW_BUNDLE_PROFILES = ["outline_discussion", "editor_detailed"];
+export const REVIEW_BUNDLE_STRICTNESS = ["warn", "fail"];
+
+export class ReviewBundlePlanError extends Error {
+  constructor(code, message, details) {
+    super(message);
+    this.name = "ReviewBundlePlanError";
+    this.code = code;
+    this.details = details;
+  }
+}
+
+function normalizeSortNumber(value) {
+  return Number.isInteger(value) ? value : MAX_SORT_VALUE;
+}
+
+function sceneSort(a, b) {
+  const partDiff = normalizeSortNumber(a.part) - normalizeSortNumber(b.part);
+  if (partDiff !== 0) return partDiff;
+
+  const chapterDiff = normalizeSortNumber(a.chapter) - normalizeSortNumber(b.chapter);
+  if (chapterDiff !== 0) return chapterDiff;
+
+  const timelineDiff = normalizeSortNumber(a.timeline_position) - normalizeSortNumber(b.timeline_position);
+  if (timelineDiff !== 0) return timelineDiff;
+
+  return String(a.scene_id).localeCompare(String(b.scene_id));
+}
+
+function buildWarningSummary(warnings) {
+  const summary = {};
+  for (const warning of warnings) {
+    const type = warning.type ?? "unknown";
+    if (!summary[type]) {
+      summary[type] = { count: 0, examples: [] };
+    }
+    summary[type].count += 1;
+    if (summary[type].examples.length < 5) {
+      summary[type].examples.push(warning.message);
+    }
+  }
+  return summary;
+}
+
+function slugifyBundleName(value) {
+  const slug = String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug || "review-bundle";
+}
+
+function assertProfile(profile) {
+  if (!REVIEW_BUNDLE_PROFILES.includes(profile)) {
+    throw new ReviewBundlePlanError(
+      "INVALID_PROFILE",
+      `Unsupported review bundle profile '${profile}'.`,
+      { supported_profiles: REVIEW_BUNDLE_PROFILES }
+    );
+  }
+}
+
+function assertStrictness(strictness) {
+  if (!REVIEW_BUNDLE_STRICTNESS.includes(strictness)) {
+    throw new ReviewBundlePlanError(
+      "INVALID_STRICTNESS",
+      `Unsupported strictness '${strictness}'.`,
+      { supported_strictness: REVIEW_BUNDLE_STRICTNESS }
+    );
+  }
+}
+
+function resolveRequestedSceneIds(dbHandle, projectId, sceneIds) {
+  if (!Array.isArray(sceneIds) || sceneIds.length === 0) {
+    return { requested: [], existing: new Set() };
+  }
+
+  const placeholders = sceneIds.map(() => "?").join(",");
+  const rows = dbHandle.prepare(
+    `SELECT scene_id FROM scenes WHERE project_id = ? AND scene_id IN (${placeholders})`
+  ).all(projectId, ...sceneIds);
+
+  return {
+    requested: sceneIds,
+    existing: new Set(rows.map(row => row.scene_id)),
+  };
+}
+
+export function buildReviewBundlePlan(dbHandle, {
+  project_id,
+  profile,
+  part,
+  chapter,
+  tag,
+  scene_ids,
+  strictness = "warn",
+  include_scene_ids = true,
+  include_metadata_sidebar = false,
+  include_paragraph_anchors = false,
+  bundle_name,
+} = {}) {
+  if (!project_id) {
+    throw new ReviewBundlePlanError("INVALID_PROJECT_ID", "project_id is required.");
+  }
+
+  assertProfile(profile);
+  assertStrictness(strictness);
+
+  const projectRow = dbHandle.prepare(`SELECT project_id FROM projects WHERE project_id = ?`).get(project_id);
+  if (!projectRow) {
+    throw new ReviewBundlePlanError("NOT_FOUND", `Project '${project_id}' not found.`);
+  }
+
+  const requestedSceneIds = resolveRequestedSceneIds(dbHandle, project_id, scene_ids);
+  const conditions = ["s.project_id = ?"];
+  const params = [project_id];
+  const joins = [];
+
+  if (tag) {
+    joins.push("JOIN scene_tags st ON st.scene_id = s.scene_id AND st.tag = ?");
+    params.push(tag);
+  }
+  if (Array.isArray(scene_ids) && scene_ids.length > 0) {
+    const placeholders = scene_ids.map(() => "?").join(",");
+    conditions.push(`s.scene_id IN (${placeholders})`);
+    params.push(...scene_ids);
+  }
+  if (part !== undefined) {
+    conditions.push("s.part = ?");
+    params.push(part);
+  }
+  if (chapter !== undefined) {
+    conditions.push("s.chapter = ?");
+    params.push(chapter);
+  }
+
+  let query = `
+    SELECT DISTINCT
+      s.scene_id,
+      s.project_id,
+      s.title,
+      s.part,
+      s.chapter,
+      s.timeline_position,
+      s.word_count,
+      s.logline,
+      s.pov,
+      s.save_the_cat_beat,
+      s.metadata_stale
+    FROM scenes s
+  `;
+
+  if (joins.length > 0) {
+    query += ` ${joins.join(" ")}`;
+  }
+  query += ` WHERE ${conditions.join(" AND ")}`;
+
+  const rows = dbHandle.prepare(query).all(...params).sort(sceneSort);
+  if (rows.length === 0) {
+    throw new ReviewBundlePlanError(
+      "NO_RESULTS",
+      "No scenes matched the requested review bundle scope.",
+      {
+        project_id,
+        filters: {
+          ...(part !== undefined ? { part } : {}),
+          ...(chapter !== undefined ? { chapter } : {}),
+          ...(tag ? { tag } : {}),
+          ...(Array.isArray(scene_ids) ? { scene_ids } : {}),
+        },
+      }
+    );
+  }
+
+  const includedSceneIds = new Set(rows.map(row => row.scene_id));
+  const excludedSceneIds = requestedSceneIds.requested.filter(sceneId => !includedSceneIds.has(sceneId));
+  const notFoundSceneIds = requestedSceneIds.requested.filter(sceneId => !requestedSceneIds.existing.has(sceneId));
+  const filteredOutSceneIds = excludedSceneIds.filter(sceneId => requestedSceneIds.existing.has(sceneId));
+
+  const warnings = [];
+
+  if (notFoundSceneIds.length > 0) {
+    warnings.push({
+      type: "requested_scene_ids_not_found",
+      message: `${notFoundSceneIds.length} requested scene_id value(s) do not exist in project '${project_id}'.`,
+      scene_ids: notFoundSceneIds,
+    });
+  }
+
+  if (filteredOutSceneIds.length > 0) {
+    warnings.push({
+      type: "requested_scene_ids_filtered_out",
+      message: `${filteredOutSceneIds.length} requested scene_id value(s) were excluded by additional filters.`,
+      scene_ids: filteredOutSceneIds,
+    });
+  }
+
+  const staleRows = rows.filter(row => Number(row.metadata_stale) === 1);
+  if (staleRows.length > 0) {
+    warnings.push({
+      type: "metadata_stale",
+      message: `${staleRows.length} scene(s) have stale metadata and may need re-enrichment before editorial use.`,
+      count: staleRows.length,
+    });
+  }
+
+  const missingOrderingRows = rows.filter(
+    row => row.part == null || row.chapter == null || row.timeline_position == null
+  );
+  if (missingOrderingRows.length > 0) {
+    warnings.push({
+      type: "missing_ordering_fields",
+      message: `${missingOrderingRows.length} scene(s) are missing part/chapter/timeline_position metadata; fallback ordering was applied.`,
+      count: missingOrderingRows.length,
+    });
+  }
+
+  const missingWordCountRows = rows.filter(row => row.word_count == null);
+  if (missingWordCountRows.length > 0) {
+    warnings.push({
+      type: "missing_word_count",
+      message: `${missingWordCountRows.length} scene(s) are missing word_count; estimated_word_count may be low.`,
+      count: missingWordCountRows.length,
+    });
+  }
+
+  const blockers = [];
+  if (strictness === "fail" && staleRows.length > 0) {
+    blockers.push({
+      code: "STALE_METADATA",
+      message: `${staleRows.length} scene(s) are marked metadata_stale.`,
+      scene_ids: staleRows.map(row => row.scene_id),
+    });
+  }
+
+  const estimatedWordCount = rows.reduce((sum, row) => {
+    const count = Number(row.word_count);
+    return sum + (Number.isFinite(count) ? count : 0);
+  }, 0);
+
+  const safeBundleName = slugifyBundleName(bundle_name || `${project_id}-${profile}`);
+  const appliedFilters = {
+    ...(part !== undefined ? { part } : {}),
+    ...(chapter !== undefined ? { chapter } : {}),
+    ...(tag ? { tag } : {}),
+    ...(Array.isArray(scene_ids) ? { scene_ids } : {}),
+  };
+
+  return {
+    ok: true,
+    profile,
+    resolved_scope: {
+      project_id,
+      filters: appliedFilters,
+      options: {
+        include_scene_ids: Boolean(include_scene_ids),
+        include_metadata_sidebar: Boolean(include_metadata_sidebar),
+        include_paragraph_anchors: Boolean(include_paragraph_anchors),
+      },
+    },
+    ordering: rows.map(row => ({
+      scene_id: row.scene_id,
+      project_id: row.project_id,
+      title: row.title,
+      part: row.part,
+      chapter: row.chapter,
+      timeline_position: row.timeline_position,
+      metadata_stale: Number(row.metadata_stale) === 1,
+    })),
+    summary: {
+      scene_count: rows.length,
+      estimated_word_count: estimatedWordCount,
+      excluded_scene_ids: excludedSceneIds,
+    },
+    warnings,
+    warning_summary: buildWarningSummary(warnings),
+    strictness_result: {
+      strictness,
+      can_proceed: blockers.length === 0,
+      blockers,
+    },
+    planned_outputs: [
+      `${safeBundleName}.md`,
+      `${safeBundleName}.manifest.json`,
+    ],
+  };
+}

--- a/test/integration.test.mjs
+++ b/test/integration.test.mjs
@@ -1708,6 +1708,57 @@ describe("find_scenes tool", () => {
   });
 });
 
+describe("preview_review_bundle tool", () => {
+  test("returns dry-run plan for outline profile", async () => {
+    const text = await callTool("preview_review_bundle", {
+      project_id: "test-novel",
+      profile: "outline_discussion",
+    });
+    const parsed = JSON.parse(text);
+
+    assert.equal(parsed.ok, true);
+    assert.equal(parsed.profile, "outline_discussion");
+    assert.equal(parsed.summary.scene_count, 3);
+    assert.equal(parsed.strictness_result.can_proceed, true);
+    assert.ok(Array.isArray(parsed.planned_outputs));
+    assert.ok(parsed.planned_outputs.some(name => name.endsWith(".md")));
+    assert.ok(parsed.planned_outputs.some(name => name.endsWith(".manifest.json")));
+  });
+
+  test("applies scene_ids as intersection with other filters", async () => {
+    const text = await callTool("preview_review_bundle", {
+      project_id: "test-novel",
+      profile: "outline_discussion",
+      chapter: 1,
+      scene_ids: ["sc-001", "sc-003"],
+    });
+    const parsed = JSON.parse(text);
+
+    assert.equal(parsed.ok, true);
+    assert.equal(parsed.summary.scene_count, 1);
+    assert.deepEqual(parsed.ordering.map(row => row.scene_id), ["sc-001"]);
+    assert.deepEqual(parsed.summary.excluded_scene_ids, ["sc-003"]);
+  });
+
+  test("strictness fail reports blockers when stale metadata exists", async () => {
+    const scenePath = path.join(writeSyncDir, "projects", "test-novel", "part-1", "chapter-1", "sc-001.md");
+    const before = fs.readFileSync(scenePath, "utf8");
+    fs.writeFileSync(scenePath, `${before}\n\nStale marker line for review bundle strictness test.\n`, "utf8");
+    await callWriteTool("sync");
+
+    const text = await callWriteTool("preview_review_bundle", {
+      project_id: "test-novel",
+      profile: "editor_detailed",
+      strictness: "fail",
+    });
+    const parsed = JSON.parse(text);
+
+    assert.equal(parsed.ok, true);
+    assert.equal(parsed.strictness_result.can_proceed, false);
+    assert.ok(parsed.strictness_result.blockers.some(blocker => blocker.code === "STALE_METADATA"));
+  });
+});
+
 describe("get_scene_prose tool", () => {
   test("returns prose content for sc-001", async () => {
     const text = await callTool("get_scene_prose", { scene_id: "sc-001" });

--- a/test/unit.test.mjs
+++ b/test/unit.test.mjs
@@ -33,6 +33,53 @@ import {
   mergeSidecarData,
 } from "../scrivener-direct.js";
 import { runSceneCharacterBatch } from "../scene-character-batch.js";
+import { buildReviewBundlePlan } from "../review-bundles.js";
+
+function insertTestScene(db, {
+  sceneId,
+  projectId = "test-novel",
+  title = null,
+  part = null,
+  chapter = null,
+  timelinePosition = null,
+  metadataStale = 0,
+  wordCount = null,
+}) {
+  const now = new Date().toISOString();
+  db.prepare(`
+    INSERT INTO scenes (
+      scene_id,
+      project_id,
+      title,
+      part,
+      chapter,
+      timeline_position,
+      word_count,
+      file_path,
+      prose_checksum,
+      metadata_stale,
+      updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    sceneId,
+    projectId,
+    title,
+    part,
+    chapter,
+    timelinePosition,
+    wordCount,
+    `/tmp/${sceneId}.md`,
+    "deadbeef",
+    metadataStale,
+    now
+  );
+}
+
+function setupReviewBundleTestDb() {
+  const db = openDb(":memory:");
+  db.prepare(`INSERT INTO projects (project_id, universe_id, name) VALUES (?, ?, ?)`).run("test-novel", null, "Test Novel");
+  return db;
+}
 
 // ---------------------------------------------------------------------------
 // checksumProse
@@ -49,6 +96,108 @@ describe("checksumProse", () => {
   test("returns a non-empty hex string", () => {
     const result = checksumProse("some prose");
     assert.match(result, /^[0-9a-f]+$/);
+  });
+});
+
+describe("buildReviewBundlePlan", () => {
+  test("orders scenes deterministically with timeline and scene_id fallback", () => {
+    const db = setupReviewBundleTestDb();
+    try {
+      insertTestScene(db, {
+        sceneId: "sc-002",
+        part: 1,
+        chapter: 1,
+        timelinePosition: 1,
+        wordCount: 400,
+      });
+      insertTestScene(db, {
+        sceneId: "sc-001",
+        part: 1,
+        chapter: 1,
+        timelinePosition: null,
+        wordCount: 500,
+      });
+      insertTestScene(db, {
+        sceneId: "sc-003",
+        part: 1,
+        chapter: 2,
+        timelinePosition: 1,
+        wordCount: 300,
+      });
+
+      const plan = buildReviewBundlePlan(db, {
+        project_id: "test-novel",
+        profile: "outline_discussion",
+      });
+
+      assert.equal(plan.ok, true);
+      assert.deepEqual(
+        plan.ordering.map(row => row.scene_id),
+        ["sc-002", "sc-001", "sc-003"]
+      );
+      assert.equal(plan.summary.estimated_word_count, 1200);
+      assert.ok(plan.warning_summary.missing_ordering_fields);
+    } finally {
+      db.close();
+    }
+  });
+
+  test("applies scene_ids as intersection with chapter filter", () => {
+    const db = setupReviewBundleTestDb();
+    try {
+      insertTestScene(db, {
+        sceneId: "sc-001",
+        part: 1,
+        chapter: 1,
+        timelinePosition: 1,
+        wordCount: 300,
+      });
+      insertTestScene(db, {
+        sceneId: "sc-003",
+        part: 1,
+        chapter: 2,
+        timelinePosition: 1,
+        wordCount: 350,
+      });
+
+      const plan = buildReviewBundlePlan(db, {
+        project_id: "test-novel",
+        profile: "outline_discussion",
+        chapter: 1,
+        scene_ids: ["sc-001", "sc-003"],
+      });
+
+      assert.deepEqual(plan.ordering.map(row => row.scene_id), ["sc-001"]);
+      assert.deepEqual(plan.summary.excluded_scene_ids, ["sc-003"]);
+      assert.ok(plan.warning_summary.requested_scene_ids_filtered_out);
+    } finally {
+      db.close();
+    }
+  });
+
+  test("strictness fail blocks when stale scenes are included", () => {
+    const db = setupReviewBundleTestDb();
+    try {
+      insertTestScene(db, {
+        sceneId: "sc-001",
+        part: 1,
+        chapter: 1,
+        timelinePosition: 1,
+        metadataStale: 1,
+      });
+
+      const plan = buildReviewBundlePlan(db, {
+        project_id: "test-novel",
+        profile: "editor_detailed",
+        strictness: "fail",
+      });
+
+      assert.equal(plan.strictness_result.can_proceed, false);
+      assert.equal(plan.strictness_result.blockers[0].code, "STALE_METADATA");
+      assert.ok(plan.warning_summary.metadata_stale);
+    } finally {
+      db.close();
+    }
   });
 });
 


### PR DESCRIPTION
**What changed:**
- Added the `preview_review_bundle` tool to the server.
- Implemented the `planner` module to handle review bundle logic.
- Added comprehensive tests for the new functionality.
- Regenerated documentation to reflect these changes.

**Why:**
To provide users with a way to preview and review bundles before finalization, improving the reliability and transparency of the MCP writing process.

**Review focus:**
- The logic in the new `planner` module.
- Integration of `preview_review_bundle` in the server.
- Coverage and accuracy of the new tests.

**Testing:**
- Ran existing test suite to ensure no regressions.
- Added new unit and integration tests for the planner and the tool.
- Verified document regeneration output.
