### PR TITLE
fix(scene-character-batch): tighten precision-first character linking

### DIFF
--- a/scene-character-batch.js
+++ b/scene-character-batch.js
@@ -30,14 +30,16 @@ function normalizeCharacterRows(rows) {
   const clean = rows
     .filter(row => row?.character_id && row?.name)
     .map(row => {
-      const tokens = [...new Set(String(row.name).toLowerCase().split(/\s+/).filter(Boolean))];
+      const phrase_tokens = String(row.name).toLowerCase().split(/\s+/).filter(Boolean);
+      const tokens = [...new Set(phrase_tokens)];
       return {
         character_id: row.character_id,
         name: String(row.name).trim(),
+        phrase_tokens,
         tokens,
         informative_tokens: tokens.filter(isDistinctiveToken),
-        full_name_regex: tokens.length > 1
-          ? new RegExp(`\\b${tokens.map(escapeRegex).join("\\s+")}\\b`, "i")
+        full_name_regex: phrase_tokens.length > 1
+          ? new RegExp(`\\b${phrase_tokens.map(escapeRegex).join("\\s+")}\\b`, "i")
           : null,
       };
     })
@@ -78,7 +80,7 @@ function inferCharactersFromProse(prose, characterRows) {
     }
 
     // Precision-first v1 policy: multi-token names require a full phrase match.
-    if (row.tokens.length !== 1) {
+    if (row.phrase_tokens.length !== 1) {
       continue;
     }
 

--- a/scene-character-batch.js
+++ b/scene-character-batch.js
@@ -2,50 +2,87 @@ import fs from "node:fs";
 import matter from "gray-matter";
 import { normalizeSceneMetaForPath, readMeta, writeMeta } from "./sync.js";
 
+const NON_DISTINCTIVE_TOKENS = new Set([
+  "the",
+  "and",
+  "for",
+  "with",
+  "from",
+  "into",
+  "onto",
+  "over",
+  "under",
+  "after",
+  "before",
+  "about",
+  "around",
+]);
+
 function escapeRegex(text) {
   return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function isDistinctiveToken(token) {
+  return Boolean(token) && token.length >= 3 && !NON_DISTINCTIVE_TOKENS.has(token);
 }
 
 function normalizeCharacterRows(rows) {
   const clean = rows
     .filter(row => row?.character_id && row?.name)
-    .map(row => ({
-      character_id: row.character_id,
-      name: String(row.name).trim(),
-      tokens: [...new Set(String(row.name).toLowerCase().split(/\s+/).filter(Boolean))],
-    }))
+    .map(row => {
+      const tokens = [...new Set(String(row.name).toLowerCase().split(/\s+/).filter(Boolean))];
+      return {
+        character_id: row.character_id,
+        name: String(row.name).trim(),
+        tokens,
+        informative_tokens: tokens.filter(isDistinctiveToken),
+        full_name_regex: tokens.length > 1
+          ? new RegExp(`\\b${tokens.map(escapeRegex).join("\\s+")}\\b`, "i")
+          : null,
+      };
+    })
     .filter(row => row.name.length > 0);
 
   const tokenMap = new Map();
+  const byId = new Map();
+  const nameMap = new Map();
   for (const row of clean) {
-    for (const token of row.tokens) {
-      if (!token || token.length < 3) continue;
+    byId.set(row.character_id, row);
+
+    const normalizedName = row.name.toLowerCase();
+    const exactNameIds = nameMap.get(normalizedName) ?? [];
+    exactNameIds.push(row.character_id);
+    nameMap.set(normalizedName, exactNameIds);
+
+    for (const token of row.informative_tokens) {
       const ids = tokenMap.get(token) ?? [];
       ids.push(row.character_id);
       tokenMap.set(token, ids);
     }
   }
 
-  return { clean, tokenMap };
+  return { clean, tokenMap, byId, nameMap };
 }
 
 function inferCharactersFromProse(prose, characterRows) {
   const { clean, tokenMap } = characterRows;
   const inferred = new Set();
+  const full_name_matches = new Set();
   const ambiguous_tokens = [];
 
   for (const row of clean) {
-    if (row.tokens.length > 1) {
-      const pattern = row.tokens.map(escapeRegex).join("\\s+");
-      const regex = new RegExp(`\\b${pattern}\\b`, "i");
-      if (regex.test(prose)) {
-        inferred.add(row.character_id);
-        continue;
-      }
+    if (row.full_name_regex?.test(prose)) {
+      inferred.add(row.character_id);
+      full_name_matches.add(row.character_id);
+      continue;
     }
 
-    for (const token of row.tokens) {
-      if (!token || token.length < 3) continue;
+    // Precision-first v1 policy: multi-token names require a full phrase match.
+    if (row.tokens.length !== 1) {
+      continue;
+    }
+
+    for (const token of row.informative_tokens) {
       const tokenRegex = new RegExp(`\\b${escapeRegex(token)}\\b`, "i");
       if (!tokenRegex.test(prose)) continue;
 
@@ -58,10 +95,71 @@ function inferCharactersFromProse(prose, characterRows) {
     }
   }
 
+  for (const [token, tokenIds] of tokenMap.entries()) {
+    if (tokenIds.length < 2) continue;
+    const tokenRegex = new RegExp(`\\b${escapeRegex(token)}\\b`, "i");
+    if (tokenRegex.test(prose) && !ambiguous_tokens.includes(token)) {
+      ambiguous_tokens.push(token);
+    }
+  }
+
   return {
     inferred_characters: [...inferred],
+    full_name_matches: [...full_name_matches],
     ambiguous_tokens,
   };
+}
+
+function resolveCharacterEntry(entry, characterRows) {
+  const value = String(entry ?? "").trim();
+  if (!value) return null;
+
+  if (characterRows.byId.has(value)) {
+    return value;
+  }
+
+  const exactNameIds = characterRows.nameMap.get(value.toLowerCase());
+  if (exactNameIds?.length === 1) {
+    return exactNameIds[0];
+  }
+
+  const words = value.toLowerCase().split(/\s+/).filter(isDistinctiveToken);
+  if (words.length === 0) {
+    return value;
+  }
+
+  const matches = characterRows.clean.filter(row =>
+    words.every(word => row.informative_tokens.includes(word))
+  );
+
+  if (matches.length === 1) {
+    return matches[0].character_id;
+  }
+
+  return value;
+}
+
+function pruneLessSpecificCharacters(characterIds, fullNameMatches, characterRows) {
+  const kept = new Set(characterIds);
+
+  for (const candidateId of [...kept]) {
+    const candidate = characterRows.byId.get(candidateId);
+    if (!candidate || candidate.informative_tokens.length < 2) continue;
+
+    for (const dominantId of fullNameMatches) {
+      if (candidateId === dominantId) continue;
+      const dominant = characterRows.byId.get(dominantId);
+      if (!dominant) continue;
+      if (candidate.informative_tokens.length >= dominant.informative_tokens.length) continue;
+
+      if (candidate.informative_tokens.every(token => dominant.informative_tokens.includes(token))) {
+        kept.delete(candidateId);
+        break;
+      }
+    }
+  }
+
+  return [...kept];
 }
 
 function nextTurn() {
@@ -125,10 +223,15 @@ export async function runSceneCharacterBatch({ syncDir, args, onProgress, should
       const { meta } = readMeta(scene.file_path, syncDir, { writable: !dry_run });
 
       const before_characters = [...new Set((meta.characters ?? []).map(String).filter(Boolean))];
+      const normalized_before_characters = [...new Set(
+        before_characters
+          .map(character => resolveCharacterEntry(character, normalizedCharacterRows))
+          .filter(Boolean)
+      )];
       const inference = inferCharactersFromProse(prose, normalizedCharacterRows);
       const inferred_characters = inference.inferred_characters;
 
-      const afterSet = new Set(before_characters);
+      const afterSet = new Set(normalized_before_characters);
       if (replace_mode === "replace") {
         afterSet.clear();
       }
@@ -136,7 +239,11 @@ export async function runSceneCharacterBatch({ syncDir, args, onProgress, should
         afterSet.add(characterId);
       }
 
-      const after_characters = [...afterSet];
+      const after_characters = pruneLessSpecificCharacters(
+        [...afterSet],
+        inference.full_name_matches,
+        normalizedCharacterRows
+      );
       const beforeSet = new Set(before_characters);
       const added = after_characters.filter(id => !beforeSet.has(id));
       const afterSetLookup = new Set(after_characters);

--- a/test/integration.test.mjs
+++ b/test/integration.test.mjs
@@ -235,7 +235,7 @@ No name. No explanation.
 
 She turned the card over. On the back, in smaller writing: *You know what happened to your father. We do too.*
 
-Elena sat down on the floor of the empty flat and stared at the card for a long time.
+Elena Voss sat down on the floor of the empty flat and stared at the card for a long time.
 `
   );
 

--- a/test/unit.test.mjs
+++ b/test/unit.test.mjs
@@ -1280,6 +1280,32 @@ describe("runSceneCharacterBatch", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
+  test("does not infer multi-token names from a non-distinctive token", async () => {
+    const { dir } = makeBatchFixture();
+    const filePath = writeBatchScene(dir, "sc-001", "The airport crowd surges toward the gate.", []);
+
+    const result = await runSceneCharacterBatch({
+      syncDir: dir,
+      args: {
+        project_id: "test-novel",
+        dry_run: true,
+        replace_mode: "merge",
+        include_match_details: true,
+        target_scenes: [{ scene_id: "sc-001", project_id: "test-novel", file_path: filePath }],
+        character_rows: [
+          { character_id: "char-the-swarm", name: "The Swarm" },
+        ],
+      },
+    });
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.results[0].inferred_characters, []);
+    assert.deepEqual(result.results[0].match_details.ambiguous_tokens, []);
+    assert.equal(result.results[0].status, "unchanged");
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
   test("keeps status unchanged when inferred matches coexist with ambiguous tokens", async () => {
     const { dir } = makeBatchFixture();
     const filePath = writeBatchScene(dir, "sc-001", "Elena Vasquez arrives after dark.", ["elena-v"]);
@@ -1329,6 +1355,57 @@ describe("runSceneCharacterBatch", () => {
     assert.deepEqual(result.results[0].after_characters.sort(), ["elena", "marcus"]);
     assert.deepEqual(result.results[0].added, ["elena"]);
     assert.deepEqual(result.results[0].removed, []);
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("merge mode normalizes legacy plain-name entries to canonical ids", async () => {
+    const { dir } = makeBatchFixture();
+    const filePath = writeBatchScene(dir, "sc-001", "No named character appears here.", ["Elena Vasquez"]);
+
+    const result = await runSceneCharacterBatch({
+      syncDir: dir,
+      args: {
+        project_id: "test-novel",
+        dry_run: true,
+        replace_mode: "merge",
+        target_scenes: [{ scene_id: "sc-001", project_id: "test-novel", file_path: filePath }],
+        character_rows: [
+          { character_id: "char-elena-vasquez", name: "Elena Vasquez" },
+        ],
+      },
+    });
+
+    assert.deepEqual(result.results[0].before_characters, ["Elena Vasquez"]);
+    assert.deepEqual(result.results[0].after_characters, ["char-elena-vasquez"]);
+    assert.deepEqual(result.results[0].added, ["char-elena-vasquez"]);
+    assert.deepEqual(result.results[0].removed, ["Elena Vasquez"]);
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("removes a less specific existing id when a more specific full-name match is inferred", async () => {
+    const { dir } = makeBatchFixture();
+    const filePath = writeBatchScene(dir, "sc-001", "Victor Alexeyevich Sidorin studies the report.", ["char-victor-sidorin"]);
+
+    const result = await runSceneCharacterBatch({
+      syncDir: dir,
+      args: {
+        project_id: "test-novel",
+        dry_run: true,
+        replace_mode: "merge",
+        target_scenes: [{ scene_id: "sc-001", project_id: "test-novel", file_path: filePath }],
+        character_rows: [
+          { character_id: "char-victor-sidorin", name: "Victor Sidorin" },
+          { character_id: "char-victor-alexeyevich-sidorin", name: "Victor Alexeyevich Sidorin" },
+        ],
+      },
+    });
+
+    assert.deepEqual(result.results[0].before_characters, ["char-victor-sidorin"]);
+    assert.deepEqual(result.results[0].after_characters, ["char-victor-alexeyevich-sidorin"]);
+    assert.deepEqual(result.results[0].added, ["char-victor-alexeyevich-sidorin"]);
+    assert.deepEqual(result.results[0].removed, ["char-victor-sidorin"]);
 
     fs.rmSync(dir, { recursive: true, force: true });
   });

--- a/test/unit.test.mjs
+++ b/test/unit.test.mjs
@@ -1256,7 +1256,7 @@ describe("runSceneCharacterBatch", () => {
 
   test("does not treat duplicate tokens in one name as ambiguous", async () => {
     const { dir } = makeBatchFixture();
-    const filePath = writeBatchScene(dir, "sc-001", "Luna appears in the doorway.", []);
+    const filePath = writeBatchScene(dir, "sc-001", "Luna Luna appears in the doorway.", []);
 
     const result = await runSceneCharacterBatch({
       syncDir: dir,
@@ -1276,6 +1276,33 @@ describe("runSceneCharacterBatch", () => {
     assert.equal(result.ok, true);
     assert.deepEqual(result.results[0].inferred_characters, ["luna"]);
     assert.deepEqual(result.results[0].match_details.ambiguous_tokens, []);
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("does not infer repeated-token names from a single token mention", async () => {
+    const { dir } = makeBatchFixture();
+    const filePath = writeBatchScene(dir, "sc-001", "Luna appears in the doorway.", []);
+
+    const result = await runSceneCharacterBatch({
+      syncDir: dir,
+      args: {
+        project_id: "test-novel",
+        dry_run: true,
+        replace_mode: "merge",
+        include_match_details: true,
+        target_scenes: [{ scene_id: "sc-001", project_id: "test-novel", file_path: filePath }],
+        character_rows: [
+          { character_id: "luna", name: "Luna Luna" },
+          { character_id: "marcus", name: "Marcus Hale" },
+        ],
+      },
+    });
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.results[0].inferred_characters, []);
+    assert.deepEqual(result.results[0].match_details.ambiguous_tokens, []);
+    assert.equal(result.results[0].status, "unchanged");
 
     fs.rmSync(dir, { recursive: true, force: true });
   });


### PR DESCRIPTION
## Summary
- Tighten batch character matching to reduce false positives.
- Require full-phrase match for multi-token names and ignore non-distinctive tokens for token matching.
- Normalize legacy plain-name scene character entries to canonical IDs and prune less-specific IDs when a more specific full-name match is inferred.
- Add unit regressions for Swarm over-linking, legacy-name normalization, and Victor duplicate pruning.
- Update one integration fixture to assert write-path behavior with an explicit full-name mention under precision-first rules.

## Motivation
Batch character enrichment was over-linking broad names (for example "The Swarm") and preserving mixed canonical/non-canonical character entries, which polluted scene-character links and downstream arc/filter analysis.

## Implementation
- Refactor scene-character batch inference to distinguish full-name phrase matches from single-token inference.
- Enforce precision-first behavior for multi-token names.
- Add canonicalization pass for existing sidecar character entries before merge.
- Add pruning step that removes less-specific existing IDs when dominated by a more specific full-name match.
- Keep output contract and async job behavior unchanged.

## Testing
- `npm run lint`
- `npm test`

## Risks and tradeoffs
- Recall is intentionally lower for partial mentions of multi-token names; this is a deliberate precision-first tradeoff.
- Existing polluted scene metadata is not auto-cleaned by this PR; this change prevents future over-linking and improves normalization during subsequent batch runs.

## Follow-up
- Add a targeted metadata cleanup pass for already polluted scene sidecars.
- Add metadata-lint checks for mixed canonical/non-canonical scene character entries.