### PR TITLE
feat: add beta_reader_personalized review bundle profile

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -162,7 +162,7 @@ Dry-run planning tool for review bundles. Resolves scene scope, deterministic or
 | Parameter | Type | Required | Description |
 | --- | --- | :---: | --- |
 | `project_id` | `string` | Yes | Project ID to scope the review bundle (e.g. 'test-novel'). |
-| `profile` | `enum` | Yes | Bundle profile: outline_discussion or editor_detailed. |
+| `profile` | `enum` | Yes | Bundle profile: outline_discussion, editor_detailed, or beta_reader_personalized. |
 | `part` | `integer` | No | Optional part filter. |
 | `chapter` | `integer` | No | Optional chapter filter. |
 | `tag` | `string` | No | Optional tag filter (exact match). |
@@ -171,6 +171,7 @@ Dry-run planning tool for review bundles. Resolves scene scope, deterministic or
 | `include_scene_ids` | `boolean` | No | Advisory placeholder for later rendering behavior (default true). Included in preview output options, but does not change planning results in Phase 4A.1. |
 | `include_metadata_sidebar` | `boolean` | No | Advisory placeholder for later rendering behavior (default false). Included in preview output options, but does not change planning results in Phase 4A.1. |
 | `include_paragraph_anchors` | `boolean` | No | Advisory placeholder for later rendering behavior (default false). Included in preview output options, but does not change planning results in Phase 4A.1. |
+| `recipient_name` | `string` | No | Optional recipient display name for beta_reader_personalized profile. |
 | `bundle_name` | `string` | No | Optional output bundle base name override (slugified in planned outputs). |
 
 ---
@@ -182,7 +183,7 @@ Generate markdown review bundle artifacts from planned scene scope. Writes files
 | Parameter | Type | Required | Description |
 | --- | --- | :---: | --- |
 | `project_id` | `string` | Yes | Project ID to scope the review bundle (e.g. 'test-novel'). |
-| `profile` | `enum` | Yes | Bundle profile: outline_discussion or editor_detailed. |
+| `profile` | `enum` | Yes | Bundle profile: outline_discussion, editor_detailed, or beta_reader_personalized. |
 | `output_dir` | `string` | Yes | Directory path to write bundle artifacts into. |
 | `part` | `integer` | No | Optional part filter. |
 | `chapter` | `integer` | No | Optional chapter filter. |
@@ -192,6 +193,7 @@ Generate markdown review bundle artifacts from planned scene scope. Writes files
 | `include_scene_ids` | `boolean` | No | Include scene IDs in markdown headings (default true). |
 | `include_metadata_sidebar` | `boolean` | No | Include metadata sidebar in markdown output (default false). |
 | `include_paragraph_anchors` | `boolean` | No | Include paragraph anchors in markdown output (default false). |
+| `recipient_name` | `string` | No | Optional recipient display name for beta_reader_personalized profile. |
 | `bundle_name` | `string` | No | Optional output bundle base name override (slugified in filenames). |
 | `source_commit` | `string` | No | Optional explicit source commit for provenance. Defaults to current HEAD when available. |
 

--- a/index.js
+++ b/index.js
@@ -1352,7 +1352,7 @@ function createMcpServer() {
     "Dry-run planning tool for review bundles. Resolves scene scope, deterministic ordering, warnings, and planned output filenames without writing files. Note: include_scene_ids/include_metadata_sidebar/include_paragraph_anchors are advisory placeholders in Phase 4A.1 and do not alter planning semantics yet.",
     {
       project_id: z.string().describe("Project ID to scope the review bundle (e.g. 'test-novel')."),
-      profile: z.enum(REVIEW_BUNDLE_PROFILES).describe("Bundle profile: outline_discussion or editor_detailed."),
+      profile: z.enum(REVIEW_BUNDLE_PROFILES).describe("Bundle profile: outline_discussion, editor_detailed, or beta_reader_personalized."),
       part: z.number().int().optional().describe("Optional part filter."),
       chapter: z.number().int().optional().describe("Optional chapter filter."),
       tag: z.string().optional().describe("Optional tag filter (exact match)."),
@@ -1361,6 +1361,7 @@ function createMcpServer() {
       include_scene_ids: z.boolean().optional().describe("Advisory placeholder for later rendering behavior (default true). Included in preview output options, but does not change planning results in Phase 4A.1."),
       include_metadata_sidebar: z.boolean().optional().describe("Advisory placeholder for later rendering behavior (default false). Included in preview output options, but does not change planning results in Phase 4A.1."),
       include_paragraph_anchors: z.boolean().optional().describe("Advisory placeholder for later rendering behavior (default false). Included in preview output options, but does not change planning results in Phase 4A.1."),
+      recipient_name: z.string().optional().describe("Optional recipient display name for beta_reader_personalized profile."),
       bundle_name: z.string().optional().describe("Optional output bundle base name override (slugified in planned outputs)."),
     },
     async ({
@@ -1374,6 +1375,7 @@ function createMcpServer() {
       include_scene_ids = true,
       include_metadata_sidebar = false,
       include_paragraph_anchors = false,
+      recipient_name,
       bundle_name,
     }) => {
       const projectIdCheck = validateProjectId(project_id);
@@ -1393,6 +1395,7 @@ function createMcpServer() {
           include_scene_ids,
           include_metadata_sidebar,
           include_paragraph_anchors,
+          recipient_name,
           bundle_name,
         });
         return jsonResponse(plan);
@@ -1414,7 +1417,7 @@ function createMcpServer() {
     "Generate markdown review bundle artifacts from planned scene scope. Writes files only under output_dir and returns manifest/provenance details.",
     {
       project_id: z.string().describe("Project ID to scope the review bundle (e.g. 'test-novel')."),
-      profile: z.enum(REVIEW_BUNDLE_PROFILES).describe("Bundle profile: outline_discussion or editor_detailed."),
+      profile: z.enum(REVIEW_BUNDLE_PROFILES).describe("Bundle profile: outline_discussion, editor_detailed, or beta_reader_personalized."),
       output_dir: z.string().describe("Directory path to write bundle artifacts into."),
       part: z.number().int().optional().describe("Optional part filter."),
       chapter: z.number().int().optional().describe("Optional chapter filter."),
@@ -1424,6 +1427,7 @@ function createMcpServer() {
       include_scene_ids: z.boolean().optional().describe("Include scene IDs in markdown headings (default true)."),
       include_metadata_sidebar: z.boolean().optional().describe("Include metadata sidebar in markdown output (default false)."),
       include_paragraph_anchors: z.boolean().optional().describe("Include paragraph anchors in markdown output (default false)."),
+      recipient_name: z.string().optional().describe("Optional recipient display name for beta_reader_personalized profile."),
       bundle_name: z.string().optional().describe("Optional output bundle base name override (slugified in filenames)."),
       source_commit: z.string().optional().describe("Optional explicit source commit for provenance. Defaults to current HEAD when available."),
     },
@@ -1439,6 +1443,7 @@ function createMcpServer() {
       include_scene_ids = true,
       include_metadata_sidebar = false,
       include_paragraph_anchors = false,
+      recipient_name,
       bundle_name,
       source_commit,
     }) => {
@@ -1472,6 +1477,7 @@ function createMcpServer() {
           include_scene_ids,
           include_metadata_sidebar,
           include_paragraph_anchors,
+          recipient_name,
           bundle_name,
         });
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "manual:test": "node scripts/manual/test.mjs",
     "manual:scenarios": "node scripts/manual/test-scenarios.mjs",
     "manual:merge-beta-test": "node scripts/manual/run_mcp_test.js",
+    "manual:review-bundle": "node scripts/manual/run_create_review_bundle.js",
     "setup:openclaw-env": "sh scripts/setup-openclaw-env.sh",
     "release": "release-it",
     "lint": "eslint index.js importer.js db.js sync.js metadata-lint.js scripts/",

--- a/review-bundles.js
+++ b/review-bundles.js
@@ -63,8 +63,12 @@ function escapeMarkdown(text) {
     .replace(/([*_`\[\]#])/g, "\\$1");
 }
 
+function normalizeRecipientDisplayName(recipientName) {
+  return recipientName?.trim() || "Beta Reader";
+}
+
 function renderBetaNoticeMarkdown({ projectId, recipientName }) {
-  const displayName = recipientName?.trim() || "Beta Reader";
+  const displayName = normalizeRecipientDisplayName(recipientName);
   return [
     "# Non-Distribution Notice",
     "",
@@ -78,14 +82,15 @@ function renderBetaNoticeMarkdown({ projectId, recipientName }) {
   ].join("\n") + "\n";
 }
 
-function renderBetaFeedbackFormMarkdown({ projectId, recipientName }) {
-  const displayName = recipientName?.trim() || "Beta Reader";
+function renderBetaFeedbackFormMarkdown({ projectId, recipientName, generatedAt }) {
+  const displayName = normalizeRecipientDisplayName(recipientName);
+  const feedbackDate = String(generatedAt ?? new Date().toISOString()).slice(0, 10);
   return [
     "# Beta Reader Feedback Form",
     "",
     `- Project: ${escapeMarkdown(projectId)}`,
     `- Reader: ${escapeMarkdown(displayName)}`,
-    `- Date: ${new Date().toISOString().slice(0, 10)}`,
+    `- Date: ${feedbackDate}`,
     "",
     "## Big-Picture Questions",
     "",
@@ -621,13 +626,14 @@ export function renderReviewBundleMarkdown(dbHandle, plan, { generatedAt, syncDi
   const rows = loadBundleSceneRows(dbHandle, plan.resolved_scope.project_id, sceneIds);
   const sections = [];
   const recipientName = plan.resolved_scope?.options?.recipient_name;
+  const recipientDisplayName = normalizeRecipientDisplayName(recipientName);
 
   const headerLines = [
     `# Review Bundle: ${escapeMarkdown(plan.resolved_scope.project_id)}`,
     "",
     `- Profile: ${profile}`,
     ...(profile === "beta_reader_personalized"
-      ? [`- Recipient: ${escapeMarkdown(recipientName || "Beta Reader")}`]
+      ? [`- Recipient: ${escapeMarkdown(recipientDisplayName)}`]
       : []),
     `- Generated at: ${generatedAt ?? new Date().toISOString()}`,
     `- Scene count: ${plan.summary.scene_count}`,
@@ -704,10 +710,15 @@ export function createReviewBundleArtifacts(dbHandle, {
     );
   }
 
-  const markdownFileName = plan.planned_outputs.find(name => name.endsWith(".md"));
-  const manifestFileName = plan.planned_outputs.find(name => name.endsWith(".manifest.json"));
   const noticeFileName = plan.planned_outputs.find(name => name.endsWith(".notice.md")) ?? null;
   const feedbackFileName = plan.planned_outputs.find(name => name.endsWith(".feedback-form.md")) ?? null;
+  const markdownFileName = plan.planned_outputs.find(
+    name =>
+      name.endsWith(".md") &&
+      !name.endsWith(".notice.md") &&
+      !name.endsWith(".feedback-form.md")
+  );
+  const manifestFileName = plan.planned_outputs.find(name => name.endsWith(".manifest.json"));
   if (!markdownFileName || !manifestFileName) {
     throw new ReviewBundlePlanError(
       "INVALID_PLAN_OUTPUTS",
@@ -727,7 +738,7 @@ export function createReviewBundleArtifacts(dbHandle, {
     ? renderBetaNoticeMarkdown({ projectId: plan.resolved_scope.project_id, recipientName })
     : null;
   const betaFeedbackForm = plan.profile === "beta_reader_personalized"
-    ? renderBetaFeedbackFormMarkdown({ projectId: plan.resolved_scope.project_id, recipientName })
+    ? renderBetaFeedbackFormMarkdown({ projectId: plan.resolved_scope.project_id, recipientName, generatedAt })
     : null;
   const manifest = {
     bundle_id: path.basename(markdownFileName, ".md"),

--- a/review-bundles.js
+++ b/review-bundles.js
@@ -64,7 +64,13 @@ function escapeMarkdown(text) {
 }
 
 function normalizeRecipientDisplayName(recipientName) {
-  return recipientName?.trim() || "Beta Reader";
+  const normalized = String(recipientName ?? "")
+    .replace(/[\x00-\x1f\x7f]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 100);
+
+  return normalized || "Beta Reader";
 }
 
 function renderBetaNoticeMarkdown({ projectId, recipientName }) {
@@ -315,6 +321,9 @@ export function buildReviewBundlePlan(dbHandle, {
     const count = Number(row.word_count);
     return sum + (Number.isFinite(count) ? count : 0);
   }, 0);
+  const resolvedRecipientName = profile === "beta_reader_personalized"
+    ? normalizeRecipientDisplayName(recipient_name)
+    : undefined;
 
   const safeBundleName = slugifyBundleName(bundle_name || `${project_id}-${profile}`);
   const appliedFilters = {
@@ -334,7 +343,7 @@ export function buildReviewBundlePlan(dbHandle, {
         include_scene_ids: Boolean(include_scene_ids),
         include_metadata_sidebar: Boolean(include_metadata_sidebar),
         include_paragraph_anchors: Boolean(include_paragraph_anchors),
-        ...(recipient_name ? { recipient_name } : {}),
+        ...(resolvedRecipientName ? { recipient_name: resolvedRecipientName } : {}),
       },
     },
     ordering: rows.map(row => ({

--- a/review-bundles.js
+++ b/review-bundles.js
@@ -4,7 +4,7 @@ import matter from "gray-matter";
 
 const MAX_SORT_VALUE = Number.MAX_SAFE_INTEGER;
 
-export const REVIEW_BUNDLE_PROFILES = ["outline_discussion", "editor_detailed"];
+export const REVIEW_BUNDLE_PROFILES = ["outline_discussion", "editor_detailed", "beta_reader_personalized"];
 export const REVIEW_BUNDLE_STRICTNESS = ["warn", "fail"];
 
 export class ReviewBundlePlanError extends Error {
@@ -61,6 +61,51 @@ function escapeMarkdown(text) {
   return String(text ?? "")
     .replace(/\\/g, "\\\\")
     .replace(/([*_`\[\]#])/g, "\\$1");
+}
+
+function renderBetaNoticeMarkdown({ projectId, recipientName }) {
+  const displayName = recipientName?.trim() || "Beta Reader";
+  return [
+    "# Non-Distribution Notice",
+    "",
+    `This review packet is prepared for ${escapeMarkdown(displayName)} for private beta-reading purposes only.`,
+    "",
+    "Please do not distribute, repost, or share this material without explicit author permission.",
+    "",
+    "This notice is informational only and is not legal advice.",
+    "",
+    `Project: ${escapeMarkdown(projectId)}`,
+  ].join("\n") + "\n";
+}
+
+function renderBetaFeedbackFormMarkdown({ projectId, recipientName }) {
+  const displayName = recipientName?.trim() || "Beta Reader";
+  return [
+    "# Beta Reader Feedback Form",
+    "",
+    `- Project: ${escapeMarkdown(projectId)}`,
+    `- Reader: ${escapeMarkdown(displayName)}`,
+    `- Date: ${new Date().toISOString().slice(0, 10)}`,
+    "",
+    "## Big-Picture Questions",
+    "",
+    "1. Which sections felt most compelling, and why?",
+    "2. Where did pacing feel slow, rushed, or unclear?",
+    "3. Were any character motivations confusing or unconvincing?",
+    "",
+    "## Scene-Level Notes",
+    "",
+    "Use scene IDs when possible.",
+    "",
+    "- Scene ID:",
+    "- Comment:",
+    "- Severity (nit / moderate / major):",
+    "",
+    "## Final Thoughts",
+    "",
+    "- What should be prioritized in the next revision?",
+    "- Any continuity concerns to flag?",
+  ].join("\n") + "\n";
 }
 
 function resolveOutputFilePath(outputDir, fileName) {
@@ -125,6 +170,7 @@ export function buildReviewBundlePlan(dbHandle, {
   include_metadata_sidebar = false,
   include_paragraph_anchors = false,
   bundle_name,
+  recipient_name,
 } = {}) {
   if (!project_id) {
     throw new ReviewBundlePlanError("INVALID_PROJECT_ID", "project_id is required.");
@@ -283,6 +329,7 @@ export function buildReviewBundlePlan(dbHandle, {
         include_scene_ids: Boolean(include_scene_ids),
         include_metadata_sidebar: Boolean(include_metadata_sidebar),
         include_paragraph_anchors: Boolean(include_paragraph_anchors),
+        ...(recipient_name ? { recipient_name } : {}),
       },
     },
     ordering: rows.map(row => ({
@@ -308,6 +355,12 @@ export function buildReviewBundlePlan(dbHandle, {
     },
     planned_outputs: [
       `${safeBundleName}.md`,
+      ...(profile === "beta_reader_personalized"
+        ? [
+            `${safeBundleName}.notice.md`,
+            `${safeBundleName}.feedback-form.md`,
+          ]
+        : []),
       `${safeBundleName}.manifest.json`,
     ],
   };
@@ -567,19 +620,34 @@ export function renderReviewBundleMarkdown(dbHandle, plan, { generatedAt, syncDi
   const sceneIds = plan.ordering.map(row => row.scene_id);
   const rows = loadBundleSceneRows(dbHandle, plan.resolved_scope.project_id, sceneIds);
   const sections = [];
+  const recipientName = plan.resolved_scope?.options?.recipient_name;
 
   const headerLines = [
     `# Review Bundle: ${escapeMarkdown(plan.resolved_scope.project_id)}`,
     "",
     `- Profile: ${profile}`,
+    ...(profile === "beta_reader_personalized"
+      ? [`- Recipient: ${escapeMarkdown(recipientName || "Beta Reader")}`]
+      : []),
     `- Generated at: ${generatedAt ?? new Date().toISOString()}`,
     `- Scene count: ${plan.summary.scene_count}`,
   ];
   sections.push(headerLines.join("\n"));
 
+  if (profile === "beta_reader_personalized") {
+    sections.push(
+      [
+        "## Usage Notice",
+        "",
+        "This beta-reader draft is intended for private review and feedback.",
+        "Please do not redistribute without explicit author permission.",
+      ].join("\n")
+    );
+  }
+
   for (const scene of rows) {
     let prose = "";
-    if (profile === "editor_detailed") {
+    if (profile === "editor_detailed" || profile === "beta_reader_personalized") {
       const resolved = readProse(scene.file_path, { syncDir });
       if (resolved === null) {
         throw new ReviewBundlePlanError(
@@ -638,6 +706,8 @@ export function createReviewBundleArtifacts(dbHandle, {
 
   const markdownFileName = plan.planned_outputs.find(name => name.endsWith(".md"));
   const manifestFileName = plan.planned_outputs.find(name => name.endsWith(".manifest.json"));
+  const noticeFileName = plan.planned_outputs.find(name => name.endsWith(".notice.md")) ?? null;
+  const feedbackFileName = plan.planned_outputs.find(name => name.endsWith(".feedback-form.md")) ?? null;
   if (!markdownFileName || !manifestFileName) {
     throw new ReviewBundlePlanError(
       "INVALID_PLAN_OUTPUTS",
@@ -647,9 +717,18 @@ export function createReviewBundleArtifacts(dbHandle, {
 
   const markdownPath = resolveOutputFilePath(normalizedOutputDir, markdownFileName);
   const manifestPath = resolveOutputFilePath(normalizedOutputDir, manifestFileName);
+  const noticePath = noticeFileName ? resolveOutputFilePath(normalizedOutputDir, noticeFileName) : null;
+  const feedbackPath = feedbackFileName ? resolveOutputFilePath(normalizedOutputDir, feedbackFileName) : null;
 
   const generatedAt = new Date().toISOString();
   const markdown = renderReviewBundleMarkdown(dbHandle, plan, { generatedAt, syncDir });
+  const recipientName = plan.resolved_scope?.options?.recipient_name;
+  const betaNotice = plan.profile === "beta_reader_personalized"
+    ? renderBetaNoticeMarkdown({ projectId: plan.resolved_scope.project_id, recipientName })
+    : null;
+  const betaFeedbackForm = plan.profile === "beta_reader_personalized"
+    ? renderBetaFeedbackFormMarkdown({ projectId: plan.resolved_scope.project_id, recipientName })
+    : null;
   const manifest = {
     bundle_id: path.basename(markdownFileName, ".md"),
     profile: plan.profile,
@@ -665,7 +744,7 @@ export function createReviewBundleArtifacts(dbHandle, {
     scene_ids: plan.ordering.map(row => row.scene_id),
   };
 
-  for (const outputPath of [markdownPath, manifestPath]) {
+  for (const outputPath of [markdownPath, manifestPath, noticePath, feedbackPath].filter(Boolean)) {
     try {
       const stat = fs.lstatSync(outputPath);
       if (stat.isSymbolicLink()) {
@@ -692,12 +771,20 @@ export function createReviewBundleArtifacts(dbHandle, {
 
   fs.writeFileSync(markdownPath, markdown, "utf8");
   fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + "\n", "utf8");
+  if (noticePath && betaNotice != null) {
+    fs.writeFileSync(noticePath, betaNotice, "utf8");
+  }
+  if (feedbackPath && betaFeedbackForm != null) {
+    fs.writeFileSync(feedbackPath, betaFeedbackForm, "utf8");
+  }
 
   return {
     bundle_id: manifest.bundle_id,
     output_paths: {
       bundle_markdown: markdownPath,
       manifest_json: manifestPath,
+      ...(noticePath ? { notice_md: noticePath } : {}),
+      ...(feedbackPath ? { feedback_form_md: feedbackPath } : {}),
     },
     generated_at: generatedAt,
   };

--- a/scripts/manual/run_create_review_bundle.js
+++ b/scripts/manual/run_create_review_bundle.js
@@ -2,11 +2,12 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import path from "path";
 import process from "process";
+import fs from "node:fs";
 
 async function main() {
   const [projectId, profile, outputDir, ...flags] = process.argv.slice(2);
   if (!projectId || !profile || !outputDir) {
-    console.error("Usage: WRITING_SYNC_DIR=/path/to/sync node scripts/manual/run_create_review_bundle.js <project_id> <profile> <output_dir> [--anchors] [--bundle-name <name>]");
+    console.error("Usage: WRITING_SYNC_DIR=/path/to/sync node scripts/manual/run_create_review_bundle.js <project_id> <profile> <output_dir> [--anchors] [--recipient <name>] [--bundle-name <name>] [--skip-preview] [--show-files]");
     process.exit(1);
   }
 
@@ -19,8 +20,28 @@ async function main() {
   }
 
   const includeParagraphAnchors = flags.includes("--anchors");
+  const skipPreview = flags.includes("--skip-preview");
+  const showFiles = flags.includes("--show-files");
   const bundleNameIdx = flags.indexOf("--bundle-name");
   const bundleName = bundleNameIdx !== -1 ? flags[bundleNameIdx + 1] : undefined;
+  const recipientIdx = flags.indexOf("--recipient");
+  const recipientName = recipientIdx !== -1 ? flags[recipientIdx + 1] : undefined;
+
+  const baseArguments = {
+    project_id: projectId,
+    profile,
+    ...(includeParagraphAnchors ? { include_paragraph_anchors: true } : {}),
+    ...(bundleName ? { bundle_name: bundleName } : {}),
+    ...(recipientName ? { recipient_name: recipientName } : {}),
+  };
+
+  function printArtifactExcerpt(label, filePath) {
+    if (!filePath || !fs.existsSync(filePath)) return;
+    const content = fs.readFileSync(filePath, "utf8");
+    const excerpt = content.split("\n").slice(0, 20).join("\n");
+    console.log(`\n--- ${label}: ${filePath} ---`);
+    console.log(excerpt);
+  }
 
   const transport = new StdioClientTransport({
     command: process.execPath,
@@ -41,18 +62,38 @@ async function main() {
 
   try {
     await client.connect(transport);
+
+    if (!skipPreview) {
+      const previewResult = await client.callTool({
+        name: "preview_review_bundle",
+        arguments: baseArguments,
+      });
+      const previewText = previewResult.content?.[0]?.text ?? "";
+      console.log("\n=== preview_review_bundle ===");
+      console.log(previewText);
+    }
+
     const result = await client.callTool({
       name: "create_review_bundle",
       arguments: {
-        project_id: projectId,
-        profile: profile,
+        ...baseArguments,
         output_dir: outputDir,
-        ...(includeParagraphAnchors ? { include_paragraph_anchors: true } : {}),
-        ...(bundleName ? { bundle_name: bundleName } : {})
       }
     });
 
-    console.log(JSON.stringify(result, null, 2));
+    const resultText = result.content?.[0]?.text ?? "";
+    console.log("\n=== create_review_bundle ===");
+    console.log(resultText);
+
+    if (showFiles) {
+      const parsed = JSON.parse(resultText);
+      if (parsed.ok && parsed.output_paths) {
+        printArtifactExcerpt("Bundle Markdown", parsed.output_paths.bundle_markdown);
+        printArtifactExcerpt("Manifest JSON", parsed.output_paths.manifest_json);
+        printArtifactExcerpt("Notice Markdown", parsed.output_paths.notice_md);
+        printArtifactExcerpt("Feedback Form Markdown", parsed.output_paths.feedback_form_md);
+      }
+    }
   } catch (e) {
     console.error(e);
     process.exitCode = 1;

--- a/test/integration.test.mjs
+++ b/test/integration.test.mjs
@@ -1757,6 +1757,21 @@ describe("preview_review_bundle tool", () => {
     assert.equal(parsed.strictness_result.can_proceed, false);
     assert.ok(parsed.strictness_result.blockers.some(blocker => blocker.code === "STALE_METADATA"));
   });
+
+  test("beta profile preview includes planned notice + feedback outputs", async () => {
+    const text = await callTool("preview_review_bundle", {
+      project_id: "test-novel",
+      profile: "beta_reader_personalized",
+      recipient_name: "Jordan Example",
+    });
+    const parsed = JSON.parse(text);
+
+    assert.equal(parsed.ok, true);
+    assert.equal(parsed.profile, "beta_reader_personalized");
+    assert.equal(parsed.resolved_scope.options.recipient_name, "Jordan Example");
+    assert.ok(parsed.planned_outputs.some(name => name.endsWith(".notice.md")));
+    assert.ok(parsed.planned_outputs.some(name => name.endsWith(".feedback-form.md")));
+  });
 });
 
 describe("create_review_bundle tool", () => {
@@ -1807,6 +1822,43 @@ describe("create_review_bundle tool", () => {
       const markdown = fs.readFileSync(parsed.output_paths.bundle_markdown, "utf8");
       assert.ok(markdown.includes("<!-- sc-001:p1 -->"));
       assert.ok(markdown.includes("She was at the bottom of the gangway"));
+    } finally {
+      fs.rmSync(outDir, { recursive: true, force: true });
+    }
+  });
+
+  test("writes beta bundle markdown + notice + feedback artifacts", async () => {
+    const outDir = fs.mkdtempSync(path.join(writeSyncDir, "review-bundles-beta-"));
+    try {
+      const text = await callWriteTool("create_review_bundle", {
+        project_id: "test-novel",
+        profile: "beta_reader_personalized",
+        output_dir: outDir,
+        recipient_name: "Jordan Example",
+      });
+      const parsed = JSON.parse(text);
+
+      assert.equal(parsed.ok, true);
+      assert.ok(parsed.output_paths?.bundle_markdown);
+      assert.ok(parsed.output_paths?.manifest_json);
+      assert.ok(parsed.output_paths?.notice_md);
+      assert.ok(parsed.output_paths?.feedback_form_md);
+      assert.ok(fs.existsSync(parsed.output_paths.bundle_markdown));
+      assert.ok(fs.existsSync(parsed.output_paths.notice_md));
+      assert.ok(fs.existsSync(parsed.output_paths.feedback_form_md));
+
+      const markdown = fs.readFileSync(parsed.output_paths.bundle_markdown, "utf8");
+      assert.ok(markdown.includes("- Profile: beta_reader_personalized"));
+      assert.ok(markdown.includes("- Recipient: Jordan Example"));
+      assert.ok(markdown.includes("She was at the bottom of the gangway"));
+
+      const notice = fs.readFileSync(parsed.output_paths.notice_md, "utf8");
+      assert.ok(notice.includes("Non-Distribution Notice"));
+      assert.ok(notice.includes("Jordan Example"));
+
+      const feedback = fs.readFileSync(parsed.output_paths.feedback_form_md, "utf8");
+      assert.ok(feedback.includes("Beta Reader Feedback Form"));
+      assert.ok(feedback.includes("Jordan Example"));
     } finally {
       fs.rmSync(outDir, { recursive: true, force: true });
     }

--- a/test/integration.test.mjs
+++ b/test/integration.test.mjs
@@ -1771,6 +1771,15 @@ describe("preview_review_bundle tool", () => {
     assert.equal(parsed.resolved_scope.options.recipient_name, "Jordan Example");
     assert.ok(parsed.planned_outputs.some(name => name.endsWith(".notice.md")));
     assert.ok(parsed.planned_outputs.some(name => name.endsWith(".feedback-form.md")));
+    assert.ok(
+      parsed.planned_outputs.some(
+        name =>
+          name.endsWith(".md") &&
+          !name.endsWith(".notice.md") &&
+          !name.endsWith(".feedback-form.md")
+      )
+    );
+    assert.ok(parsed.planned_outputs.some(name => name.endsWith(".manifest.json")));
   });
 });
 
@@ -1844,6 +1853,7 @@ describe("create_review_bundle tool", () => {
       assert.ok(parsed.output_paths?.notice_md);
       assert.ok(parsed.output_paths?.feedback_form_md);
       assert.ok(fs.existsSync(parsed.output_paths.bundle_markdown));
+      assert.ok(fs.existsSync(parsed.output_paths.manifest_json));
       assert.ok(fs.existsSync(parsed.output_paths.notice_md));
       assert.ok(fs.existsSync(parsed.output_paths.feedback_form_md));
 
@@ -1852,6 +1862,8 @@ describe("create_review_bundle tool", () => {
       assert.ok(markdown.includes("- Recipient: Jordan Example"));
       assert.ok(markdown.includes("She was at the bottom of the gangway"));
 
+      const manifest = JSON.parse(fs.readFileSync(parsed.output_paths.manifest_json, "utf8"));
+
       const notice = fs.readFileSync(parsed.output_paths.notice_md, "utf8");
       assert.ok(notice.includes("Non-Distribution Notice"));
       assert.ok(notice.includes("Jordan Example"));
@@ -1859,6 +1871,7 @@ describe("create_review_bundle tool", () => {
       const feedback = fs.readFileSync(parsed.output_paths.feedback_form_md, "utf8");
       assert.ok(feedback.includes("Beta Reader Feedback Form"));
       assert.ok(feedback.includes("Jordan Example"));
+      assert.ok(feedback.includes(`- Date: ${manifest.generated_at.slice(0, 10)}`));
     } finally {
       fs.rmSync(outDir, { recursive: true, force: true });
     }

--- a/test/unit.test.mjs
+++ b/test/unit.test.mjs
@@ -200,6 +200,34 @@ describe("buildReviewBundlePlan", () => {
     }
   });
 
+  test("beta profile plans companion notice and feedback outputs", () => {
+    const db = setupReviewBundleTestDb();
+    try {
+      insertTestScene(db, {
+        sceneId: "sc-010",
+        part: 1,
+        chapter: 1,
+        timelinePosition: 1,
+        wordCount: 250,
+      });
+
+      const plan = buildReviewBundlePlan(db, {
+        project_id: "test-novel",
+        profile: "beta_reader_personalized",
+        recipient_name: "Alex Reader",
+      });
+
+      assert.equal(plan.ok, true);
+      assert.equal(plan.resolved_scope.options.recipient_name, "Alex Reader");
+      assert.ok(plan.planned_outputs.some(name => name.endsWith(".md")));
+      assert.ok(plan.planned_outputs.some(name => name.endsWith(".notice.md")));
+      assert.ok(plan.planned_outputs.some(name => name.endsWith(".feedback-form.md")));
+      assert.ok(plan.planned_outputs.some(name => name.endsWith(".manifest.json")));
+    } finally {
+      db.close();
+    }
+  });
+
   test("renderReviewBundleMarkdown escapes outline loglines with markdown metacharacters", () => {
     const db = setupReviewBundleTestDb();
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "bundle-outline-"));

--- a/test/unit.test.mjs
+++ b/test/unit.test.mjs
@@ -219,7 +219,14 @@ describe("buildReviewBundlePlan", () => {
 
       assert.equal(plan.ok, true);
       assert.equal(plan.resolved_scope.options.recipient_name, "Alex Reader");
-      assert.ok(plan.planned_outputs.some(name => name.endsWith(".md")));
+      assert.ok(
+        plan.planned_outputs.some(
+          name =>
+            name.endsWith(".md") &&
+            !name.endsWith(".notice.md") &&
+            !name.endsWith(".feedback-form.md")
+        )
+      );
       assert.ok(plan.planned_outputs.some(name => name.endsWith(".notice.md")));
       assert.ok(plan.planned_outputs.some(name => name.endsWith(".feedback-form.md")));
       assert.ok(plan.planned_outputs.some(name => name.endsWith(".manifest.json")));

--- a/test/unit.test.mjs
+++ b/test/unit.test.mjs
@@ -235,6 +235,29 @@ describe("buildReviewBundlePlan", () => {
     }
   });
 
+  test("beta profile normalizes recipient_name in resolved options", () => {
+    const db = setupReviewBundleTestDb();
+    try {
+      insertTestScene(db, {
+        sceneId: "sc-011",
+        part: 1,
+        chapter: 1,
+        timelinePosition: 1,
+        wordCount: 250,
+      });
+
+      const plan = buildReviewBundlePlan(db, {
+        project_id: "test-novel",
+        profile: "beta_reader_personalized",
+        recipient_name: "  Jordan\n\tExample  ",
+      });
+
+      assert.equal(plan.resolved_scope.options.recipient_name, "Jordan Example");
+    } finally {
+      db.close();
+    }
+  });
+
   test("renderReviewBundleMarkdown escapes outline loglines with markdown metacharacters", () => {
     const db = setupReviewBundleTestDb();
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "bundle-outline-"));


### PR DESCRIPTION
## Summary

- Adds M2 baseline support for the `beta_reader_personalized` profile in review bundles.
- Extends bundle planning to include beta companion outputs: `*.notice.md` and `*.feedback-form.md`.
- Extends artifact generation to write companion files and return their output paths.
- Adds `recipient_name` as an optional input to `preview_review_bundle` and `create_review_bundle`.
- Adds unit/integration coverage for beta planning and artifact generation.
- Regenerates `docs/tools.md` to reflect updated tool schemas.

## Motivation

Phase 4A.2 calls for personalized beta-reader bundles with explicit non-distribution framing and an attached feedback form. M1 delivered planner + markdown bundle generation for `outline_discussion` and `editor_detailed`; this closes the next planned slice.

## Implementation

- `review-bundles.js`:
  - Adds `beta_reader_personalized` to `REVIEW_BUNDLE_PROFILES`.
  - Threads optional `recipient_name` through plan options.
  - Adds beta planned outputs (`.notice.md`, `.feedback-form.md`).
  - Renders beta bundle markdown as prose-heavy output (same prose inclusion behavior as editor profile), with recipient header and usage notice.
  - Adds companion template renderers for notice and feedback form markdown.
  - Writes companion artifacts when profile is beta and returns `notice_md` / `feedback_form_md` paths.
- `index.js`:
  - Updates tool schema descriptions to include beta profile.
  - Adds optional `recipient_name` parameter to preview/create review bundle tools.
  - Threads `recipient_name` into planning.
- Tests:
  - Unit: verifies beta planned outputs and recipient_name option propagation.
  - Integration: verifies beta preview planned outputs and beta create writes markdown + notice + feedback artifacts.

## Testing

- `npm test`
- `npm test -- --grep "review_bundle"`

## Risks and tradeoffs

- `recipient_name` is optional (default fallback: "Beta Reader") to preserve API compatibility and avoid introducing a new hard requirement for profile creation.
- Notice/feedback templates are intentionally simple and fixed-format in this slice; this avoids template-system scope expansion.
- Beta profile currently reuses prose rendering behavior from editor profile for deterministic consistency.

## Follow-up

- Confirm whether `recipient_name` should become required for `beta_reader_personalized` in a future tightening pass.
- Iterate on notice/feedback schema once real reader workflows provide feedback.
- Optional: add explicit response metadata listing companion artifacts by semantic role in addition to file paths.
