### PR TITLE
docs: close out review bundles M1 and add troubleshooting guidance

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -165,3 +165,49 @@ rm -rf node_modules package-lock.json
 npm install
 npm test
 ```
+
+### `preview_review_bundle` or `create_review_bundle` returns warnings about stale metadata
+
+One or more scenes have `metadata_stale: true`, meaning their prose changed after metadata was last indexed.
+
+In `strictness=warn` mode (default), the bundle is generated with a warning in the response and manifest.
+
+In `strictness=fail` mode, generation is blocked and the response includes a `blockers` list with the affected `scene_ids`.
+
+Fix: re-enrich stale scenes before generating the bundle.
+
+```json
+{ "tool": "enrich_scene_characters_batch", "project_id": "your-project" }
+```
+
+Or run a full sync to pick up any external file changes:
+
+```json
+{ "tool": "sync" }
+```
+
+Then retry bundle generation.
+
+### `create_review_bundle` returns warnings about missing ordering fields
+
+Some scenes are missing `part`, `chapter`, or `timeline_position` metadata. Deterministic ordering falls back to alphabetical `scene_id` sort for those scenes, and a `missing_ordering_fields` warning is included in the response.
+
+In `strictness=warn` mode, the bundle is generated with the fallback ordering applied.
+
+In `strictness=fail` mode, generation is currently not blocked by missing ordering fields alone — only stale metadata triggers a hard block. If you need strict ordering guarantees, update the affected scenes via `update_scene_metadata` before generating.
+
+Fix: use `find_scenes` to identify scenes with null ordering fields, then update them:
+
+```json
+{ "tool": "update_scene_metadata", "scene_id": "sc-001-example", "part": 1, "chapter": 2, "timeline_position": 3 }
+```
+
+### `create_review_bundle` writes no files / `INVALID_OUTPUT_PATH`
+
+The `output_dir` path may not exist or the `bundle_name` contains characters that resolve outside the output directory.
+
+Fix:
+
+1. Create the output directory before calling the tool.
+2. Use a simple `bundle_name` with alphanumeric characters and hyphens — special characters are slugified but extreme values are rejected.
+3. Verify that `output_dir` is an absolute path pointing to a writable location outside the manuscript sync folder.

--- a/docs/development.md
+++ b/docs/development.md
@@ -174,19 +174,19 @@ In `strictness=warn` mode (default), the bundle is generated with a warning in t
 
 In `strictness=fail` mode, generation is blocked and the response includes a `blockers` list with the affected `scene_ids`.
 
-Fix: re-enrich stale scenes before generating the bundle.
+Fix: re-enrich each stale scene before generating the bundle. In `strictness=fail` mode, use the `scene_ids` returned in `strictness_result.blockers` and call `enrich_scene` for each one so metadata is re-derived and the stale flag is cleared.
 
 ```json
-{ "tool": "enrich_scene_characters_batch", "project_id": "your-project" }
+{ "tool": "enrich_scene", "scene_id": "sc-001-example" }
 ```
 
-Or run a full sync to pick up any external file changes:
+If prose or sidecars were edited outside this server, run a full sync first to refresh the index:
 
 ```json
 { "tool": "sync" }
 ```
 
-Then retry bundle generation.
+Then run `enrich_scene` for stale scenes and retry bundle generation.
 
 ### `create_review_bundle` returns warnings about missing ordering fields
 
@@ -199,15 +199,24 @@ In `strictness=fail` mode, generation is currently not blocked by missing orderi
 Fix: use `find_scenes` to identify scenes with null ordering fields, then update them:
 
 ```json
-{ "tool": "update_scene_metadata", "scene_id": "sc-001-example", "part": 1, "chapter": 2, "timeline_position": 3 }
+{
+	"tool": "update_scene_metadata",
+	"project_id": "my-project",
+	"scene_id": "sc-001-example",
+	"fields": {
+		"part": 1,
+		"chapter": 2,
+		"timeline_position": 3
+	}
+}
 ```
 
 ### `create_review_bundle` writes no files / `INVALID_OUTPUT_PATH`
 
-The `output_dir` path may not exist or the `bundle_name` contains characters that resolve outside the output directory.
+The `output_dir` path may be outside `WRITING_SYNC_DIR`, or the `bundle_name` contains characters that resolve outside the output directory.
 
 Fix:
 
-1. Create the output directory before calling the tool.
-2. Use a simple `bundle_name` with alphanumeric characters and hyphens — special characters are slugified but extreme values are rejected.
-3. Verify that `output_dir` is an absolute path pointing to a writable location outside the manuscript sync folder.
+1. Verify that `output_dir` is an absolute path pointing to a writable location inside the manuscript sync folder (`WRITING_SYNC_DIR`).
+2. You do not need to create the output directory first; the tool creates it if it does not already exist.
+3. Use a simple `bundle_name` with alphanumeric characters and hyphens — special characters are slugified to a safe name, and if nothing usable remains the tool falls back to `review-bundle`.

--- a/docs/prd/in-progress/review-bundles-implementation.md
+++ b/docs/prd/in-progress/review-bundles-implementation.md
@@ -1,6 +1,6 @@
 # Review Bundles — Phase 4A.1 Implementation Checklist
 
-**Status:** 📋 Planned
+**Status:** ✅ M1 Delivered — `outline_discussion` and `editor_detailed` tools are merged and tested
 
 This checklist scopes only the first delivery slice:
 - `outline_discussion`

--- a/docs/prd/in-progress/review-bundles.md
+++ b/docs/prd/in-progress/review-bundles.md
@@ -1,6 +1,6 @@
 # Review Bundles for Editorial Workflows
 
-**Status:** 📋 Proposed (Phase 4A)
+**Status:** ✅ M1 Delivered (Phase 4A.1) — M2 Pending (`beta_reader_personalized`)
 
 ## Goal
 


### PR DESCRIPTION
## Summary

- Promotes review-bundles PRDs from `todo/` to `in-progress/` now that M1 is merged and tested.
- Updates status fields in both PRD files to reflect that `outline_discussion` and `editor_detailed` tools are delivered.
- Adds a review bundle troubleshooting section to `docs/development.md` covering the three most common issues.

## Motivation

PRs #73 and #74 delivered the full M1 scope (planner + markdown artifact writer), but the PRD bookkeeping and user-facing troubleshooting docs were not updated as part of those PRs. This closes that gap.

## Implementation

- Rename `docs/prd/todo/review-bundles*.md` → `docs/prd/in-progress/` (git detects as renames, 98% similarity).
- Update status lines in both PRD files to `✅ M1 Delivered`.
- Add three troubleshooting entries to `docs/development.md`:
  - Stale metadata warning and how to re-enrich before bundling.
  - Missing ordering fields fallback behavior and how to fix via `update_scene_metadata`.
  - `INVALID_OUTPUT_PATH` causes and safe `output_dir` usage.

## Testing

- Not run: documentation-only change. No behaviour is modified.

## Risks and tradeoffs

None. Documentation-only change.

## Follow-up

- M2: `beta_reader_personalized` profile (notice + feedback form templates).