### PR TITLE
docs: add AGENTS workflow and reusable review skills

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,17 +1,27 @@
-## <Feature/Fix Title>
+## Summary
 
-**What changed:**
-Brief summary of the change and which files were modified.
+- Briefly describe what changed.
+- Keep this concrete and reviewer-oriented.
 
-**Why:**
-Design rationale, problem context, or architectural decision. Reference PRD.md where relevant.
+## Motivation
 
-**Review focus:**
-- Key areas/files reviewers should scrutinize
-- Non-obvious design choices or tradeoffs
-- Anything that deviates from established patterns
+Explain why the change is needed.
 
-**Testing:**
-- New tests added (unit, integration, etc.)
-- Test coverage (pass count before/after, or statement coverage)
-- Manual verification steps if applicable
+## Implementation
+
+Describe the key technical decisions.
+
+## Testing
+
+- `npm test`
+- `npm run lint`
+- Manual test of <specific workflow>
+- Not run: <reason>
+
+## Risks and tradeoffs
+
+Call out anything reviewers should pay attention to.
+
+## Follow-up
+
+List any known follow-up work, or write None.

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: code-review
+description: Use when reviewing code changes, PR diffs, reviewer comments, or deciding whether a change is ready to merge.
+---
+
+# Code Review Skill
+
+## Purpose
+
+Review changes for correctness, maintainability, scope control, and alignment with project intent.
+
+## Required process
+
+Before giving review feedback:
+
+1. Review the diff against `main`.
+2. Review related context in `PRD.md`.
+3. Identify the purpose of the change.
+4. Check whether the implementation matches that purpose.
+5. Check whether the change introduces unnecessary scope.
+6. Check tests and validation.
+7. Separate blocking issues from suggestions.
+
+## Review priorities
+
+Review in this order:
+
+1. Correctness
+2. Safety and data integrity
+3. Scope control
+4. Maintainability
+5. Test coverage
+6. Readability
+7. Style
+
+Do not spend most of the review on style if correctness or scope is unclear.
+
+## Feedback categories
+
+Use these labels when useful:
+
+- **Blocking:** Must be fixed before merge.
+- **Question:** Needs clarification before deciding.
+- **Suggestion:** Improvement, but not required.
+- **Nit:** Small style/readability issue.
+
+## Rules
+
+- Do not approve changes that contradict `PRD.md`.
+- Do not approve hidden scope expansion.
+- Do not request unrelated refactors.
+- Do not nitpick style unless it affects readability or consistency.
+- Do not assume tests passed unless evidence is present.
+- Do not treat all reviewer comments as equally important.
+- If feedback is ambiguous, ask for clarification instead of guessing.
+- Prefer small, focused follow-up PRs over expanding the current PR.
+
+## What to check
+
+### Correctness
+
+- Does the code do what the PR claims?
+- Are edge cases handled?
+- Are errors handled intentionally?
+- Are async/state transitions safe?
+- Are assumptions explicit?
+
+### Scope
+
+- Is the change limited to one concern?
+- Are unrelated files modified?
+- Is there accidental cleanup mixed in?
+- Would any part be better as a follow-up PR?
+
+### Tests
+
+- Are tests added or updated for changed behavior?
+- Do tests cover important edge cases?
+- Are integration tests needed?
+- Were tests actually run?
+
+### Maintainability
+
+- Is the logic understandable?
+- Are names clear?
+- Is duplication acceptable or harmful?
+- Is complexity proportional to the value?
+
+### Documentation
+
+- Does user-facing behavior need docs?
+- Does `PRD.md` need an update?
+- Does the PR description match the actual change?
+
+## Review output format
+
+Prefer this structure:
+
+```md
+## Review summary
+
+Brief overall assessment.
+
+## Blocking
+
+- ...
+
+## Questions
+
+- ...
+
+## Suggestions
+
+- ...
+
+## Nits
+
+- ...
+
+## Testing notes
+
+- ...
+```
+
+Omit empty sections.
+
+## When reviewing reviewer comments
+
+Group comments into:
+
+- Correctness issues
+- Required changes
+- Optional improvements
+- Opinions / preferences
+- Conflicting or unclear feedback
+
+Then recommend what to implement, what to push back on, and what to clarify.
+
+## Final review stance
+
+End with one of:
+
+- Ready to merge
+- Ready after minor changes
+- Needs changes
+- Needs clarification before review can continue

--- a/.github/skills/commit-writing/SKILL.md
+++ b/.github/skills/commit-writing/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: commit-writing
+description: Use when preparing commits, reviewing staged changes, splitting work into commits, or writing commit messages.
+---
+
+# Commit Writing Skill
+
+## Purpose
+
+Create clear, reviewable commits with useful history and no accidental noise.
+
+## Required process
+
+Before committing:
+
+1. Inspect the current branch and changed files.
+2. Review the diff.
+3. Identify whether the changes represent one concern or multiple concerns.
+4. Confirm no forbidden or unrelated files are included.
+5. Stage only the files relevant to the commit.
+6. Write a structured commit message.
+
+## Commit style
+
+Use Conventional Commit style:
+
+- `feat: ...`
+- `fix: ...`
+- `refactor: ...`
+- `test: ...`
+- `docs: ...`
+- `chore: ...`
+- `ci: ...`
+
+Use a scope when it adds clarity:
+
+```text
+feat(auth): add token refresh handling
+fix(cli): avoid writing runs.json
+docs(prd): clarify release workflow
+```
+
+## Rules
+
+- Never commit runs.json.
+- Never create vague commits such as:
+  - misc fixes
+  - updates
+  - changes
+  - wip
+- Keep each commit focused on one logical concern.
+- Separate unrelated changes into separate commits.
+- Separate formatting-only changes from behavioral changes.
+- Separate refactors from feature or bug-fix commits unless the refactor is strictly required for the change.
+- Include tests in the same commit as the behavior they validate when practical.
+- Do not amend or rewrite existing commits unless explicitly asked.
+
+## Commit message format
+
+Prefer:
+```text
+type(scope): concise imperative summary
+```
+
+Examples:
+```text
+feat(pr): add pull request description template
+fix(workflow): prevent direct commits to main
+test(cli): cover branch validation
+docs(agents): document review handling workflow
+```
+
+The summary should:
+
+- Be imperative.
+- Be specific.
+- Avoid trailing punctuation.
+- Explain the outcome, not the activity.
+
+Good:
+```text
+fix(cli): skip transient run metadata during commit
+```
+
+Bad:
+```text
+fix: stuff
+```
+
+## When multiple commits are needed
+
+Use multiple commits when the diff contains:
+
+- More than one feature
+- A bug fix plus unrelated cleanup
+- Test infrastructure plus product behavior
+- Documentation changes unrelated to the implementation
+- Generated files mixed with source changes
+
+When splitting commits, explain the proposed grouping before committing.
+
+## Final response after committing
+
+After creating commits, summarize:
+
+- Commit hash and message
+- Files included
+- Any files intentionally left uncommitted
+- Test status

--- a/.github/skills/pr-description/SKILL.md
+++ b/.github/skills/pr-description/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: pr-description
+description: Use when opening a pull request, updating a pull request description, or preparing a summary for review.
+---
+
+# PR Description Skill
+
+## Purpose
+
+Write pull request descriptions that help reviewers understand the change quickly and review it effectively.
+
+## Required process
+
+Before writing the PR description:
+
+1. Review the branch diff against `main`.
+2. Review relevant notes in `PRD.md`.
+3. Identify the user-facing or maintainer-facing purpose of the change.
+4. Identify test coverage and validation performed.
+5. Identify risks, tradeoffs, and follow-up work.
+6. Ensure the PR is scoped to one concern.
+
+## PR title
+
+Use a clear title matching the primary change.
+
+Prefer Conventional Commit style:
+
+```text
+feat: add pull request description workflow
+fix: prevent runs.json from being committed
+docs: clarify maintainer release process
+```
+
+## PR description template
+
+Use this structure:
+
+```markdown
+
+## Summary
+
+- Briefly describe what changed.
+- Keep this concrete and reviewer-oriented.
+
+## Motivation
+
+Explain why the change is needed.
+
+## Implementation
+
+Describe the key technical decisions.
+
+## Testing
+
+List validation performed.
+
+Examples:
+
+- `npm test`
+- `npm run lint`
+- Manual test of `<specific workflow>`
+- Not run: `<reason>`
+
+## Risks and tradeoffs
+
+Call out anything reviewers should pay attention to.
+
+## Follow-up
+
+List any known follow-up work, or write `None`.
+```
+
+## Rules
+
+- Do not write vague PR descriptions.
+- Do not claim tests were run unless they actually were.
+- Do not hide uncertainty. If something was not validated, say so.
+- Do not expand the PR scope in the description to make it sound larger than it is.
+- Mention any intentional omissions.
+- Mention any behavior changes explicitly.
+- Mention any migration, release, or compatibility impact if relevant.
+- Update the PR description if the implementation scope changes after review.
+
+## Good summary examples
+
+Good:
+```markdown
+## Summary
+
+- Adds a reusable PR description skill.
+- Documents the required structure for summary, motivation, implementation, testing, risks, and follow-up.
+- Aligns PR descriptions with the repo's existing PR-only workflow.
+```
+
+Bad:
+```markdown
+## Summary
+
+Updated some docs and improved workflow.
+```
+
+## Testing section rules
+
+If tests were run:
+```markdown
+## Testing
+
+- `npm test`
+- `npm run lint`
+```
+
+If tests were not run:
+```markdown
+## Testing
+
+- Not run: documentation-only change.
+```
+
+If validation was manual:
+```markdown
+## Testing
+
+- Manually reviewed generated PR description against the branch diff.
+```
+
+## Final response after opening PR
+
+After opening or updating a PR, summarize:
+
+- PR title
+- PR URL
+- Main change
+- Testing status
+-Any known risks

--- a/.github/skills/pr-description/SKILL.md
+++ b/.github/skills/pr-description/SKILL.md
@@ -132,4 +132,4 @@ After opening or updating a PR, summarize:
 - PR URL
 - Main change
 - Testing status
--Any known risks
+- Any known risks

--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -30,7 +30,8 @@ jobs:
               "## Follow-up",
             ];
 
-            const missing = requiredSections.filter((section) => !body.includes(section));
+            const bodyLower = body.toLowerCase();
+            const missing = requiredSections.filter((section) => !bodyLower.includes(section.toLowerCase()));
 
             const testingMatch = body.match(/## Testing\s*([\s\S]*?)(?=\n##\s|$)/i);
             const testingContent = testingMatch ? testingMatch[1] : "";

--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -10,33 +10,61 @@ on:
 
 jobs:
   validate-pr-body:
-    name: Validate PR body sections
+    name: Validate PR description sections
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read
 
     steps:
-      - name: Check required sections
+      - name: Check required sections and testing content
         uses: actions/github-script@v7
         with:
           script: |
             const body = context.payload.pull_request.body || "";
             const requiredSections = [
-              "**What changed:**",
-              "**Why:**",
-              "**Review focus:**",
-              "**Testing:**",
+              "## Summary",
+              "## Motivation",
+              "## Implementation",
+              "## Testing",
+              "## Risks and tradeoffs",
+              "## Follow-up",
             ];
 
             const missing = requiredSections.filter((section) => !body.includes(section));
 
-            if (missing.length > 0) {
+            const testingMatch = body.match(/## Testing\s*([\s\S]*?)(?=\n##\s|$)/i);
+            const testingContent = testingMatch ? testingMatch[1] : "";
+            const hasTestingEvidence =
+              /-\s*`[^`]+`/.test(testingContent) ||
+              /-\s*Not run\s*:/i.test(testingContent) ||
+              /-\s*Manual(?:ly)?\s+/i.test(testingContent);
+
+            if (missing.length > 0 || !hasTestingEvidence) {
+              const testingMessage = hasTestingEvidence
+                ? []
+                : [
+                    "Testing section must include at least one bullet with either:",
+                    "- a command in backticks (for example: - `npm test`)",
+                    "- Not run: <reason>",
+                    "- Manual/Manually ...",
+                    "",
+                  ];
+
               core.setFailed(
                 [
-                  "PR body is missing required template sections:",
-                  ...missing.map((section) => `- ${section}`),
+                  "PR description does not match required structure:",
+                  ...(missing.length > 0
+                    ? [
+                        "Missing required sections:",
+                        ...missing.map((section) => `- ${section}`),
+                        "",
+                      ]
+                    : []),
+                  ...testingMessage,
+                  "Expected sections (in this style):",
+                  ...requiredSections.map((section) => `- ${section}`),
                   "",
-                  "Use .github/PULL_REQUEST_TEMPLATE.md as the source of truth.",
+                  "Source of truth: .github/skills/pr-description/SKILL.md",
                 ].join("\n")
               );
             }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,10 +34,12 @@ All changes MUST follow this sequence:
 ### 2. Branch creation
 
 - Create a new branch from `main`
-- Naming:
+- Naming: follow `.github/instructions/contribution-workflow.instructions.md`
   - `feat/<short-description>`
   - `fix/<short-description>`
+  - `docs/<short-description>`
   - `chore/<short-description>`
+  - `refactor/<short-description>`
 
 ### 3. Implementation
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,31 +4,120 @@ Purpose: Persist project-specific operating context for future AI sessions.
 
 Canonical release setup and maintainer operations live in `MAINTAINERS.md`.
 
+---
+
 ## Ways of working
 
-- Always review the `PRD.md` for related notes to the functionality discussed to maintain consistency over time, and avoid unnecessary scope creep.
-- Don't implement features immediately. First, discuss potential tradeoffs with the user.
-  - Consider if a feature is in line with the established design principles of the tool, as established in the PRD.
-  - Consider if the added scope and maintenance is proportional to the added value of new functionality.
-  - Critically analyze not only the new feature, but how it relates to existing features.
-  - Always consider unit tests and integration tests as part of changes.
-- All changes should start with a new branch from `main`.
-- Always open a PR at the end
-  - Write an appropriate description that helps the reviewer effectively.
+- Always review `PRD.md` before proposing or implementing changes.
+- Do not implement immediately. First:
+  - Identify tradeoffs
+  - Validate alignment with design principles
+  - Evaluate scope vs value
+  - Consider impact on existing features
+- Always include test strategy (unit + integration) in proposals.
+- If required context is missing or unclear, STOP and ask before proceeding.
+
+---
+
+## Development workflow (strict)
+
+All changes MUST follow this sequence:
+
+- Do not skip, reorder, or parallelize workflow steps.
+
+### 1. Discussion phase
+
+- MUST review `PRD.md` before proceeding
+- No code changes before tradeoffs are discussed and approved
+- If approval is unclear, do not proceed
+
+### 2. Branch creation
+
+- Create a new branch from `main`
+- Naming:
+  - `feat/<short-description>`
+  - `fix/<short-description>`
+  - `chore/<short-description>`
+
+### 3. Implementation
+
+- Keep changes scoped to a single concern
+- Write tests alongside implementation
+- Do not include unrelated changes
+
+### 4. Commit
+
+- MUST use `skills/commit-writing/SKILL.md`
+- Do not proceed to PR until commits are clean and scoped
+
+### 5. Pull Request (required)
+
+- ALWAYS open a PR after implementation and commit preparation (no direct merges)
+- MUST use `skills/pr-description/SKILL.md`
+- PR must accurately reflect the actual implementation
+
+### 6. Review handling
+
+- MUST use `skills/code-review/SKILL.md`
+- Do not blindly apply all feedback
+- Group feedback into:
+  - correctness issues
+  - improvements
+  - opinions
+- Ask for clarification if feedback is ambiguous or conflicting
+- Do not consider the PR complete or merged unless explicitly instructed
+
+### 7. Completion
+
+A change is considered complete when:
+
+- All blocking issues are resolved
+- Tests are passing or explicitly not run with a valid reason
+- PR description matches final implementation
+
+### 8. Follow-up changes
+
+- Apply fixes in new commits (do not rewrite history unless explicitly requested)
+- Update PR description if behavior or scope changes
+
+---
+
+## Skills
+
+Use these specialized skills:
+
+- `skills/commit-writing/SKILL.md` (used during Commit step)
+- `skills/pr-description/SKILL.md` (used during Pull Request step)
+- `skills/code-review/SKILL.md` (used during Review handling step)
+
+These define execution details. This file defines workflow and constraints.
+
+---
 
 ## Repo workflow defaults
 
-- Branch strategy: PR-only into main.
-- Merge preference: linear history.
-  - Default: squash merge.
-  - Optional: rebase merge when preserving multiple meaningful commits.
-  - Avoid merge commits unless explicitly needed.
-- Direct pushes to main are not part of normal workflow.
+- Branch strategy: PR-only into main
+- Merge preference:
+  - Default: squash merge
+  - Optional: rebase merge for meaningful commit history
+  - Avoid merge commits unless necessary
+
+---
+
+## Hard constraints
+
+- Never push directly to `main`
+- Always isolate changes to a single concern per PR
+- If a branch is already merged, create a new branch for fixes
+
+---
 
 ## Session hygiene
 
-- Never commit runs.json.
-- Keep release changes in focused PRs with one concern each.
-- If branch has already merged, create a new branch for follow-up fixes.
+- Prefer clarity over speed
+- If uncertain, ask instead of assuming
+- Avoid partial implementations without explicit acknowledgment
+
+---
 
 > Specialized workflows and release debugging procedures live in `.github/instructions/`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,18 +49,18 @@ All changes MUST follow this sequence:
 
 ### 4. Commit
 
-- MUST use `skills/commit-writing/SKILL.md`
+- MUST use `.github/skills/commit-writing/SKILL.md`
 - Do not proceed to PR until commits are clean and scoped
 
 ### 5. Pull Request (required)
 
 - ALWAYS open a PR after implementation and commit preparation (no direct merges)
-- MUST use `skills/pr-description/SKILL.md`
+- MUST use `.github/skills/pr-description/SKILL.md`
 - PR must accurately reflect the actual implementation
 
 ### 6. Review handling
 
-- MUST use `skills/code-review/SKILL.md`
+- MUST use `.github/skills/code-review/SKILL.md`
 - Do not blindly apply all feedback
 - Group feedback into:
   - correctness issues
@@ -88,9 +88,9 @@ A change is considered complete when:
 
 Use these specialized skills:
 
-- `skills/commit-writing/SKILL.md` (used during Commit step)
-- `skills/pr-description/SKILL.md` (used during Pull Request step)
-- `skills/code-review/SKILL.md` (used during Review handling step)
+- `.github/skills/commit-writing/SKILL.md` (used during Commit step)
+- `.github/skills/pr-description/SKILL.md` (used during Pull Request step)
+- `.github/skills/code-review/SKILL.md` (used during Review handling step)
 
 These define execution details. This file defines workflow and constraints.
 


### PR DESCRIPTION
## Summary

- Expands AGENTS.md with a strict end-to-end contribution workflow (discussion, branch creation, implementation, commit, PR, review handling, completion, and follow-up rules).
- Adds three reusable skills under .github/skills:
  - code-review
  - commit-writing
  - pr-description
- Documents repo-level constraints and expectations for PR-only flow into main.

## Motivation

Provide persistent, explicit guidance for AI-assisted sessions so branch/PR hygiene, review handling, and commit quality are consistent across iterations.

## Implementation

- Reworked AGENTS.md into a workflow-first operations document.
- Added focused SKILL.md guides for:
  - evaluating PR diffs and feedback quality (code-review)
  - producing scoped, conventional commits (commit-writing)
  - writing accurate, reviewer-friendly PR descriptions (pr-description)
- Kept scope docs-only with no runtime code-path changes.

## Testing

- Not run: documentation/process-only changes.

## Risks and tradeoffs

- Risk: stricter workflow language may require small process adjustments in existing habits.
- No runtime or behavior impact to server/tooling code.

## Follow-up

- None.