### PR TITLE
fix(metadata-lint): warn on mixed scene character reference styles

### DIFF
--- a/metadata-lint.js
+++ b/metadata-lint.js
@@ -119,6 +119,21 @@ function validateUniqueArrays(meta, kind, issues) {
   }
 }
 
+function validateSceneCharacterReferenceStyle(meta, issues) {
+  if (!Array.isArray(meta.characters) || meta.characters.length === 0) return;
+
+  const hasCanonicalIds = meta.characters.some(value => /^char-/.test(String(value).trim()));
+  const hasNonCanonicalEntries = meta.characters.some(value => !/^char-/.test(String(value).trim()));
+
+  if (!hasCanonicalIds || !hasNonCanonicalEntries) return;
+
+  issues.push({
+    level: "warning",
+    code: "MIXED_CHARACTER_REFERENCE_STYLE",
+    message: "Scene characters contains mixed canonical and non-canonical references. Prefer canonical character_id values only.",
+  });
+}
+
 export function validateMetadataObject(meta, { sourcePath, kindHint } = {}) {
   const issues = [];
   const kind = metadataKindSchema.parse(kindHint ?? detectMetadataKind(meta));
@@ -167,6 +182,10 @@ export function validateMetadataObject(meta, { sourcePath, kindHint } = {}) {
   }
 
   validateUniqueArrays(meta, kind, issues);
+
+  if (kind === "scene") {
+    validateSceneCharacterReferenceStyle(meta, issues);
+  }
 
   if (kind === "scene" && sourcePath) {
     const sidecar = sourcePath.endsWith(".meta.yaml");

--- a/metadata-lint.js
+++ b/metadata-lint.js
@@ -122,6 +122,8 @@ function validateUniqueArrays(meta, kind, issues) {
 function validateSceneCharacterReferenceStyle(meta, issues) {
   if (!Array.isArray(meta.characters) || meta.characters.length === 0) return;
 
+  if (!meta.characters.every(value => typeof value === "string")) return;
+
   const hasCanonicalIds = meta.characters.some(value => /^char-/.test(String(value).trim()));
   const hasNonCanonicalEntries = meta.characters.some(value => !/^char-/.test(String(value).trim()));
 
@@ -130,7 +132,7 @@ function validateSceneCharacterReferenceStyle(meta, issues) {
   issues.push({
     level: "warning",
     code: "MIXED_CHARACTER_REFERENCE_STYLE",
-    message: "Scene characters contains mixed canonical and non-canonical references. Prefer canonical character_id values only.",
+    message: "Scene characters contain mixed canonical and non-canonical references. Prefer canonical character_id values only.",
   });
 }
 

--- a/test/unit.test.mjs
+++ b/test/unit.test.mjs
@@ -2966,6 +2966,19 @@ describe("metadata lint", () => {
     assert.ok(!result.issues.some(i => i.code === "MIXED_CHARACTER_REFERENCE_STYLE"));
   });
 
+  test("does not warn when scene character references are non-canonical only", () => {
+    const result = validateMetadataObject({
+      scene_id: "sc-001",
+      title: "Arrival",
+      part: 1,
+      chapter: 1,
+      characters: ["Victor Sidorin", "Sebastian"],
+    });
+
+    assert.equal(result.ok, true);
+    assert.ok(!result.issues.some(i => i.code === "MIXED_CHARACTER_REFERENCE_STYLE"));
+  });
+
   test("flags schema errors and legacy keys", () => {
     const result = validateMetadataObject({
       scene_id: "sc-001",

--- a/test/unit.test.mjs
+++ b/test/unit.test.mjs
@@ -2940,6 +2940,32 @@ describe("metadata lint", () => {
     assert.equal(result.issues.length, 0);
   });
 
+  test("warns on mixed canonical and non-canonical scene character references", () => {
+    const result = validateMetadataObject({
+      scene_id: "sc-001",
+      title: "Arrival",
+      part: 1,
+      chapter: 1,
+      characters: ["char-elena", "Victor Sidorin"],
+    });
+
+    assert.equal(result.ok, true);
+    assert.ok(result.issues.some(i => i.code === "MIXED_CHARACTER_REFERENCE_STYLE"));
+  });
+
+  test("does not warn when scene character references are canonical only", () => {
+    const result = validateMetadataObject({
+      scene_id: "sc-001",
+      title: "Arrival",
+      part: 1,
+      chapter: 1,
+      characters: ["char-elena", "char-marcus"],
+    });
+
+    assert.equal(result.ok, true);
+    assert.ok(!result.issues.some(i => i.code === "MIXED_CHARACTER_REFERENCE_STYLE"));
+  });
+
   test("flags schema errors and legacy keys", () => {
     const result = validateMetadataObject({
       scene_id: "sc-001",


### PR DESCRIPTION
## Summary
- Add a scene metadata lint warning when the characters array mixes canonical IDs (char-*) with non-canonical entries.
- Keep lint non-blocking by classifying this as a warning, not an error.
- Add unit coverage for both mixed-style warning and canonical-only no-warning behavior.

## Motivation
Mixed character reference styles in scene sidecars cause inconsistent indexing and downstream analysis noise. A dedicated lint warning makes this visible early without blocking workflows.

## Implementation
- Add validateSceneCharacterReferenceStyle in metadata-lint validation flow.
- Detect mixed usage of canonical character_id entries and non-canonical entries in scene characters arrays.
- Emit warning code MIXED_CHARACTER_REFERENCE_STYLE with actionable message.
- Add unit tests in test/unit.test.mjs for mixed and canonical-only cases.

## Testing
- `npm run lint`
- `npm test`

## Risks and tradeoffs
- Warning-only behavior does not enforce automatic correction; it relies on user follow-up.
- Detection is format-based and intentionally conservative to avoid false hard failures.

## Follow-up
- Add a cleanup utility to normalize existing scene sidecars to canonical character IDs.
- Consider optional strict mode to promote this warning to an error in CI.