### PR TITLE
feat(styleguide): generate prose-styleguide.md from resolved config

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -16,6 +16,7 @@
 - [`get_runtime_config`](#get_runtime_config)
 - [`setup_prose_styleguide_config`](#setup_prose_styleguide_config)
 - [`get_prose_styleguide_config`](#get_prose_styleguide_config)
+- [`setup_prose_styleguide_skill`](#setup_prose_styleguide_skill)
 - [`preview_review_bundle`](#preview_review_bundle)
 - [`create_review_bundle`](#create_review_bundle)
 - [`find_scenes`](#find_scenes)
@@ -179,6 +180,17 @@ Resolve prose-styleguide.config.yaml with cascading precedence (sync root, then 
 | Parameter | Type | Required | Description |
 | --- | --- | :---: | --- |
 | `project_id` | `string` | No | Optional project ID for project-scoped resolution (e.g. 'the-lamb' or 'universe-1/book-1'). |
+
+---
+
+## setup_prose_styleguide_skill
+
+Generate skills/prose-styleguide.md from the resolved prose styleguide config and universal craft rules.
+
+| Parameter | Type | Required | Description |
+| --- | --- | :---: | --- |
+| `project_id` | `string` | No | Optional project ID for scoped config resolution (e.g. 'the-lamb' or 'universe-1/book-1'). |
+| `overwrite` | `boolean` | No | If true, replaces an existing skills/prose-styleguide.md file. |
 
 ---
 

--- a/index.js
+++ b/index.js
@@ -24,6 +24,11 @@ import {
   resolveStyleguideConfig,
 } from "./prose-styleguide.js";
 import {
+  PROSE_STYLEGUIDE_SKILL_BASENAME,
+  PROSE_STYLEGUIDE_SKILL_DIRNAME,
+  buildProseStyleguideSkill,
+} from "./prose-styleguide-skill.js";
+import {
   REVIEW_BUNDLE_PROFILES,
   REVIEW_BUNDLE_STRICTNESS,
   ReviewBundlePlanError,
@@ -1509,6 +1514,90 @@ function createMcpServer() {
         next_step: resolved.setup_required
           ? "No prose-styleguide.config.yaml was found. Run setup to create one at sync root or project root."
           : "Config resolved successfully.",
+      });
+    }
+  );
+
+  s.tool(
+    "setup_prose_styleguide_skill",
+    "Generate skills/prose-styleguide.md from the resolved prose styleguide config and universal craft rules.",
+    {
+      project_id: z.string().optional().describe("Optional project ID for scoped config resolution (e.g. 'the-lamb' or 'universe-1/book-1')."),
+      overwrite: z.boolean().optional().describe("If true, replaces an existing skills/prose-styleguide.md file."),
+    },
+    async ({ project_id, overwrite = false }) => {
+      if (project_id !== undefined) {
+        const projectIdCheck = validateProjectId(project_id);
+        if (!projectIdCheck.ok) {
+          return errorResponse("INVALID_PROJECT_ID", projectIdCheck.reason, { project_id });
+        }
+      }
+
+      if (!SYNC_DIR_WRITABLE) {
+        return errorResponse(
+          "SYNC_DIR_NOT_WRITABLE",
+          "Cannot write prose styleguide skill because WRITING_SYNC_DIR is not writable in this runtime.",
+          { sync_dir: SYNC_DIR_ABS }
+        );
+      }
+
+      const resolved = resolveStyleguideConfig({
+        syncDir: SYNC_DIR,
+        projectId: project_id,
+      });
+      if (!resolved.ok) {
+        return errorResponse(
+          resolved.error.code,
+          resolved.error.message,
+          resolved.error.details
+        );
+      }
+      if (resolved.setup_required || !resolved.resolved_config) {
+        return errorResponse(
+          "STYLEGUIDE_CONFIG_REQUIRED",
+          "Cannot generate prose-styleguide.md before prose-styleguide.config.yaml is set up.",
+          {
+            project_id: project_id ?? null,
+            next_step: "Run setup_prose_styleguide_config first.",
+          }
+        );
+      }
+
+      const skillPath = path.join(SYNC_DIR, PROSE_STYLEGUIDE_SKILL_DIRNAME, PROSE_STYLEGUIDE_SKILL_BASENAME);
+      if (!isPathCandidateInsideSyncDir(skillPath)) {
+        return errorResponse(
+          "INVALID_SKILL_PATH",
+          "Resolved prose styleguide skill path must be inside WRITING_SYNC_DIR.",
+          { target_path: path.resolve(skillPath), sync_dir: SYNC_DIR_ABS }
+        );
+      }
+
+      if (fs.existsSync(skillPath) && !overwrite) {
+        return errorResponse(
+          "STYLEGUIDE_SKILL_EXISTS",
+          "skills/prose-styleguide.md already exists. Set overwrite=true to replace it.",
+          { target_path: path.resolve(skillPath) }
+        );
+      }
+
+      const generated = buildProseStyleguideSkill({
+        resolvedConfig: resolved.resolved_config,
+        sources: resolved.sources,
+        projectId: project_id ?? null,
+      });
+      if (!generated.ok) {
+        return errorResponse(generated.error.code, generated.error.message);
+      }
+
+      fs.mkdirSync(path.dirname(skillPath), { recursive: true });
+      fs.writeFileSync(skillPath, generated.markdown, "utf8");
+
+      return jsonResponse({
+        ok: true,
+        file_path: path.resolve(skillPath),
+        project_id: project_id ?? null,
+        injected_rules: generated.injected_rules,
+        source_count: resolved.sources.length,
       });
     }
   );

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "scene-character-normalization.js",
     "review-bundles.js",
     "prose-styleguide.js",
+    "prose-styleguide-skill.js",
     "scripts/",
     "README.md",
     "CHANGELOG.md"

--- a/prose-styleguide-skill.js
+++ b/prose-styleguide-skill.js
@@ -1,0 +1,125 @@
+export const PROSE_STYLEGUIDE_SKILL_DIRNAME = "skills";
+export const PROSE_STYLEGUIDE_SKILL_BASENAME = "prose-styleguide.md";
+
+const LANGUAGE_LABELS = {
+  english_us: "English (US)",
+  english_uk: "English (UK)",
+  english_au: "English (AU)",
+  english_ca: "English (CA)",
+  swedish: "Swedish",
+  norwegian: "Norwegian",
+  danish: "Danish",
+  finnish: "Finnish",
+  french: "French",
+  italian: "Italian",
+  russian: "Russian",
+  portuguese_pt: "Portuguese (PT)",
+  portuguese_br: "Portuguese (BR)",
+  german: "German",
+  dutch: "Dutch",
+  polish: "Polish",
+  czech: "Czech",
+  hungarian: "Hungarian",
+  spanish: "Spanish",
+  irish: "Irish",
+  japanese: "Japanese",
+  korean: "Korean",
+  chinese_traditional: "Chinese (Traditional)",
+  chinese_simplified: "Chinese (Simplified)",
+};
+
+const CONFIG_RULE_RENDERERS = {
+  language: (value) => `Primary writing language: ${LANGUAGE_LABELS[value] ?? value}.`,
+  spelling: (value) => `Spelling variant: ${value.toUpperCase()}.`,
+  quotation_style: (value) => {
+    const labels = {
+      double: "double quotes",
+      single: "single quotes",
+      guillemets: "guillemets (« »)",
+      low9: "low-9 quotation marks",
+      dialogue_dash_en: "Scandinavian en-dash dialogue",
+      dialogue_dash_em: "Spanish/Irish em-dash dialogue",
+      corner_brackets: "corner brackets (「 」)",
+    };
+    return `Dialogue quotation style: ${labels[value] ?? value}.`;
+  },
+  quotation_style_nested: (value) => `Nested quotation style: ${value}.`,
+  em_dash_spacing: (value) => `Em dash spacing: ${value}.`,
+  ellipsis_style: (value) => `Ellipsis style: ${value}.`,
+  abbreviation_periods: (value) => `Abbreviation periods: ${value}.`,
+  oxford_comma: (value) => `Oxford comma: ${value}.`,
+  numbers: (value) => `Number formatting rule: ${value}.`,
+  date_format: (value) => `Date format: ${value}.`,
+  time_format: (value) => `Time format: ${value}.`,
+  tense: (value) => `Default narrative tense: ${value}. Flag deviations as questions, not hard errors.`,
+  pov: (value) => `Default POV: ${value}. Flag shifts as intentional-or-drift questions.`,
+  dialogue_tags: (value) => `Dialogue tag policy: ${value}.`,
+  sentence_fragments: (value) => `Sentence fragments policy: ${value}.`,
+};
+
+export function buildProseStyleguideSkill({ resolvedConfig, sources = [], projectId = null }) {
+  if (!resolvedConfig || typeof resolvedConfig !== "object") {
+    return {
+      ok: false,
+      error: {
+        code: "INVALID_STYLEGUIDE_CONFIG",
+        message: "Cannot generate prose-styleguide.md without a resolved config object.",
+      },
+    };
+  }
+
+  const injectedRules = [];
+  for (const [field, renderRule] of Object.entries(CONFIG_RULE_RENDERERS)) {
+    if (resolvedConfig[field] === undefined) continue;
+    injectedRules.push(renderRule(resolvedConfig[field]));
+  }
+
+  const sourceLines = sources.length
+    ? sources.map((source) => `- ${source.scope}: ${source.file_path}`)
+    : ["- none"];
+
+  const voiceNotes = typeof resolvedConfig.voice_notes === "string" && resolvedConfig.voice_notes.trim()
+    ? resolvedConfig.voice_notes.trim().split("\n").map((line) => `> ${line}`).join("\n")
+    : "> None provided.";
+
+  const markdown = [
+    "# Prose Styleguide",
+    "",
+    "## Standing Order",
+    "Apply this styleguide by default for prose critique and edits. Preserve author voice over mechanical cleanup.",
+    "",
+    "## Resolved Scope",
+    `- Project scope: ${projectId ?? "sync-root default"}`,
+    ...sourceLines,
+    "",
+    "## Mechanical Conventions",
+    "These are injected from prose-styleguide.config.yaml and should be applied consistently:",
+    ...injectedRules.map((rule) => `- ${rule}`),
+    "",
+    "## Universal Craft Rules",
+    "- Identify scene purpose before proposing changes.",
+    "- Require transformation (emotional, relational, narrative, or thematic).",
+    "- Prefer critique before rewrite.",
+    "- Preserve cadence and specificity; avoid flattening voice.",
+    "- Ask before normalizing intentional instability (flashbacks, POV drift, syntax breaks).",
+    "",
+    "## Review Posture",
+    "- Prioritize structural issues, then convention drift, then line-level polish.",
+    "- Treat convention drift as a question when intent may be deliberate.",
+    "",
+    "## Edit Posture",
+    "- Do not shorten unless requested.",
+    "- Apply conventions consistently while preserving tone.",
+    "- Justify significant rewrites.",
+    "",
+    "## Voice Notes",
+    voiceNotes,
+    "",
+  ].join("\n");
+
+  return {
+    ok: true,
+    markdown,
+    injected_rules: injectedRules,
+  };
+}

--- a/test/integration.test.mjs
+++ b/test/integration.test.mjs
@@ -631,6 +631,49 @@ describe("get_prose_styleguide_config tool", () => {
   });
 });
 
+describe("setup_prose_styleguide_skill tool", () => {
+  test("requires a styleguide config before skill generation", async () => {
+    const rootConfigPath = path.join(writeSyncDir, "prose-styleguide.config.yaml");
+    fs.rmSync(rootConfigPath, { force: true });
+
+    const text = await callWriteTool("setup_prose_styleguide_skill", { overwrite: true });
+    const parsed = JSON.parse(text);
+
+    assert.equal(parsed.ok, false);
+    assert.equal(parsed.error.code, "STYLEGUIDE_CONFIG_REQUIRED");
+  });
+
+  test("writes skills/prose-styleguide.md from resolved config", async () => {
+    fs.writeFileSync(
+      path.join(writeSyncDir, "prose-styleguide.config.yaml"),
+      [
+        "language: english_uk",
+        "dialogue_tags: minimal",
+        "voice_notes: |",
+        "  Keep the tone restrained.",
+      ].join("\n"),
+      "utf8"
+    );
+
+    const text = await callWriteTool("setup_prose_styleguide_skill", { overwrite: true });
+    const parsed = JSON.parse(text);
+
+    assert.equal(parsed.ok, true);
+    assert.equal(typeof parsed.file_path, "string");
+    assert.equal(parsed.file_path.length > 0, true);
+    assert.ok(Array.isArray(parsed.injected_rules));
+    assert.equal(parsed.injected_rules.length > 0, true);
+
+    const skillPath = path.join(writeSyncDir, "skills", "prose-styleguide.md");
+    assert.equal(fs.existsSync(skillPath), true);
+    const skillText = fs.readFileSync(skillPath, "utf8");
+    assert.match(skillText, /# Prose Styleguide/);
+    assert.match(skillText, /Primary writing language: English \(UK\)\./);
+    assert.match(skillText, /Dialogue tag policy: minimal\./);
+    assert.match(skillText, /> Keep the tone restrained\./);
+  });
+});
+
 describe("import_scrivener_sync tool", () => {
   test("dry-run returns machine-readable counts without writing files", async () => {
     const projectId = "import-preview";

--- a/test/unit.test.mjs
+++ b/test/unit.test.mjs
@@ -36,6 +36,7 @@ import { runSceneCharacterBatch } from "../scene-character-batch.js";
 import { buildCharacterNormalizationContext, isDistinctiveToken, normalizeSceneCharacters } from "../scene-character-normalization.js";
 import { buildReviewBundlePlan, renderReviewBundleMarkdown, ReviewBundlePlanError } from "../review-bundles.js";
 import { buildStyleguideConfigDraft, resolveStyleguideConfig } from "../prose-styleguide.js";
+import { buildProseStyleguideSkill } from "../prose-styleguide-skill.js";
 
 function insertTestScene(db, {
   sceneId,
@@ -351,6 +352,36 @@ describe("styleguide config hardening", () => {
     } finally {
       fs.rmSync(syncDir, { recursive: true, force: true });
     }
+  });
+});
+
+describe("buildProseStyleguideSkill", () => {
+  test("renders markdown with injected rules and voice notes", () => {
+    const result = buildProseStyleguideSkill({
+      resolvedConfig: {
+        language: "english_uk",
+        quotation_style: "single",
+        tense: "present",
+        voice_notes: "Keep subtext strong.\nAvoid over-explaining emotions.",
+      },
+      sources: [{ scope: "sync_root", file_path: "/tmp/prose-styleguide.config.yaml" }],
+      projectId: "test-novel",
+    });
+
+    assert.equal(result.ok, true);
+    assert.match(result.markdown, /# Prose Styleguide/);
+    assert.match(result.markdown, /Project scope: test-novel/);
+    assert.match(result.markdown, /Primary writing language: English \(UK\)\./);
+    assert.match(result.markdown, /Dialogue quotation style: single quotes\./);
+    assert.match(result.markdown, /Default narrative tense: present\./);
+    assert.match(result.markdown, /> Keep subtext strong\./);
+    assert.match(result.markdown, /> Avoid over-explaining emotions\./);
+  });
+
+  test("fails when resolved config is missing", () => {
+    const result = buildProseStyleguideSkill({ resolvedConfig: null });
+    assert.equal(result.ok, false);
+    assert.equal(result.error.code, "INVALID_STYLEGUIDE_CONFIG");
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds a new prose styleguide skill generator module that renders deterministic markdown from resolved styleguide config values plus universal craft rules.
- Adds MCP tool `setup_prose_styleguide_skill` to write `skills/prose-styleguide.md` in WRITING_SYNC_DIR.
- Adds guardrails for missing config, non-writable sync dir, overwrite behavior, and sync-dir path safety.
- Adds unit and integration tests for generation success and required-config failure paths.
- Regenerates tool docs.

## Motivation

Implements the next guideline-generation PRD slice after config setup/resolution: generating the canonical skill file from resolved config so prose editing can consume a standing-order styleguide artifact.

## Implementation

- New module: `prose-styleguide-skill.js`
  - Exports constants for target skill path pieces.
  - Exports `buildProseStyleguideSkill` to produce markdown + injected rules from resolved config.
- New MCP tool: `setup_prose_styleguide_skill`
  - Validates optional `project_id`.
  - Resolves config via existing cascade resolver.
  - Returns `STYLEGUIDE_CONFIG_REQUIRED` when no config exists.
  - Writes `skills/prose-styleguide.md` with overwrite protection.
- Packaging/docs:
  - Adds module to package `files`.
  - Updates generated `docs/tools.md`.

## Testing

- `npm run docs`
- `npm test` (274/274 passing)
- Added tests:
  - Unit: markdown render + error on missing resolved config
  - Integration: missing-config error and successful file generation with expected content

## Risks and tradeoffs

- Generated markdown currently uses concise textual mappings for config fields; wording can be refined in follow-ups without changing tool contract.
- This slice intentionally focuses on deterministic generation and file creation; conversational wizard and drift detection remain separate follow-ups.

## Follow-up

- Add conversational update/summarize workflow for config values.
- Add drift-check helper between declared config and scene prose.
- Wire styleguide loading into prose edit paths as standing-order context.