### PR TITLE
feat: add create_review_bundle markdown artifact generation

### DIFF
--- a/docs/prd/todo/review-bundles-implementation.md
+++ b/docs/prd/todo/review-bundles-implementation.md
@@ -171,7 +171,7 @@ Write behavior:
 
 1. M2: `beta_reader_personalized` templates (`notice.md`, `feedback-form.md`).
 2. M3: optional async generation for large projects.
-3. M4: optional DOCX adapter.
+3. M4: optional DOCX/PDF adapters.
 
 ## Related
 

--- a/docs/prd/todo/review-bundles.md
+++ b/docs/prd/todo/review-bundles.md
@@ -125,8 +125,9 @@ Companion outputs:
 - `feedback-form.md` (for beta profile)
 - `notice.md` (for beta profile)
 
-Potential extension (not required in Phase 4A):
+Potential extensions (not required in Phase 4A):
 - optional DOCX adapter built from the same intermediate representation
+- optional PDF adapter built from the same intermediate representation
 
 ## Tool Surface (Proposed)
 
@@ -197,7 +198,7 @@ Optional async counterpart for large projects may be added if generation time be
 
 - Phase 4A.1: `outline_discussion` + `editor_detailed` in markdown only
 - Phase 4A.2: `beta_reader_personalized` (notice + feedback form templates)
-- Phase 4A.3: optional DOCX adapter if markdown adoption is strong
+- Phase 4A.3: optional DOCX/PDF adapters if markdown adoption is strong
 
 ## Open Questions
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -15,6 +15,7 @@
 - [`cancel_async_job`](#cancel_async_job)
 - [`get_runtime_config`](#get_runtime_config)
 - [`preview_review_bundle`](#preview_review_bundle)
+- [`create_review_bundle`](#create_review_bundle)
 - [`find_scenes`](#find_scenes)
 - [`get_scene_prose`](#get_scene_prose)
 - [`get_chapter_prose`](#get_chapter_prose)
@@ -171,6 +172,28 @@ Dry-run planning tool for review bundles. Resolves scene scope, deterministic or
 | `include_metadata_sidebar` | `boolean` | No | Advisory placeholder for later rendering behavior (default false). Included in preview output options, but does not change planning results in Phase 4A.1. |
 | `include_paragraph_anchors` | `boolean` | No | Advisory placeholder for later rendering behavior (default false). Included in preview output options, but does not change planning results in Phase 4A.1. |
 | `bundle_name` | `string` | No | Optional output bundle base name override (slugified in planned outputs). |
+
+---
+
+## create_review_bundle
+
+Generate markdown review bundle artifacts from planned scene scope. Writes files only under output_dir and returns manifest/provenance details.
+
+| Parameter | Type | Required | Description |
+| --- | --- | :---: | --- |
+| `project_id` | `string` | Yes | Project ID to scope the review bundle (e.g. 'test-novel'). |
+| `profile` | `enum` | Yes | Bundle profile: outline_discussion or editor_detailed. |
+| `output_dir` | `string` | Yes | Directory path to write bundle artifacts into. |
+| `part` | `integer` | No | Optional part filter. |
+| `chapter` | `integer` | No | Optional chapter filter. |
+| `tag` | `string` | No | Optional tag filter (exact match). |
+| `scene_ids` | `string[]` | No | Optional explicit scene_id allowlist. Intersects with other filters. |
+| `strictness` | `enum` | No | Strictness mode: warn (default) or fail. |
+| `include_scene_ids` | `boolean` | No | Include scene IDs in markdown headings (default true). |
+| `include_metadata_sidebar` | `boolean` | No | Include metadata sidebar in markdown output (default false). |
+| `include_paragraph_anchors` | `boolean` | No | Include paragraph anchors in markdown output (default false). |
+| `bundle_name` | `string` | No | Optional output bundle base name override (slugified in filenames). |
+| `source_commit` | `string` | No | Optional explicit source commit for provenance. Defaults to current HEAD when available. |
 
 ---
 

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ import yaml from "js-yaml";
 import { z } from "zod";
 import { openDb } from "./db.js";
 import { syncAll, isSyncDirWritable, getSyncOwnershipDiagnostics, getFileWriteDiagnostics, writeMeta, readMeta, indexSceneFile, normalizeSceneMetaForPath, sidecarPath } from "./sync.js";
-import { isGitAvailable, isGitRepository, initGitRepository, createSnapshot, listSnapshots, getSceneProseAtCommit } from "./git.js";
+import { isGitAvailable, isGitRepository, initGitRepository, createSnapshot, listSnapshots, getSceneProseAtCommit, getHeadCommitHash } from "./git.js";
 import { renderCharacterArcTemplate, renderCharacterSheetTemplate, renderPlaceSheetTemplate, slugifyEntityName } from "./world-entity-templates.js";
 import { importScrivenerSync, validateProjectId } from "./importer.js";
 import { ASYNC_PROGRESS_PREFIX } from "./async-progress.js";
@@ -22,6 +22,7 @@ import {
   REVIEW_BUNDLE_STRICTNESS,
   ReviewBundlePlanError,
   buildReviewBundlePlan,
+  createReviewBundleArtifacts,
 } from "./review-bundles.js";
 
 const SYNC_DIR = process.env.WRITING_SYNC_DIR ?? "./sync";
@@ -1361,6 +1362,104 @@ function createMcpServer() {
         return errorResponse(
           "PREVIEW_FAILED",
           error instanceof Error ? error.message : "Failed to generate review bundle preview."
+        );
+      }
+    }
+  );
+
+  // ---- create_review_bundle -----------------------------------------------
+  s.tool(
+    "create_review_bundle",
+    "Generate markdown review bundle artifacts from planned scene scope. Writes files only under output_dir and returns manifest/provenance details.",
+    {
+      project_id: z.string().describe("Project ID to scope the review bundle (e.g. 'test-novel')."),
+      profile: z.enum(REVIEW_BUNDLE_PROFILES).describe("Bundle profile: outline_discussion or editor_detailed."),
+      output_dir: z.string().describe("Directory path to write bundle artifacts into."),
+      part: z.number().int().optional().describe("Optional part filter."),
+      chapter: z.number().int().optional().describe("Optional chapter filter."),
+      tag: z.string().optional().describe("Optional tag filter (exact match)."),
+      scene_ids: z.array(z.string()).optional().describe("Optional explicit scene_id allowlist. Intersects with other filters."),
+      strictness: z.enum(REVIEW_BUNDLE_STRICTNESS).optional().describe("Strictness mode: warn (default) or fail."),
+      include_scene_ids: z.boolean().optional().describe("Include scene IDs in markdown headings (default true)."),
+      include_metadata_sidebar: z.boolean().optional().describe("Include metadata sidebar in markdown output (default false)."),
+      include_paragraph_anchors: z.boolean().optional().describe("Include paragraph anchors in markdown output (default false)."),
+      bundle_name: z.string().optional().describe("Optional output bundle base name override (slugified in filenames)."),
+      source_commit: z.string().optional().describe("Optional explicit source commit for provenance. Defaults to current HEAD when available."),
+    },
+    async ({
+      project_id,
+      profile,
+      output_dir,
+      part,
+      chapter,
+      tag,
+      scene_ids,
+      strictness = "warn",
+      include_scene_ids = true,
+      include_metadata_sidebar = false,
+      include_paragraph_anchors = false,
+      bundle_name,
+      source_commit,
+    }) => {
+      const projectIdCheck = validateProjectId(project_id);
+      if (!projectIdCheck.ok) {
+        return errorResponse("INVALID_PROJECT_ID", projectIdCheck.reason, { project_id });
+      }
+
+      try {
+        const plan = buildReviewBundlePlan(db, {
+          project_id,
+          profile,
+          part,
+          chapter,
+          tag,
+          scene_ids,
+          strictness,
+          include_scene_ids,
+          include_metadata_sidebar,
+          include_paragraph_anchors,
+          bundle_name,
+        });
+
+        if (!plan.strictness_result.can_proceed) {
+          return errorResponse(
+            "STRICTNESS_BLOCKED",
+            "Bundle generation blocked by strictness policy.",
+            { strictness_result: plan.strictness_result, warning_summary: plan.warning_summary }
+          );
+        }
+
+        const provenanceCommit = source_commit ?? getHeadCommitHash(SYNC_DIR);
+        const artifacts = createReviewBundleArtifacts(db, {
+          plan,
+          output_dir,
+          source_commit: provenanceCommit,
+        });
+
+        return jsonResponse({
+          ok: true,
+          bundle_id: artifacts.bundle_id,
+          output_paths: artifacts.output_paths,
+          summary: {
+            scene_count: plan.summary.scene_count,
+            profile: plan.profile,
+            applied_filters: plan.resolved_scope.filters,
+          },
+          warnings: plan.warnings,
+          warning_summary: plan.warning_summary,
+          provenance: {
+            source_commit: provenanceCommit,
+            generated_at: artifacts.generated_at,
+            project_id: plan.resolved_scope.project_id,
+          },
+        });
+      } catch (error) {
+        if (error instanceof ReviewBundlePlanError) {
+          return errorResponse(error.code, error.message, error.details);
+        }
+        return errorResponse(
+          "CREATE_BUNDLE_FAILED",
+          error instanceof Error ? error.message : "Failed to create review bundle artifacts."
         );
       }
     }

--- a/index.js
+++ b/index.js
@@ -1479,6 +1479,7 @@ function createMcpServer() {
           plan,
           output_dir: resolvedOutputDir,
           source_commit: provenanceCommit,
+          syncDir: SYNC_DIR_ABS,
         });
 
         return jsonResponse({

--- a/index.js
+++ b/index.js
@@ -1406,6 +1406,27 @@ function createMcpServer() {
         return errorResponse("INVALID_PROJECT_ID", projectIdCheck.reason, { project_id });
       }
 
+      const resolvedOutputDir = path.resolve(output_dir);
+      if (!isPathInsideSyncDir(resolvedOutputDir)) {
+        return errorResponse(
+          "INVALID_OUTPUT_DIR",
+          "output_dir must be inside WRITING_SYNC_DIR.",
+          { output_dir: resolvedOutputDir, sync_dir: SYNC_DIR_ABS }
+        );
+      }
+      const outputDirSegments = path
+        .relative(SYNC_DIR_REAL, resolvedOutputDir)
+        .split(path.sep)
+        .filter(Boolean)
+        .map(segment => segment.toLowerCase());
+      if (outputDirSegments.includes("scenes")) {
+        return errorResponse(
+          "INVALID_OUTPUT_DIR",
+          "output_dir cannot be inside a scenes directory. Choose a dedicated export folder under WRITING_SYNC_DIR.",
+          { output_dir: resolvedOutputDir }
+        );
+      }
+
       try {
         const plan = buildReviewBundlePlan(db, {
           project_id,
@@ -1429,10 +1450,10 @@ function createMcpServer() {
           );
         }
 
-        const provenanceCommit = source_commit ?? getHeadCommitHash(SYNC_DIR);
+        const provenanceCommit = source_commit ?? (GIT_ENABLED ? getHeadCommitHash(SYNC_DIR) : null);
         const artifacts = createReviewBundleArtifacts(db, {
           plan,
-          output_dir,
+          output_dir: resolvedOutputDir,
           source_commit: provenanceCommit,
         });
 

--- a/index.js
+++ b/index.js
@@ -51,6 +51,38 @@ function isPathInsideSyncDir(candidatePath) {
   return !(rel.startsWith("..") || path.isAbsolute(rel));
 }
 
+function resolveOutputDirWithinSync(outputDir) {
+  let resolvedOutputDir = path.resolve(outputDir);
+  let existingAncestor = resolvedOutputDir;
+
+  while (!fs.existsSync(existingAncestor)) {
+    const parentDir = path.dirname(existingAncestor);
+    if (parentDir === existingAncestor) {
+      throw new ReviewBundlePlanError(
+        "INVALID_OUTPUT_DIR",
+        "output_dir must be inside WRITING_SYNC_DIR.",
+        { output_dir: resolvedOutputDir, sync_dir: SYNC_DIR_ABS }
+      );
+    }
+    existingAncestor = parentDir;
+  }
+
+  const realExistingAncestor = fs.realpathSync.native(existingAncestor);
+  const relativeFromAncestor = path.relative(existingAncestor, resolvedOutputDir);
+  resolvedOutputDir = path.resolve(realExistingAncestor, relativeFromAncestor);
+
+  const relativeToSyncDir = path.relative(SYNC_DIR_REAL, resolvedOutputDir);
+  if (relativeToSyncDir.startsWith("..") || path.isAbsolute(relativeToSyncDir)) {
+    throw new ReviewBundlePlanError(
+      "INVALID_OUTPUT_DIR",
+      "output_dir must be inside WRITING_SYNC_DIR.",
+      { output_dir: resolvedOutputDir, sync_dir: SYNC_DIR_ABS }
+    );
+  }
+
+  return { resolvedOutputDir, relativeToSyncDir };
+}
+
 function parsePositiveIntEnv(rawValue, defaultValue) {
   const parsed = parseInt(rawValue ?? String(defaultValue), 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : defaultValue;
@@ -1406,28 +1438,20 @@ function createMcpServer() {
         return errorResponse("INVALID_PROJECT_ID", projectIdCheck.reason, { project_id });
       }
 
-      const resolvedOutputDir = path.resolve(output_dir);
-      if (!isPathInsideSyncDir(resolvedOutputDir)) {
-        return errorResponse(
-          "INVALID_OUTPUT_DIR",
-          "output_dir must be inside WRITING_SYNC_DIR.",
-          { output_dir: resolvedOutputDir, sync_dir: SYNC_DIR_ABS }
-        );
-      }
-      const outputDirSegments = path
-        .relative(SYNC_DIR_REAL, resolvedOutputDir)
-        .split(path.sep)
-        .filter(Boolean)
-        .map(segment => segment.toLowerCase());
-      if (outputDirSegments.includes("scenes")) {
-        return errorResponse(
-          "INVALID_OUTPUT_DIR",
-          "output_dir cannot be inside a scenes directory. Choose a dedicated export folder under WRITING_SYNC_DIR.",
-          { output_dir: resolvedOutputDir }
-        );
-      }
-
       try {
+        const { resolvedOutputDir, relativeToSyncDir } = resolveOutputDirWithinSync(output_dir);
+        const outputDirSegments = relativeToSyncDir
+          .split(path.sep)
+          .filter(Boolean)
+          .map(segment => segment.toLowerCase());
+        if (outputDirSegments.includes("scenes")) {
+          return errorResponse(
+            "INVALID_OUTPUT_DIR",
+            "output_dir cannot be inside a scenes directory. Choose a dedicated export folder under WRITING_SYNC_DIR.",
+            { output_dir: resolvedOutputDir }
+          );
+        }
+
         const plan = buildReviewBundlePlan(db, {
           project_id,
           profile,

--- a/index.js
+++ b/index.js
@@ -67,7 +67,16 @@ function resolveOutputDirWithinSync(outputDir) {
     existingAncestor = parentDir;
   }
 
-  const realExistingAncestor = fs.realpathSync.native(existingAncestor);
+  let realExistingAncestor;
+  try {
+    realExistingAncestor = fs.realpathSync.native(existingAncestor);
+  } catch (err) {
+    throw new ReviewBundlePlanError(
+      "INVALID_OUTPUT_DIR",
+      "output_dir ancestor could not be resolved: path may be inaccessible.",
+      { output_dir: outputDir, existing_ancestor: existingAncestor, cause: err.message }
+    );
+  }
   const relativeFromAncestor = path.relative(existingAncestor, resolvedOutputDir);
   resolvedOutputDir = path.resolve(realExistingAncestor, relativeFromAncestor);
 

--- a/review-bundles.js
+++ b/review-bundles.js
@@ -316,6 +316,9 @@ export function buildReviewBundlePlan(dbHandle, {
 function loadBundleSceneRows(dbHandle, projectId, sceneIds) {
   if (!Array.isArray(sceneIds) || sceneIds.length === 0) return [];
   const rows = [];
+  // 900 is safely below SQLite's per-query bound of 999 host parameters
+  // (one slot is used by the project_id binding, leaving 998 for scene_id placeholders;
+  // 900 gives extra headroom for any future additions to the query).
   const chunkSize = 900;
   for (let offset = 0; offset < sceneIds.length; offset += chunkSize) {
     const chunk = sceneIds.slice(offset, offset + chunkSize);
@@ -427,6 +430,9 @@ function resolveSceneFilePath(filePath, { syncDir } = {}) {
     }
   } else {
     candidates.push(path.resolve(realSyncDir, rel));
+    // Scrivener External Folder Sync sometimes stores paths prefixed with
+    // "sync/" (the name of the sync folder itself) relative to the project
+    // root. Strip that prefix so we can find the file within realSyncDir.
     if (rel === "sync" || rel.startsWith("sync/")) {
       candidates.push(path.resolve(realSyncDir, rel.replace(/^sync\/?/, "")));
     }
@@ -565,10 +571,23 @@ export function renderReviewBundleMarkdown(dbHandle, plan, { generatedAt, syncDi
   sections.push(headerLines.join("\n"));
 
   for (const scene of rows) {
-    const withProse = {
-      ...scene,
-      prose: profile === "editor_detailed" ? (readProse(scene.file_path, { syncDir }) ?? "") : "",
-    };
+    let prose = "";
+    if (profile === "editor_detailed") {
+      const resolved = readProse(scene.file_path, { syncDir });
+      if (resolved === null) {
+        throw new ReviewBundlePlanError(
+          "SCENE_PROSE_READ_FAILED",
+          `Scene prose is unavailable for scene ${scene.scene_id}: file_path is null or could not be resolved within syncDir.`,
+          {
+            scene_id: scene.scene_id,
+            file_path: scene.file_path ?? null,
+            sync_dir: syncDir,
+          }
+        );
+      }
+      prose = resolved;
+    }
+    const withProse = { ...scene, prose };
     sections.push(renderSceneBlock(withProse, {
       profile,
       includeSceneIds,
@@ -671,4 +690,5 @@ export function createReviewBundleArtifacts(dbHandle, {
     },
     generated_at: generatedAt,
   };
+
 }

--- a/review-bundles.js
+++ b/review-bundles.js
@@ -60,7 +60,7 @@ function slugifyBundleName(value) {
 function escapeMarkdown(text) {
   return String(text ?? "")
     .replace(/\\/g, "\\\\")
-    .replace(/([*_`\[\]])/g, "\\$1");
+    .replace(/([*_`\[\]#])/g, "\\$1");
 }
 
 function resolveOutputFilePath(outputDir, fileName) {
@@ -559,7 +559,10 @@ export function renderReviewBundleMarkdown(dbHandle, plan, { generatedAt, syncDi
   const includeMetadataSidebar = Boolean(plan.resolved_scope?.options?.include_metadata_sidebar);
   const includeParagraphAnchors = Boolean(plan.resolved_scope?.options?.include_paragraph_anchors);
   // Prefer explicitly threaded syncDir; fall back to env (with "./sync" default matching index.js).
-  const syncDir = syncDirOpt ?? process.env.WRITING_SYNC_DIR ?? "./sync";
+  // Prefer explicitly threaded syncDir; fall back to env.
+  // No further fallback: if syncDir is null, resolveSceneFilePath returns null
+  // and SCENE_PROSE_READ_FAILED is thrown, making misconfiguration explicit.
+  const syncDir = syncDirOpt ?? process.env.WRITING_SYNC_DIR ?? null;
 
   const sceneIds = plan.ordering.map(row => row.scene_id);
   const rows = loadBundleSceneRows(dbHandle, plan.resolved_scope.project_id, sceneIds);
@@ -679,7 +682,11 @@ export function createReviewBundleArtifacts(dbHandle, {
       }
     } catch (error) {
       if (error instanceof ReviewBundlePlanError) throw error;
-      // ENOENT — file doesn't exist yet, which is fine.
+      if (error?.code !== "ENOENT") throw error;
+      // ENOENT — file doesn't exist yet, which is the expected case.
+      // Note: there is an inherent TOCTOU window between this lstat check and the
+      // writeFileSync below. This is acceptable for a local tool where the caller
+      // controls the output directory.
     }
   }
 

--- a/review-bundles.js
+++ b/review-bundles.js
@@ -339,15 +339,87 @@ function loadBundleSceneRows(dbHandle, projectId, sceneIds) {
   }
 
   const rowMap = new Map(rows.map(row => [row.scene_id, row]));
-  return sceneIds.map(sceneId => rowMap.get(sceneId)).filter(Boolean);
+  const orderedRows = [];
+  const missingSceneIds = [];
+
+  for (const sceneId of sceneIds) {
+    const row = rowMap.get(sceneId);
+    if (row) {
+      orderedRows.push(row);
+    } else {
+      missingSceneIds.push(sceneId);
+    }
+  }
+
+  if (missingSceneIds.length > 0) {
+    throw new ReviewBundlePlanError(
+      "MISSING_SCENE_ROWS",
+      `Bundle includes ${missingSceneIds.length} scene(s) that could not be loaded from the database.`,
+      {
+        project_id: projectId,
+        missing_scene_ids: missingSceneIds,
+        requested_scene_count: sceneIds.length,
+        resolved_scene_count: orderedRows.length,
+      }
+    );
+  }
+
+  return orderedRows;
 }
 
-function readProse(filePath) {
+function normalizeRelativePath(inputPath) {
+  return String(inputPath).replace(/\\/g, "/").replace(/^\.\//, "");
+}
+
+function resolveSceneFilePath(filePath, { syncDir } = {}) {
+  if (!filePath) return null;
+
+  const normalizedSyncDir = syncDir ? path.resolve(syncDir) : null;
+  const candidates = [];
+
+  if (path.isAbsolute(filePath)) {
+    candidates.push(filePath);
+  } else {
+    candidates.push(path.resolve(filePath));
+    if (normalizedSyncDir) {
+      const rel = normalizeRelativePath(filePath);
+      candidates.push(path.resolve(normalizedSyncDir, rel));
+      if (rel === "sync" || rel.startsWith("sync/")) {
+        candidates.push(path.resolve(normalizedSyncDir, rel.replace(/^sync\/?/, "")));
+      }
+    }
+  }
+
+  for (const candidate of candidates) {
+    if (candidate && fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  return candidates[0] ?? null;
+}
+
+function readProse(filePath, { syncDir } = {}) {
+  const resolvedPath = resolveSceneFilePath(filePath, { syncDir });
+  if (!resolvedPath) return null;
   try {
-    const raw = fs.readFileSync(filePath, "utf8");
+    const raw = fs.readFileSync(resolvedPath, "utf8");
     return matter(raw).content.trim();
-  } catch {
-    return null;
+  } catch (error) {
+    const errorCode = error && typeof error === "object" && "code" in error && typeof error.code === "string"
+      ? error.code
+      : null;
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    throw new ReviewBundlePlanError(
+      "SCENE_PROSE_READ_FAILED",
+      `Failed to read scene prose from ${resolvedPath}.`,
+      {
+        file_path: filePath,
+        resolved_path: resolvedPath,
+        error_code: errorCode,
+        cause: errorMessage,
+      }
+    );
   }
 }
 
@@ -376,7 +448,7 @@ function renderSceneBlock(scene, options) {
       parts.push(`_${escapeMarkdown(summaryParts.join(" | "))}_`);
     }
     if (scene.logline) {
-      parts.push(scene.logline.trim());
+      parts.push(escapeMarkdown(scene.logline.trim()));
     }
     return parts.join("\n\n");
   }
@@ -416,6 +488,7 @@ export function renderReviewBundleMarkdown(dbHandle, plan, { generatedAt } = {})
   const includeSceneIds = Boolean(plan.resolved_scope?.options?.include_scene_ids);
   const includeMetadataSidebar = Boolean(plan.resolved_scope?.options?.include_metadata_sidebar);
   const includeParagraphAnchors = Boolean(plan.resolved_scope?.options?.include_paragraph_anchors);
+  const syncDir = process.env.WRITING_SYNC_DIR;
 
   const sceneIds = plan.ordering.map(row => row.scene_id);
   const rows = loadBundleSceneRows(dbHandle, plan.resolved_scope.project_id, sceneIds);
@@ -433,7 +506,7 @@ export function renderReviewBundleMarkdown(dbHandle, plan, { generatedAt } = {})
   for (const scene of rows) {
     const withProse = {
       ...scene,
-      prose: profile === "editor_detailed" ? (readProse(scene.file_path) ?? "") : "",
+      prose: profile === "editor_detailed" ? (readProse(scene.file_path, { syncDir }) ?? "") : "",
     };
     sections.push(renderSceneBlock(withProse, {
       profile,

--- a/review-bundles.js
+++ b/review-bundles.js
@@ -499,7 +499,7 @@ function renderSceneBlock(scene, options) {
 
   const title = scene.title || scene.scene_id;
   const sceneHeading = includeSceneIds
-    ? `## ${escapeMarkdown(title)} (${scene.scene_id})`
+    ? `## ${escapeMarkdown(title)} (${escapeMarkdown(scene.scene_id)})`
     : `## ${escapeMarkdown(title)}`;
 
   const parts = [sceneHeading];
@@ -542,8 +542,12 @@ function renderSceneBlock(scene, options) {
     .split(/\n\s*\n/g)
     .map(p => p.trim())
     .filter(Boolean);
+  // Sanitize scene_id for safe embedding in an HTML comment: restrict to
+  // alphanumerics, hyphens, underscores, and dots to prevent "-->" or other
+  // sequences from prematurely terminating the comment.
+  const safeSceneId = scene.scene_id.replace(/[^a-zA-Z0-9\-_.]/g, "_");
   const anchoredParagraphs = paragraphs.map((paragraph, index) => {
-    return `<!-- ${scene.scene_id}:p${index + 1} -->\n${paragraph}`;
+    return `<!-- ${safeSceneId}:p${index + 1} -->\n${paragraph}`;
   });
   parts.push(anchoredParagraphs.join("\n\n"));
   return parts.join("\n\n");

--- a/review-bundles.js
+++ b/review-bundles.js
@@ -315,22 +315,28 @@ export function buildReviewBundlePlan(dbHandle, {
 
 function loadBundleSceneRows(dbHandle, projectId, sceneIds) {
   if (!Array.isArray(sceneIds) || sceneIds.length === 0) return [];
-  const placeholders = sceneIds.map(() => "?").join(",");
-  const rows = dbHandle.prepare(`
-    SELECT
-      scene_id,
-      project_id,
-      title,
-      part,
-      chapter,
-      timeline_position,
-      logline,
-      pov,
-      save_the_cat_beat,
-      file_path
-    FROM scenes
-    WHERE project_id = ? AND scene_id IN (${placeholders})
-  `).all(projectId, ...sceneIds);
+  const rows = [];
+  const chunkSize = 900;
+  for (let offset = 0; offset < sceneIds.length; offset += chunkSize) {
+    const chunk = sceneIds.slice(offset, offset + chunkSize);
+    const placeholders = chunk.map(() => "?").join(",");
+    const chunkRows = dbHandle.prepare(`
+      SELECT
+        scene_id,
+        project_id,
+        title,
+        part,
+        chapter,
+        timeline_position,
+        logline,
+        pov,
+        save_the_cat_beat,
+        file_path
+      FROM scenes
+      WHERE project_id = ? AND scene_id IN (${placeholders})
+    `).all(projectId, ...chunk);
+    rows.push(...chunkRows);
+  }
 
   const rowMap = new Map(rows.map(row => [row.scene_id, row]));
   return sceneIds.map(sceneId => rowMap.get(sceneId)).filter(Boolean);
@@ -405,7 +411,7 @@ function renderSceneBlock(scene, options) {
   return parts.join("\n\n");
 }
 
-export function renderReviewBundleMarkdown(dbHandle, plan) {
+export function renderReviewBundleMarkdown(dbHandle, plan, { generatedAt } = {}) {
   const profile = plan.profile;
   const includeSceneIds = Boolean(plan.resolved_scope?.options?.include_scene_ids);
   const includeMetadataSidebar = Boolean(plan.resolved_scope?.options?.include_metadata_sidebar);
@@ -419,7 +425,7 @@ export function renderReviewBundleMarkdown(dbHandle, plan) {
     `# Review Bundle: ${escapeMarkdown(plan.resolved_scope.project_id)}`,
     "",
     `- Profile: ${profile}`,
-    `- Generated at: ${new Date().toISOString()}`,
+    `- Generated at: ${generatedAt ?? new Date().toISOString()}`,
     `- Scene count: ${plan.summary.scene_count}`,
   ];
   sections.push(headerLines.join("\n"));
@@ -464,8 +470,8 @@ export function createReviewBundleArtifacts(dbHandle, {
   const markdownPath = resolveOutputFilePath(normalizedOutputDir, markdownFileName);
   const manifestPath = resolveOutputFilePath(normalizedOutputDir, manifestFileName);
 
-  const markdown = renderReviewBundleMarkdown(dbHandle, plan);
   const generatedAt = new Date().toISOString();
+  const markdown = renderReviewBundleMarkdown(dbHandle, plan, { generatedAt });
   const manifest = {
     bundle_id: path.basename(markdownFileName, ".md"),
     profile: plan.profile,

--- a/review-bundles.js
+++ b/review-bundles.js
@@ -372,31 +372,87 @@ function normalizeRelativePath(inputPath) {
 }
 
 function resolveSceneFilePath(filePath, { syncDir } = {}) {
-  if (!filePath) return null;
+  if (!filePath || !syncDir) return null;
 
-  const normalizedSyncDir = syncDir ? path.resolve(syncDir) : null;
+  const normalizedSyncDir = path.resolve(syncDir);
+  let realSyncDir;
+  try {
+    realSyncDir = fs.realpathSync.native(normalizedSyncDir);
+  } catch {
+    return null;
+  }
+
+  const rel = normalizeRelativePath(filePath);
   const candidates = [];
 
   if (path.isAbsolute(filePath)) {
-    candidates.push(filePath);
-  } else {
-    candidates.push(path.resolve(filePath));
-    if (normalizedSyncDir) {
-      const rel = normalizeRelativePath(filePath);
-      candidates.push(path.resolve(normalizedSyncDir, rel));
-      if (rel === "sync" || rel.startsWith("sync/")) {
-        candidates.push(path.resolve(normalizedSyncDir, rel.replace(/^sync\/?/, "")));
+    // Canonicalize the absolute path (resolve symlinks) so the boundary check
+    // works correctly even when syncDir itself contains a symlink component
+    // (e.g. macOS /var → /private/var or /tmp → /private/tmp).
+    const resolvedAbsolute = path.resolve(filePath);
+    let canonicalAbsolute;
+
+    if (fs.existsSync(resolvedAbsolute)) {
+      try {
+        canonicalAbsolute = fs.realpathSync.native(resolvedAbsolute);
+      } catch {
+        // Cannot canonicalize — skip this candidate.
       }
+    } else {
+      // File doesn't exist yet; walk up to the nearest existing ancestor,
+      // canonicalize that, then reconstruct the full path.
+      let ancestor = resolvedAbsolute;
+      const segments = [];
+      while (!fs.existsSync(ancestor)) {
+        const parent = path.dirname(ancestor);
+        if (parent === ancestor) { ancestor = null; break; }
+        segments.unshift(path.basename(ancestor));
+        ancestor = parent;
+      }
+      if (ancestor) {
+        try {
+          const realAncestor = fs.realpathSync.native(ancestor);
+          canonicalAbsolute = path.resolve(realAncestor, ...segments);
+        } catch {
+          // Cannot canonicalize.
+        }
+      }
+    }
+
+    if (canonicalAbsolute) {
+      const relFromSync = path.relative(realSyncDir, canonicalAbsolute);
+      if (!relFromSync.startsWith("..") && !path.isAbsolute(relFromSync)) {
+        candidates.push(canonicalAbsolute);
+      }
+    }
+  } else {
+    candidates.push(path.resolve(realSyncDir, rel));
+    if (rel === "sync" || rel.startsWith("sync/")) {
+      candidates.push(path.resolve(realSyncDir, rel.replace(/^sync\/?/, "")));
     }
   }
 
   for (const candidate of candidates) {
-    if (candidate && fs.existsSync(candidate)) {
+    if (!fs.existsSync(candidate)) {
+      // Path is inside syncDir but file is not on disk — return it so readProse
+      // can surface a meaningful SCENE_PROSE_READ_FAILED error.
       return candidate;
+    }
+
+    // File exists: validate realpath stays inside syncDir to catch symlink escapes.
+    // (For absolute paths this is already canonicalized; for relative paths, verify.)
+    try {
+      const realCandidate = fs.realpathSync.native(candidate);
+      const relReal = path.relative(realSyncDir, realCandidate);
+      if (!relReal.startsWith("..") && !path.isAbsolute(relReal)) {
+        return realCandidate;
+      }
+    } catch {
+      continue;
     }
   }
 
-  return candidates[0] ?? null;
+  return null;
 }
 
 function readProse(filePath, { syncDir } = {}) {
@@ -529,7 +585,24 @@ export function createReviewBundleArtifacts(dbHandle, {
   }
 
   const normalizedOutputDir = path.resolve(output_dir);
-  fs.mkdirSync(normalizedOutputDir, { recursive: true });
+  if (fs.existsSync(normalizedOutputDir)) {
+    if (!fs.statSync(normalizedOutputDir).isDirectory()) {
+      throw new ReviewBundlePlanError(
+        "INVALID_OUTPUT_DIR",
+        `output_dir exists but is not a directory: ${normalizedOutputDir}`
+      );
+    }
+  } else {
+    fs.mkdirSync(normalizedOutputDir, { recursive: true });
+  }
+  try {
+    fs.accessSync(normalizedOutputDir, fs.constants.W_OK);
+  } catch {
+    throw new ReviewBundlePlanError(
+      "INVALID_OUTPUT_DIR",
+      `output_dir is not writable: ${normalizedOutputDir}`
+    );
+  }
 
   const markdownFileName = plan.planned_outputs.find(name => name.endsWith(".md"));
   const manifestFileName = plan.planned_outputs.find(name => name.endsWith(".manifest.json"));
@@ -559,6 +632,20 @@ export function createReviewBundleArtifacts(dbHandle, {
     resolved_scope: plan.resolved_scope,
     scene_ids: plan.ordering.map(row => row.scene_id),
   };
+
+  for (const outputPath of [markdownPath, manifestPath]) {
+    try {
+      if (fs.lstatSync(outputPath).isSymbolicLink()) {
+        throw new ReviewBundlePlanError(
+          "INVALID_OUTPUT_PATH",
+          `Refusing to write: target path is a symlink: ${outputPath}`
+        );
+      }
+    } catch (error) {
+      if (error instanceof ReviewBundlePlanError) throw error;
+      // ENOENT — file doesn't exist yet, which is fine.
+    }
+  }
 
   fs.writeFileSync(markdownPath, markdown, "utf8");
   fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + "\n", "utf8");

--- a/review-bundles.js
+++ b/review-bundles.js
@@ -434,9 +434,13 @@ function resolveSceneFilePath(filePath, { syncDir } = {}) {
 
   for (const candidate of candidates) {
     if (!fs.existsSync(candidate)) {
-      // Path is inside syncDir but file is not on disk — return it so readProse
-      // can surface a meaningful SCENE_PROSE_READ_FAILED error.
-      return candidate;
+      // Before returning a non-existent path, verify it is still inside realSyncDir.
+      // A relative filePath with .. segments could otherwise escape the boundary.
+      const relFromSync = path.relative(realSyncDir, candidate);
+      if (!relFromSync.startsWith("..") && !path.isAbsolute(relFromSync)) {
+        return candidate;
+      }
+      continue;
     }
 
     // File exists: validate realpath stays inside syncDir to catch symlink escapes.
@@ -514,8 +518,8 @@ function renderSceneBlock(scene, options) {
       scene.part != null ? `part: ${scene.part}` : null,
       scene.chapter != null ? `chapter: ${scene.chapter}` : null,
       scene.timeline_position != null ? `timeline_position: ${scene.timeline_position}` : null,
-      scene.pov ? `pov: ${scene.pov}` : null,
-      scene.save_the_cat_beat ? `beat: ${scene.save_the_cat_beat}` : null,
+      scene.pov ? `pov: ${escapeMarkdown(scene.pov)}` : null,
+      scene.save_the_cat_beat ? `beat: ${escapeMarkdown(scene.save_the_cat_beat)}` : null,
     ].filter(Boolean);
     if (sidebar.length > 0) {
       parts.push(`> ${sidebar.join("  \\\n> ")}`);
@@ -539,12 +543,13 @@ function renderSceneBlock(scene, options) {
   return parts.join("\n\n");
 }
 
-export function renderReviewBundleMarkdown(dbHandle, plan, { generatedAt } = {}) {
+export function renderReviewBundleMarkdown(dbHandle, plan, { generatedAt, syncDir: syncDirOpt } = {}) {
   const profile = plan.profile;
   const includeSceneIds = Boolean(plan.resolved_scope?.options?.include_scene_ids);
   const includeMetadataSidebar = Boolean(plan.resolved_scope?.options?.include_metadata_sidebar);
   const includeParagraphAnchors = Boolean(plan.resolved_scope?.options?.include_paragraph_anchors);
-  const syncDir = process.env.WRITING_SYNC_DIR;
+  // Prefer explicitly threaded syncDir; fall back to env (with "./sync" default matching index.js).
+  const syncDir = syncDirOpt ?? process.env.WRITING_SYNC_DIR ?? "./sync";
 
   const sceneIds = plan.ordering.map(row => row.scene_id);
   const rows = loadBundleSceneRows(dbHandle, plan.resolved_scope.project_id, sceneIds);
@@ -579,6 +584,7 @@ export function createReviewBundleArtifacts(dbHandle, {
   plan,
   output_dir,
   source_commit = null,
+  syncDir,
 }) {
   if (!output_dir) {
     throw new ReviewBundlePlanError("INVALID_OUTPUT_DIR", "output_dir is required.");
@@ -617,7 +623,7 @@ export function createReviewBundleArtifacts(dbHandle, {
   const manifestPath = resolveOutputFilePath(normalizedOutputDir, manifestFileName);
 
   const generatedAt = new Date().toISOString();
-  const markdown = renderReviewBundleMarkdown(dbHandle, plan, { generatedAt });
+  const markdown = renderReviewBundleMarkdown(dbHandle, plan, { generatedAt, syncDir });
   const manifest = {
     bundle_id: path.basename(markdownFileName, ".md"),
     profile: plan.profile,
@@ -635,10 +641,17 @@ export function createReviewBundleArtifacts(dbHandle, {
 
   for (const outputPath of [markdownPath, manifestPath]) {
     try {
-      if (fs.lstatSync(outputPath).isSymbolicLink()) {
+      const stat = fs.lstatSync(outputPath);
+      if (stat.isSymbolicLink()) {
         throw new ReviewBundlePlanError(
           "INVALID_OUTPUT_PATH",
           `Refusing to write: target path is a symlink: ${outputPath}`
+        );
+      }
+      if (!stat.isFile()) {
+        throw new ReviewBundlePlanError(
+          "INVALID_OUTPUT_PATH",
+          `Refusing to write: target path exists but is not a regular file: ${outputPath}`
         );
       }
     } catch (error) {

--- a/review-bundles.js
+++ b/review-bundles.js
@@ -1,3 +1,7 @@
+import fs from "node:fs";
+import path from "node:path";
+import matter from "gray-matter";
+
 const MAX_SORT_VALUE = Number.MAX_SAFE_INTEGER;
 
 export const REVIEW_BUNDLE_PROFILES = ["outline_discussion", "editor_detailed"];
@@ -51,6 +55,26 @@ function slugifyBundleName(value) {
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "");
   return slug || "review-bundle";
+}
+
+function escapeMarkdown(text) {
+  return String(text ?? "")
+    .replace(/\\/g, "\\\\")
+    .replace(/([*_`\[\]])/g, "\\$1");
+}
+
+function resolveOutputFilePath(outputDir, fileName) {
+  const normalizedOutputDir = path.resolve(outputDir);
+  const target = path.resolve(normalizedOutputDir, fileName);
+  const rel = path.relative(normalizedOutputDir, target);
+  if (rel.startsWith("..") || path.isAbsolute(rel)) {
+    throw new ReviewBundlePlanError(
+      "INVALID_OUTPUT_PATH",
+      `Output file '${fileName}' resolves outside output_dir.`,
+      { output_dir: normalizedOutputDir, file_name: fileName }
+    );
+  }
+  return target;
 }
 
 function assertProfile(profile) {
@@ -286,5 +310,186 @@ export function buildReviewBundlePlan(dbHandle, {
       `${safeBundleName}.md`,
       `${safeBundleName}.manifest.json`,
     ],
+  };
+}
+
+function loadBundleSceneRows(dbHandle, projectId, sceneIds) {
+  if (!Array.isArray(sceneIds) || sceneIds.length === 0) return [];
+  const placeholders = sceneIds.map(() => "?").join(",");
+  const rows = dbHandle.prepare(`
+    SELECT
+      scene_id,
+      project_id,
+      title,
+      part,
+      chapter,
+      timeline_position,
+      logline,
+      pov,
+      save_the_cat_beat,
+      file_path
+    FROM scenes
+    WHERE project_id = ? AND scene_id IN (${placeholders})
+  `).all(projectId, ...sceneIds);
+
+  const rowMap = new Map(rows.map(row => [row.scene_id, row]));
+  return sceneIds.map(sceneId => rowMap.get(sceneId)).filter(Boolean);
+}
+
+function readProse(filePath) {
+  try {
+    const raw = fs.readFileSync(filePath, "utf8");
+    return matter(raw).content.trim();
+  } catch {
+    return null;
+  }
+}
+
+function renderSceneBlock(scene, options) {
+  const {
+    profile,
+    includeSceneIds,
+    includeMetadataSidebar,
+    includeParagraphAnchors,
+  } = options;
+
+  const title = scene.title || scene.scene_id;
+  const sceneHeading = includeSceneIds
+    ? `## ${escapeMarkdown(title)} (${scene.scene_id})`
+    : `## ${escapeMarkdown(title)}`;
+
+  const parts = [sceneHeading];
+
+  if (profile === "outline_discussion") {
+    const summaryParts = [];
+    if (scene.pov) summaryParts.push(`POV: ${scene.pov}`);
+    if (scene.save_the_cat_beat) summaryParts.push(`Beat: ${scene.save_the_cat_beat}`);
+    if (scene.part != null) summaryParts.push(`Part: ${scene.part}`);
+    if (scene.chapter != null) summaryParts.push(`Chapter: ${scene.chapter}`);
+    if (summaryParts.length > 0) {
+      parts.push(`_${escapeMarkdown(summaryParts.join(" | "))}_`);
+    }
+    if (scene.logline) {
+      parts.push(scene.logline.trim());
+    }
+    return parts.join("\n\n");
+  }
+
+  if (includeMetadataSidebar) {
+    const sidebar = [
+      scene.part != null ? `part: ${scene.part}` : null,
+      scene.chapter != null ? `chapter: ${scene.chapter}` : null,
+      scene.timeline_position != null ? `timeline_position: ${scene.timeline_position}` : null,
+      scene.pov ? `pov: ${scene.pov}` : null,
+      scene.save_the_cat_beat ? `beat: ${scene.save_the_cat_beat}` : null,
+    ].filter(Boolean);
+    if (sidebar.length > 0) {
+      parts.push(`> ${sidebar.join("  \\\n> ")}`);
+    }
+  }
+
+  const prose = scene.prose ?? "";
+  if (!includeParagraphAnchors || prose.length === 0) {
+    parts.push(prose);
+    return parts.join("\n\n");
+  }
+
+  const paragraphs = prose
+    .split(/\n\s*\n/g)
+    .map(p => p.trim())
+    .filter(Boolean);
+  const anchoredParagraphs = paragraphs.map((paragraph, index) => {
+    return `<!-- ${scene.scene_id}:p${index + 1} -->\n${paragraph}`;
+  });
+  parts.push(anchoredParagraphs.join("\n\n"));
+  return parts.join("\n\n");
+}
+
+export function renderReviewBundleMarkdown(dbHandle, plan) {
+  const profile = plan.profile;
+  const includeSceneIds = Boolean(plan.resolved_scope?.options?.include_scene_ids);
+  const includeMetadataSidebar = Boolean(plan.resolved_scope?.options?.include_metadata_sidebar);
+  const includeParagraphAnchors = Boolean(plan.resolved_scope?.options?.include_paragraph_anchors);
+
+  const sceneIds = plan.ordering.map(row => row.scene_id);
+  const rows = loadBundleSceneRows(dbHandle, plan.resolved_scope.project_id, sceneIds);
+  const sections = [];
+
+  const headerLines = [
+    `# Review Bundle: ${escapeMarkdown(plan.resolved_scope.project_id)}`,
+    "",
+    `- Profile: ${profile}`,
+    `- Generated at: ${new Date().toISOString()}`,
+    `- Scene count: ${plan.summary.scene_count}`,
+  ];
+  sections.push(headerLines.join("\n"));
+
+  for (const scene of rows) {
+    const withProse = {
+      ...scene,
+      prose: profile === "editor_detailed" ? (readProse(scene.file_path) ?? "") : "",
+    };
+    sections.push(renderSceneBlock(withProse, {
+      profile,
+      includeSceneIds,
+      includeMetadataSidebar,
+      includeParagraphAnchors,
+    }));
+  }
+
+  return sections.join("\n\n---\n\n").trim() + "\n";
+}
+
+export function createReviewBundleArtifacts(dbHandle, {
+  plan,
+  output_dir,
+  source_commit = null,
+}) {
+  if (!output_dir) {
+    throw new ReviewBundlePlanError("INVALID_OUTPUT_DIR", "output_dir is required.");
+  }
+
+  const normalizedOutputDir = path.resolve(output_dir);
+  fs.mkdirSync(normalizedOutputDir, { recursive: true });
+
+  const markdownFileName = plan.planned_outputs.find(name => name.endsWith(".md"));
+  const manifestFileName = plan.planned_outputs.find(name => name.endsWith(".manifest.json"));
+  if (!markdownFileName || !manifestFileName) {
+    throw new ReviewBundlePlanError(
+      "INVALID_PLAN_OUTPUTS",
+      "Plan is missing expected markdown/manifest filenames."
+    );
+  }
+
+  const markdownPath = resolveOutputFilePath(normalizedOutputDir, markdownFileName);
+  const manifestPath = resolveOutputFilePath(normalizedOutputDir, manifestFileName);
+
+  const markdown = renderReviewBundleMarkdown(dbHandle, plan);
+  const generatedAt = new Date().toISOString();
+  const manifest = {
+    bundle_id: path.basename(markdownFileName, ".md"),
+    profile: plan.profile,
+    generated_at: generatedAt,
+    provenance: {
+      source_commit: source_commit ?? null,
+      project_id: plan.resolved_scope.project_id,
+    },
+    summary: plan.summary,
+    warning_summary: plan.warning_summary,
+    warnings: plan.warnings,
+    resolved_scope: plan.resolved_scope,
+    scene_ids: plan.ordering.map(row => row.scene_id),
+  };
+
+  fs.writeFileSync(markdownPath, markdown, "utf8");
+  fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + "\n", "utf8");
+
+  return {
+    bundle_id: manifest.bundle_id,
+    output_paths: {
+      bundle_markdown: markdownPath,
+      manifest_json: manifestPath,
+    },
+    generated_at: generatedAt,
   };
 }

--- a/run_mcp_and_review.js
+++ b/run_mcp_and_review.js
@@ -12,8 +12,24 @@ async function callCreateBundle(client, args) {
 }
 
 async function main() {
-  const [projectId = "the-lamb", outputDir = "/Users/hanna/Code/writing/exports"] = process.argv.slice(2);
-  const writingSyncDir = process.env.WRITING_SYNC_DIR || path.dirname(path.resolve(outputDir));
+  const [projectId, outputDirArg] = process.argv.slice(2);
+  const envWritingSyncDir = process.env.WRITING_SYNC_DIR;
+
+  if (!projectId) {
+    console.error(
+      "Usage: node run_mcp_and_review.js <projectId> [outputDir]\n" +
+      "Either provide outputDir explicitly or set WRITING_SYNC_DIR to derive a default output directory."
+    );
+    process.exit(1);
+  }
+
+  if (!outputDirArg && !envWritingSyncDir) {
+    console.error("Missing output directory: provide [outputDir] or set WRITING_SYNC_DIR.");
+    process.exit(1);
+  }
+
+  const outputDir = outputDirArg || path.join(envWritingSyncDir, "exports");
+  const writingSyncDir = envWritingSyncDir || path.dirname(path.resolve(outputDir));
 
   const transport = new StdioClientTransport({
     command: process.execPath,
@@ -51,8 +67,9 @@ async function main() {
     });
   } catch (error) {
     console.error(error);
+    process.exitCode = 1;
   } finally {
-    process.exit(0);
+    process.exit(process.exitCode ?? 0);
   }
 }
 

--- a/run_mcp_and_review.js
+++ b/run_mcp_and_review.js
@@ -1,0 +1,59 @@
+import path from "node:path";
+import process from "node:process";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+async function callCreateBundle(client, args) {
+  const result = await client.callTool({
+    name: "create_review_bundle",
+    arguments: args,
+  });
+  console.log(JSON.stringify(result, null, 2));
+}
+
+async function main() {
+  const [projectId = "the-lamb", outputDir = "/Users/hanna/Code/writing/exports"] = process.argv.slice(2);
+  const writingSyncDir = process.env.WRITING_SYNC_DIR || path.dirname(path.resolve(outputDir));
+
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: ["--experimental-sqlite", path.join(process.cwd(), "index.js")],
+    env: {
+      ...process.env,
+      MCP_TRANSPORT: "stdio",
+      WRITING_SYNC_DIR: writingSyncDir,
+    },
+  });
+
+  const client = new Client(
+    { name: "manual-review-runner", version: "1.0.0" },
+    { capabilities: {} }
+  );
+
+  try {
+    await client.connect(transport);
+
+    console.log("Calling create_review_bundle (outline_discussion)...");
+    await callCreateBundle(client, {
+      project_id: projectId,
+      profile: "outline_discussion",
+      output_dir: outputDir,
+      bundle_name: "real-outline",
+    });
+
+    console.log("Calling create_review_bundle (editor_detailed)...");
+    await callCreateBundle(client, {
+      project_id: projectId,
+      profile: "editor_detailed",
+      include_paragraph_anchors: true,
+      output_dir: outputDir,
+      bundle_name: "real-editor",
+    });
+  } catch (error) {
+    console.error(error);
+  } finally {
+    process.exit(0);
+  }
+}
+
+main();

--- a/scripts/manual/run_create_review_bundle.js
+++ b/scripts/manual/run_create_review_bundle.js
@@ -1,0 +1,55 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import path from "path";
+import process from "process";
+
+async function main() {
+  const [projectId, profile, outputDir, ...flags] = process.argv.slice(2);
+  if (!projectId || !profile || !outputDir) {
+    console.log("Usage: node scripts/manual/run_create_review_bundle.js <project_id> <profile> <output_dir> [--anchors] [--bundle-name <name>]");
+    process.exit(1);
+  }
+
+  const includeParagraphAnchors = flags.includes("--anchors");
+  const bundleNameIdx = flags.indexOf("--bundle-name");
+  const bundleName = bundleNameIdx !== -1 ? flags[bundleNameIdx + 1] : undefined;
+
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: ["--experimental-sqlite", path.join(process.cwd(), "index.js")],
+    env: {
+      ...process.env,
+      MCP_TRANSPORT: "stdio",
+      WRITING_SYNC_DIR: process.env.WRITING_SYNC_DIR || path.dirname(path.resolve(outputDir))
+    }
+  });
+
+  const client = new Client({
+    name: "test-client",
+    version: "1.0.0"
+  }, {
+    capabilities: {}
+  });
+
+  try {
+    await client.connect(transport);
+    const result = await client.callTool({
+      name: "create_review_bundle",
+      arguments: {
+        project_id: projectId,
+        profile: profile,
+        output_dir: outputDir,
+        ...(includeParagraphAnchors ? { include_paragraph_anchors: true } : {}),
+        ...(bundleName ? { bundle_name: bundleName } : {})
+      }
+    });
+
+    console.log(JSON.stringify(result, null, 2));
+  } catch (e) {
+    console.error(e);
+  } finally {
+    process.exit(0);
+  }
+}
+
+main();

--- a/scripts/manual/run_create_review_bundle.js
+++ b/scripts/manual/run_create_review_bundle.js
@@ -6,7 +6,15 @@ import process from "process";
 async function main() {
   const [projectId, profile, outputDir, ...flags] = process.argv.slice(2);
   if (!projectId || !profile || !outputDir) {
-    console.log("Usage: node scripts/manual/run_create_review_bundle.js <project_id> <profile> <output_dir> [--anchors] [--bundle-name <name>]");
+    console.error("Usage: WRITING_SYNC_DIR=/path/to/sync node scripts/manual/run_create_review_bundle.js <project_id> <profile> <output_dir> [--anchors] [--bundle-name <name>]");
+    process.exit(1);
+  }
+
+  if (!process.env.WRITING_SYNC_DIR) {
+    console.error(
+      "WRITING_SYNC_DIR is required. Set it to the root of your sync directory.\n" +
+      "Usage: WRITING_SYNC_DIR=/path/to/sync node scripts/manual/run_create_review_bundle.js <project_id> <profile> <output_dir>"
+    );
     process.exit(1);
   }
 
@@ -20,7 +28,7 @@ async function main() {
     env: {
       ...process.env,
       MCP_TRANSPORT: "stdio",
-      WRITING_SYNC_DIR: process.env.WRITING_SYNC_DIR || path.dirname(path.resolve(outputDir))
+      WRITING_SYNC_DIR: process.env.WRITING_SYNC_DIR
     }
   });
 

--- a/scripts/manual/run_create_review_bundle.js
+++ b/scripts/manual/run_create_review_bundle.js
@@ -47,8 +47,9 @@ async function main() {
     console.log(JSON.stringify(result, null, 2));
   } catch (e) {
     console.error(e);
+    process.exitCode = 1;
   } finally {
-    process.exit(0);
+    process.exit(process.exitCode ?? 0);
   }
 }
 

--- a/scripts/manual/run_mcp_and_review.js
+++ b/scripts/manual/run_mcp_and_review.js
@@ -17,19 +17,21 @@ async function main() {
 
   if (!projectId) {
     console.error(
-      "Usage: node run_mcp_and_review.js <projectId> [outputDir]\n" +
-      "Either provide outputDir explicitly or set WRITING_SYNC_DIR to derive a default output directory."
+      "Usage: WRITING_SYNC_DIR=/path/to/sync node scripts/manual/run_mcp_and_review.js <projectId> [outputDir]"
     );
     process.exit(1);
   }
 
-  if (!outputDirArg && !envWritingSyncDir) {
-    console.error("Missing output directory: provide [outputDir] or set WRITING_SYNC_DIR.");
+  if (!envWritingSyncDir) {
+    console.error(
+      "WRITING_SYNC_DIR is required. Set it to the root of your sync directory.\n" +
+      "Usage: WRITING_SYNC_DIR=/path/to/sync node scripts/manual/run_mcp_and_review.js <projectId> [outputDir]"
+    );
     process.exit(1);
   }
 
   const outputDir = outputDirArg || path.join(envWritingSyncDir, "exports");
-  const writingSyncDir = envWritingSyncDir || path.dirname(path.resolve(outputDir));
+  const writingSyncDir = envWritingSyncDir;
 
   const transport = new StdioClientTransport({
     command: process.execPath,

--- a/test/integration.test.mjs
+++ b/test/integration.test.mjs
@@ -1853,6 +1853,27 @@ describe("create_review_bundle tool", () => {
       fs.rmSync(outDir, { recursive: true, force: true });
     }
   });
+
+  test("returns INVALID_OUTPUT_DIR when output_dir routes through a symlink outside WRITING_SYNC_DIR", async () => {
+    const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), "mcp-writing-bundle-symlink-outside-"));
+    const symlinkDir = path.join(writeSyncDir, "exports-link");
+    try {
+      fs.symlinkSync(outsideDir, symlinkDir, "dir");
+
+      const text = await callWriteTool("create_review_bundle", {
+        project_id: "test-novel",
+        profile: "outline_discussion",
+        output_dir: path.join(symlinkDir, "nested-output"),
+      });
+      const parsed = JSON.parse(text);
+
+      assert.equal(parsed.ok, false);
+      assert.equal(parsed.error.code, "INVALID_OUTPUT_DIR");
+    } finally {
+      fs.rmSync(symlinkDir, { recursive: true, force: true });
+      fs.rmSync(outsideDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("get_scene_prose tool", () => {

--- a/test/integration.test.mjs
+++ b/test/integration.test.mjs
@@ -1759,6 +1759,85 @@ describe("preview_review_bundle tool", () => {
   });
 });
 
+describe("create_review_bundle tool", () => {
+  test("writes outline bundle markdown + manifest to output_dir", async () => {
+    const outDir = fs.mkdtempSync(path.join(os.tmpdir(), "mcp-writing-bundle-outline-"));
+    try {
+      const text = await callWriteTool("create_review_bundle", {
+        project_id: "test-novel",
+        profile: "outline_discussion",
+        output_dir: outDir,
+        bundle_name: "editorial-outline",
+        source_commit: "test-commit-hash",
+      });
+      const parsed = JSON.parse(text);
+
+      assert.equal(parsed.ok, true);
+      assert.ok(parsed.output_paths?.bundle_markdown);
+      assert.ok(parsed.output_paths?.manifest_json);
+      assert.ok(fs.existsSync(parsed.output_paths.bundle_markdown));
+      assert.ok(fs.existsSync(parsed.output_paths.manifest_json));
+
+      const markdown = fs.readFileSync(parsed.output_paths.bundle_markdown, "utf8");
+      assert.ok(markdown.includes("# Review Bundle: test-novel"));
+      assert.ok(markdown.includes("## The Return"));
+      assert.ok(!markdown.includes("She was at the bottom of the gangway"));
+
+      const manifest = JSON.parse(fs.readFileSync(parsed.output_paths.manifest_json, "utf8"));
+      assert.equal(manifest.profile, "outline_discussion");
+      assert.equal(manifest.provenance.source_commit, "test-commit-hash");
+      assert.equal(manifest.summary.scene_count, 3);
+    } finally {
+      fs.rmSync(outDir, { recursive: true, force: true });
+    }
+  });
+
+  test("writes editor bundle with prose and paragraph anchors", async () => {
+    const outDir = fs.mkdtempSync(path.join(os.tmpdir(), "mcp-writing-bundle-editor-"));
+    try {
+      const text = await callWriteTool("create_review_bundle", {
+        project_id: "test-novel",
+        profile: "editor_detailed",
+        output_dir: outDir,
+        include_paragraph_anchors: true,
+      });
+      const parsed = JSON.parse(text);
+      assert.equal(parsed.ok, true);
+
+      const markdown = fs.readFileSync(parsed.output_paths.bundle_markdown, "utf8");
+      assert.ok(markdown.includes("<!-- sc-001:p1 -->"));
+      assert.ok(markdown.includes("She was at the bottom of the gangway"));
+    } finally {
+      fs.rmSync(outDir, { recursive: true, force: true });
+    }
+  });
+
+  test("returns STRICTNESS_BLOCKED when fail mode sees stale metadata", async () => {
+    const scenePath = path.join(writeSyncDir, "projects", "test-novel", "part-1", "chapter-1", "sc-002.md");
+    const before = fs.readFileSync(scenePath, "utf8");
+    fs.writeFileSync(scenePath, `${before}\n\nStale marker line for create bundle strictness test.\n`, "utf8");
+    await callWriteTool("sync");
+
+    const outDir = fs.mkdtempSync(path.join(os.tmpdir(), "mcp-writing-bundle-blocked-"));
+    try {
+      const text = await callWriteTool("create_review_bundle", {
+        project_id: "test-novel",
+        profile: "editor_detailed",
+        output_dir: outDir,
+        strictness: "fail",
+      });
+      const parsed = JSON.parse(text);
+
+      assert.equal(parsed.ok, false);
+      assert.equal(parsed.error.code, "STRICTNESS_BLOCKED");
+    } finally {
+      fs.rmSync(outDir, { recursive: true, force: true });
+      fs.writeFileSync(scenePath, before, "utf8");
+      await callWriteTool("enrich_scene", { scene_id: "sc-002", project_id: "test-novel" });
+    }
+  });
+});
+
 describe("get_scene_prose tool", () => {
   test("returns prose content for sc-001", async () => {
     const text = await callTool("get_scene_prose", { scene_id: "sc-001" });

--- a/test/integration.test.mjs
+++ b/test/integration.test.mjs
@@ -1761,7 +1761,7 @@ describe("preview_review_bundle tool", () => {
 
 describe("create_review_bundle tool", () => {
   test("writes outline bundle markdown + manifest to output_dir", async () => {
-    const outDir = fs.mkdtempSync(path.join(os.tmpdir(), "mcp-writing-bundle-outline-"));
+    const outDir = fs.mkdtempSync(path.join(writeSyncDir, "review-bundles-outline-"));
     try {
       const text = await callWriteTool("create_review_bundle", {
         project_id: "test-novel",
@@ -1793,7 +1793,7 @@ describe("create_review_bundle tool", () => {
   });
 
   test("writes editor bundle with prose and paragraph anchors", async () => {
-    const outDir = fs.mkdtempSync(path.join(os.tmpdir(), "mcp-writing-bundle-editor-"));
+    const outDir = fs.mkdtempSync(path.join(writeSyncDir, "review-bundles-editor-"));
     try {
       const text = await callWriteTool("create_review_bundle", {
         project_id: "test-novel",
@@ -1818,7 +1818,7 @@ describe("create_review_bundle tool", () => {
     fs.writeFileSync(scenePath, `${before}\n\nStale marker line for create bundle strictness test.\n`, "utf8");
     await callWriteTool("sync");
 
-    const outDir = fs.mkdtempSync(path.join(os.tmpdir(), "mcp-writing-bundle-blocked-"));
+    const outDir = fs.mkdtempSync(path.join(writeSyncDir, "review-bundles-blocked-"));
     try {
       const text = await callWriteTool("create_review_bundle", {
         project_id: "test-novel",
@@ -1834,6 +1834,23 @@ describe("create_review_bundle tool", () => {
       fs.rmSync(outDir, { recursive: true, force: true });
       fs.writeFileSync(scenePath, before, "utf8");
       await callWriteTool("enrich_scene", { scene_id: "sc-002", project_id: "test-novel" });
+    }
+  });
+
+  test("returns INVALID_OUTPUT_DIR when output_dir is outside WRITING_SYNC_DIR", async () => {
+    const outDir = fs.mkdtempSync(path.join(os.tmpdir(), "mcp-writing-bundle-outside-"));
+    try {
+      const text = await callWriteTool("create_review_bundle", {
+        project_id: "test-novel",
+        profile: "outline_discussion",
+        output_dir: outDir,
+      });
+      const parsed = JSON.parse(text);
+
+      assert.equal(parsed.ok, false);
+      assert.equal(parsed.error.code, "INVALID_OUTPUT_DIR");
+    } finally {
+      fs.rmSync(outDir, { recursive: true, force: true });
     }
   });
 });

--- a/test/unit.test.mjs
+++ b/test/unit.test.mjs
@@ -323,6 +323,45 @@ describe("buildReviewBundlePlan", () => {
       db.close();
     }
   });
+
+  test("renderReviewBundleMarkdown throws SCENE_PROSE_READ_FAILED when file_path is null", () => {
+    const db = setupReviewBundleTestDb();
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "bundle-null-path-"));
+    const realTempDir = fs.realpathSync.native(tempDir);
+    const prevSyncDir = process.env.WRITING_SYNC_DIR;
+    process.env.WRITING_SYNC_DIR = realTempDir;
+
+    try {
+      const now = new Date().toISOString();
+      // Use a path outside syncDir — resolveSceneFilePath returns null,
+      // which should trigger SCENE_PROSE_READ_FAILED rather than silent empty prose.
+      const outsidePath = "/nonexistent-outside-sync/scene.md";
+      db.prepare(`
+        INSERT INTO scenes (
+          scene_id, project_id, title, part, chapter, timeline_position, word_count,
+          file_path, prose_checksum, metadata_stale, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run("sc-001", "test-novel", "Null Path Scene", 1, 1, 1, 10, outsidePath, null, 0, now);
+
+      const plan = buildReviewBundlePlan(db, {
+        project_id: "test-novel",
+        profile: "editor_detailed",
+      });
+
+      assert.throws(
+        () => renderReviewBundleMarkdown(db, plan, { generatedAt: "2026-01-01T00:00:00.000Z" }),
+        error => error instanceof ReviewBundlePlanError && error.code === "SCENE_PROSE_READ_FAILED"
+      );
+    } finally {
+      if (prevSyncDir === undefined) {
+        delete process.env.WRITING_SYNC_DIR;
+      } else {
+        process.env.WRITING_SYNC_DIR = prevSyncDir;
+      }
+      fs.rmSync(tempDir, { recursive: true, force: true });
+      db.close();
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/test/unit.test.mjs
+++ b/test/unit.test.mjs
@@ -287,14 +287,22 @@ describe("buildReviewBundlePlan", () => {
 
   test("renderReviewBundleMarkdown throws when scene prose cannot be read", () => {
     const db = setupReviewBundleTestDb();
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "bundle-prose-read-"));
+    // Use the real path to avoid macOS /tmp → /private/tmp symlink discrepancy.
+    const realTempDir = fs.realpathSync.native(tempDir);
+    const prevSyncDir = process.env.WRITING_SYNC_DIR;
+    process.env.WRITING_SYNC_DIR = realTempDir;
+    // Deliberately do NOT create the file — readProse should throw SCENE_PROSE_READ_FAILED.
+    const scenePath = path.join(realTempDir, "sc-001.md");
+
     try {
-      insertTestScene(db, {
-        sceneId: "sc-001",
-        part: 1,
-        chapter: 1,
-        timelinePosition: 1,
-        wordCount: 10,
-      });
+      const now = new Date().toISOString();
+      db.prepare(`
+        INSERT INTO scenes (
+          scene_id, project_id, title, part, chapter, timeline_position, word_count,
+          file_path, prose_checksum, metadata_stale, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run("sc-001", "test-novel", "Prose Read Test", 1, 1, 1, 10, scenePath, "deadbeef", 0, now);
 
       const plan = buildReviewBundlePlan(db, {
         project_id: "test-novel",
@@ -306,6 +314,12 @@ describe("buildReviewBundlePlan", () => {
         error => error instanceof ReviewBundlePlanError && error.code === "SCENE_PROSE_READ_FAILED"
       );
     } finally {
+      if (prevSyncDir === undefined) {
+        delete process.env.WRITING_SYNC_DIR;
+      } else {
+        process.env.WRITING_SYNC_DIR = prevSyncDir;
+      }
+      fs.rmSync(tempDir, { recursive: true, force: true });
       db.close();
     }
   });

--- a/test/unit.test.mjs
+++ b/test/unit.test.mjs
@@ -33,7 +33,7 @@ import {
   mergeSidecarData,
 } from "../scrivener-direct.js";
 import { runSceneCharacterBatch } from "../scene-character-batch.js";
-import { buildReviewBundlePlan } from "../review-bundles.js";
+import { buildReviewBundlePlan, renderReviewBundleMarkdown, ReviewBundlePlanError } from "../review-bundles.js";
 
 function insertTestScene(db, {
   sceneId,
@@ -195,6 +195,116 @@ describe("buildReviewBundlePlan", () => {
       assert.equal(plan.strictness_result.can_proceed, false);
       assert.equal(plan.strictness_result.blockers[0].code, "STALE_METADATA");
       assert.ok(plan.warning_summary.metadata_stale);
+    } finally {
+      db.close();
+    }
+  });
+
+  test("renderReviewBundleMarkdown escapes outline loglines with markdown metacharacters", () => {
+    const db = setupReviewBundleTestDb();
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "bundle-outline-"));
+    const scenePath = path.join(tempDir, "sc-001.md");
+    fs.writeFileSync(scenePath, "Plain prose body.\n", "utf8");
+
+    try {
+      const now = new Date().toISOString();
+      db.prepare(`
+        INSERT INTO scenes (
+          scene_id, project_id, title, part, chapter, timeline_position, word_count,
+          logline, file_path, prose_checksum, metadata_stale, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        "sc-001",
+        "test-novel",
+        "Markdown Test",
+        1,
+        1,
+        1,
+        10,
+        "A *bold* [link] `code` logline",
+        scenePath,
+        "deadbeef",
+        0,
+        now
+      );
+
+      const plan = buildReviewBundlePlan(db, {
+        project_id: "test-novel",
+        profile: "outline_discussion",
+      });
+      const markdown = renderReviewBundleMarkdown(db, plan, { generatedAt: "2026-01-01T00:00:00.000Z" });
+
+      assert.ok(markdown.includes("A \\*bold\\* \\[link\\] \\`code\\` logline"));
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+      db.close();
+    }
+  });
+
+  test("renderReviewBundleMarkdown throws when planned scene rows are missing", () => {
+    const db = setupReviewBundleTestDb();
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "bundle-missing-rows-"));
+    const scenePath = path.join(tempDir, "sc-001.md");
+    fs.writeFileSync(scenePath, "Plain prose body.\n", "utf8");
+
+    try {
+      const now = new Date().toISOString();
+      db.prepare(`
+        INSERT INTO scenes (
+          scene_id, project_id, title, part, chapter, timeline_position, word_count,
+          file_path, prose_checksum, metadata_stale, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        "sc-001",
+        "test-novel",
+        "Missing Row Test",
+        1,
+        1,
+        1,
+        10,
+        scenePath,
+        "deadbeef",
+        0,
+        now
+      );
+
+      const plan = buildReviewBundlePlan(db, {
+        project_id: "test-novel",
+        profile: "editor_detailed",
+      });
+
+      db.prepare(`DELETE FROM scenes WHERE scene_id = ? AND project_id = ?`).run("sc-001", "test-novel");
+
+      assert.throws(
+        () => renderReviewBundleMarkdown(db, plan, { generatedAt: "2026-01-01T00:00:00.000Z" }),
+        error => error instanceof ReviewBundlePlanError && error.code === "MISSING_SCENE_ROWS"
+      );
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+      db.close();
+    }
+  });
+
+  test("renderReviewBundleMarkdown throws when scene prose cannot be read", () => {
+    const db = setupReviewBundleTestDb();
+    try {
+      insertTestScene(db, {
+        sceneId: "sc-001",
+        part: 1,
+        chapter: 1,
+        timelinePosition: 1,
+        wordCount: 10,
+      });
+
+      const plan = buildReviewBundlePlan(db, {
+        project_id: "test-novel",
+        profile: "editor_detailed",
+      });
+
+      assert.throws(
+        () => renderReviewBundleMarkdown(db, plan, { generatedAt: "2026-01-01T00:00:00.000Z" }),
+        error => error instanceof ReviewBundlePlanError && error.code === "SCENE_PROSE_READ_FAILED"
+      );
     } finally {
       db.close();
     }


### PR DESCRIPTION
## Summary

- Adds `create_review_bundle` MCP tool that generates a structured Markdown artifact (+ JSON manifest) from a review-bundle plan.
- Adds `renderReviewBundleMarkdown` and `createReviewBundleArtifacts` to `review-bundles.js`.
- Registers the tool in `index.js` with output directory validation anchored to `WRITING_SYNC_DIR`.
- Moves two manual runner scripts into `scripts/manual/` and requires `WRITING_SYNC_DIR` to be set explicitly.

## Motivation

Fulfills the Phase 4A review-bundle PRD goal: allow the MCP server to produce a shareable, provenance-stamped Markdown reading packet from a planned scene scope, covering both `outline_discussion` and `editor_detailed` profiles.

## Implementation

Key technical decisions:

- **Path security**: `resolveOutputDirWithinSync()` in `index.js` walks to the nearest existing ancestor, canonicalises via `realpathSync.native`, and validates the result stays inside `SYNC_DIR_REAL`. Output file paths are checked with `lstatSync` before writing to block symlink-based escapes.
- **Scene prose security**: `resolveSceneFilePath()` only resolves paths that land inside `realSyncDir` after symlink canonicalisation. Absolute paths and `sync/`-prefixed Scrivener paths are handled; CWD resolution is rejected.
- **Markdown safety**: `escapeMarkdown()` covers `* _ ` [ ] #`; `scene_id` values are sanitised to `[a-zA-Z0-9-_.]` before embedding in HTML anchor comments.
- **Error transparency**: Missing scene rows (`MISSING_SCENE_ROWS`), unresolvable prose paths (`SCENE_PROSE_READ_FAILED`), and inaccessible ancestors (`INVALID_OUTPUT_DIR`) all surface as typed `ReviewBundlePlanError` codes rather than generic failures.
- **syncDir threading**: `syncDir` is passed explicitly through `createReviewBundleArtifacts` → `renderReviewBundleMarkdown`; the env fallback chain ends at `null` (not a guessed default path).

## Testing

- `node --experimental-sqlite --test test/unit.test.mjs test/integration.test.mjs` — 233 tests, 0 failures.
- Unit tests cover: markdown escaping, missing scene rows, unresolvable prose paths, outside-sync file paths.
- Integration tests cover: outline bundle output, editor bundle with prose/anchors, strictness blocking, output dir outside sync, symlink bypass rejection.

## Risks and tradeoffs

- There is an inherent TOCTOU window between the `lstatSync` symlink check and `writeFileSync`. This is documented in the code and acceptable for a local tool where the caller controls the output directory.
- `escapeMarkdown` escapes `#` in metadata fields. Prose content (`editor_detailed`) is written verbatim — markdown in prose is intentional and expected.

## Follow-up

- Consider adding a test for `resolveOutputDirWithinSync` when `realpathSync.native` throws (currently covered by code path but not directly exercised).
- The `sync/`-prefix strip in `resolveSceneFilePath` (Scrivener compatibility shim) has no direct test.