### PR TITLE
feat(styleguide): add config update preview and prose drift checks

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -16,6 +16,10 @@
 - [`get_runtime_config`](#get_runtime_config)
 - [`setup_prose_styleguide_config`](#setup_prose_styleguide_config)
 - [`get_prose_styleguide_config`](#get_prose_styleguide_config)
+- [`summarize_prose_styleguide_config`](#summarize_prose_styleguide_config)
+- [`update_prose_styleguide_config`](#update_prose_styleguide_config)
+- [`preview_prose_styleguide_config_update`](#preview_prose_styleguide_config_update)
+- [`check_prose_styleguide_drift`](#check_prose_styleguide_drift)
 - [`setup_prose_styleguide_skill`](#setup_prose_styleguide_skill)
 - [`preview_review_bundle`](#preview_review_bundle)
 - [`create_review_bundle`](#create_review_bundle)
@@ -180,6 +184,56 @@ Resolve prose-styleguide.config.yaml with cascading precedence (sync root, then 
 | Parameter | Type | Required | Description |
 | --- | --- | :---: | --- |
 | `project_id` | `string` | No | Optional project ID for project-scoped resolution (e.g. 'the-lamb' or 'universe-1/book-1'). |
+
+---
+
+## summarize_prose_styleguide_config
+
+Summarize the currently resolved prose styleguide config in plain language for review or confirmation.
+
+| Parameter | Type | Required | Description |
+| --- | --- | :---: | --- |
+| `project_id` | `string` | No | Optional project ID for project-scoped resolution (e.g. 'the-lamb' or 'universe-1/book-1'). |
+
+---
+
+## update_prose_styleguide_config
+
+Update an existing prose-styleguide.config.yaml at sync-root or project-root scope by writing only explicit field changes.
+
+| Parameter | Type | Required | Description |
+| --- | --- | :---: | --- |
+| `scope` | `enum("sync_root","project_root")` | Yes | Config scope to update. |
+| `project_id` | `string` | No | Project ID when updating project_root config (e.g. 'the-lamb' or 'universe-1/book-1'). |
+| `updates` | `object` | No | Explicit config field changes to write at the selected scope. |
+
+---
+
+## preview_prose_styleguide_config_update
+
+Preview how explicit updates would change an existing prose-styleguide.config.yaml without writing any files.
+
+| Parameter | Type | Required | Description |
+| --- | --- | :---: | --- |
+| `scope` | `enum("sync_root","project_root")` | Yes | Config scope to preview updates for. |
+| `project_id` | `string` | No | Project ID when previewing project_root config updates (e.g. 'the-lamb' or 'universe-1/book-1'). |
+| `updates` | `object` | No | Explicit config field changes to preview at the selected scope. |
+
+---
+
+## check_prose_styleguide_drift
+
+Detect styleguide drift by comparing declared config conventions against observed signals in scene prose.
+
+| Parameter | Type | Required | Description |
+| --- | --- | :---: | --- |
+| `project_id` | `string` | Yes | Project ID to analyze (e.g. 'the-lamb' or 'universe-1/book-1'). |
+| `scene_ids` | `string[]` | No | Optional scene_id allowlist to analyze. |
+| `part` | `integer` | No | Optional part filter. |
+| `chapter` | `integer` | No | Optional chapter filter. |
+| `max_scenes` | `integer` | No | Maximum number of scenes to analyze (default: 50). |
+| `min_agreement` | `number` | No | Minimum agreement ratio for suggested updates (default: 0.6). |
+| `include_clean_scenes` | `boolean` | No | If true, include scenes with no detected drift in scene_results. |
 
 ---
 

--- a/index.js
+++ b/index.js
@@ -1784,7 +1784,7 @@ function createMcpServer() {
 
       const sceneAnalyses = [];
       for (const scene of targetScenes) {
-        let prose = "";
+        let prose;
         try {
           const raw = fs.readFileSync(scene.file_path, "utf8");
           prose = matter(raw).content;

--- a/index.js
+++ b/index.js
@@ -21,8 +21,15 @@ import {
   STYLEGUIDE_CONFIG_BASENAME,
   STYLEGUIDE_ENUMS,
   buildStyleguideConfigDraft,
+  previewStyleguideConfigUpdate,
   resolveStyleguideConfig,
+  summarizeStyleguideConfig,
+  updateStyleguideConfig,
 } from "./prose-styleguide.js";
+import {
+  analyzeSceneStyleguideDrift,
+  suggestStyleguideUpdatesFromScenes,
+} from "./prose-styleguide-drift.js";
 import {
   PROSE_STYLEGUIDE_SKILL_BASENAME,
   PROSE_STYLEGUIDE_SKILL_DIRNAME,
@@ -1514,6 +1521,318 @@ function createMcpServer() {
         next_step: resolved.setup_required
           ? "No prose-styleguide.config.yaml was found. Run setup to create one at sync root or project root."
           : "Config resolved successfully.",
+      });
+    }
+  );
+
+  s.tool(
+    "summarize_prose_styleguide_config",
+    "Summarize the currently resolved prose styleguide config in plain language for review or confirmation.",
+    {
+      project_id: z.string().optional().describe("Optional project ID for project-scoped resolution (e.g. 'the-lamb' or 'universe-1/book-1')."),
+    },
+    async ({ project_id }) => {
+      if (project_id !== undefined) {
+        const projectIdCheck = validateProjectId(project_id);
+        if (!projectIdCheck.ok) {
+          return errorResponse("INVALID_PROJECT_ID", projectIdCheck.reason, { project_id });
+        }
+      }
+
+      const resolved = resolveStyleguideConfig({
+        syncDir: SYNC_DIR,
+        projectId: project_id,
+      });
+      if (!resolved.ok) {
+        return errorResponse(
+          resolved.error.code,
+          resolved.error.message,
+          resolved.error.details
+        );
+      }
+      if (resolved.setup_required || !resolved.resolved_config) {
+        return errorResponse(
+          "STYLEGUIDE_CONFIG_REQUIRED",
+          "Cannot summarize prose styleguide config before prose-styleguide.config.yaml is set up.",
+          { project_id: project_id ?? null }
+        );
+      }
+
+      const summary = summarizeStyleguideConfig({
+        resolvedConfig: resolved.resolved_config,
+        inferredDefaults: resolved.inferred_defaults,
+      });
+      if (!summary.ok) {
+        return errorResponse(summary.error.code, summary.error.message);
+      }
+
+      return jsonResponse({
+        ok: true,
+        project_id: project_id ?? null,
+        summary_text: summary.summary_text,
+        summary_lines: summary.summary_lines,
+        styleguide: resolved,
+      });
+    }
+  );
+
+  s.tool(
+    "update_prose_styleguide_config",
+    "Update an existing prose-styleguide.config.yaml at sync-root or project-root scope by writing only explicit field changes.",
+    {
+      scope: z.enum(["sync_root", "project_root"]).describe("Config scope to update."),
+      project_id: z.string().optional().describe("Project ID when updating project_root config (e.g. 'the-lamb' or 'universe-1/book-1')."),
+      updates: z.object({
+        language: z.enum(STYLEGUIDE_ENUMS.language).optional(),
+        spelling: z.enum(STYLEGUIDE_ENUMS.spelling).optional(),
+        quotation_style: z.enum(STYLEGUIDE_ENUMS.quotation_style).optional(),
+        quotation_style_nested: z.enum(STYLEGUIDE_ENUMS.quotation_style_nested).optional(),
+        em_dash_spacing: z.enum(STYLEGUIDE_ENUMS.em_dash_spacing).optional(),
+        ellipsis_style: z.enum(STYLEGUIDE_ENUMS.ellipsis_style).optional(),
+        abbreviation_periods: z.enum(STYLEGUIDE_ENUMS.abbreviation_periods).optional(),
+        oxford_comma: z.enum(STYLEGUIDE_ENUMS.oxford_comma).optional(),
+        numbers: z.enum(STYLEGUIDE_ENUMS.numbers).optional(),
+        date_format: z.enum(STYLEGUIDE_ENUMS.date_format).optional(),
+        time_format: z.enum(STYLEGUIDE_ENUMS.time_format).optional(),
+        tense: z.string().optional(),
+        pov: z.enum(STYLEGUIDE_ENUMS.pov).optional(),
+        dialogue_tags: z.enum(STYLEGUIDE_ENUMS.dialogue_tags).optional(),
+        sentence_fragments: z.enum(STYLEGUIDE_ENUMS.sentence_fragments).optional(),
+        voice_notes: z.string().optional(),
+      }).describe("Explicit config field changes to write at the selected scope."),
+    },
+    async ({ scope, project_id, updates }) => {
+      if (project_id !== undefined) {
+        const projectIdCheck = validateProjectId(project_id);
+        if (!projectIdCheck.ok) {
+          return errorResponse("INVALID_PROJECT_ID", projectIdCheck.reason, { project_id });
+        }
+      }
+
+      if (scope === "project_root" && !project_id) {
+        return errorResponse(
+          "PROJECT_ID_REQUIRED",
+          "project_id is required when scope=project_root."
+        );
+      }
+
+      if (!SYNC_DIR_WRITABLE) {
+        return errorResponse(
+          "SYNC_DIR_NOT_WRITABLE",
+          "Cannot update styleguide config because WRITING_SYNC_DIR is not writable in this runtime.",
+          { sync_dir: SYNC_DIR_ABS }
+        );
+      }
+
+      const updated = updateStyleguideConfig({
+        syncDir: SYNC_DIR,
+        scope,
+        projectId: project_id,
+        updates,
+      });
+      if (!updated.ok) {
+        return errorResponse(
+          updated.error.code,
+          updated.error.message,
+          updated.error.details
+        );
+      }
+
+      return jsonResponse({
+        ok: true,
+        scope: updated.scope,
+        project_id: updated.project_id,
+        file_path: path.resolve(updated.file_path),
+        config: updated.config,
+        changed_fields: updated.changed_fields,
+        warnings: updated.warnings,
+      });
+    }
+  );
+
+  s.tool(
+    "preview_prose_styleguide_config_update",
+    "Preview how explicit updates would change an existing prose-styleguide.config.yaml without writing any files.",
+    {
+      scope: z.enum(["sync_root", "project_root"]).describe("Config scope to preview updates for."),
+      project_id: z.string().optional().describe("Project ID when previewing project_root config updates (e.g. 'the-lamb' or 'universe-1/book-1')."),
+      updates: z.object({
+        language: z.enum(STYLEGUIDE_ENUMS.language).optional(),
+        spelling: z.enum(STYLEGUIDE_ENUMS.spelling).optional(),
+        quotation_style: z.enum(STYLEGUIDE_ENUMS.quotation_style).optional(),
+        quotation_style_nested: z.enum(STYLEGUIDE_ENUMS.quotation_style_nested).optional(),
+        em_dash_spacing: z.enum(STYLEGUIDE_ENUMS.em_dash_spacing).optional(),
+        ellipsis_style: z.enum(STYLEGUIDE_ENUMS.ellipsis_style).optional(),
+        abbreviation_periods: z.enum(STYLEGUIDE_ENUMS.abbreviation_periods).optional(),
+        oxford_comma: z.enum(STYLEGUIDE_ENUMS.oxford_comma).optional(),
+        numbers: z.enum(STYLEGUIDE_ENUMS.numbers).optional(),
+        date_format: z.enum(STYLEGUIDE_ENUMS.date_format).optional(),
+        time_format: z.enum(STYLEGUIDE_ENUMS.time_format).optional(),
+        tense: z.string().optional(),
+        pov: z.enum(STYLEGUIDE_ENUMS.pov).optional(),
+        dialogue_tags: z.enum(STYLEGUIDE_ENUMS.dialogue_tags).optional(),
+        sentence_fragments: z.enum(STYLEGUIDE_ENUMS.sentence_fragments).optional(),
+        voice_notes: z.string().optional(),
+      }).describe("Explicit config field changes to preview at the selected scope."),
+    },
+    async ({ scope, project_id, updates }) => {
+      if (project_id !== undefined) {
+        const projectIdCheck = validateProjectId(project_id);
+        if (!projectIdCheck.ok) {
+          return errorResponse("INVALID_PROJECT_ID", projectIdCheck.reason, { project_id });
+        }
+      }
+
+      if (scope === "project_root" && !project_id) {
+        return errorResponse(
+          "PROJECT_ID_REQUIRED",
+          "project_id is required when scope=project_root."
+        );
+      }
+
+      const preview = previewStyleguideConfigUpdate({
+        syncDir: SYNC_DIR,
+        scope,
+        projectId: project_id,
+        updates,
+      });
+      if (!preview.ok) {
+        return errorResponse(
+          preview.error.code,
+          preview.error.message,
+          preview.error.details
+        );
+      }
+
+      return jsonResponse({
+        ok: true,
+        scope: preview.scope,
+        project_id: preview.project_id,
+        file_path: path.resolve(preview.file_path),
+        current_config: preview.current_config,
+        next_config: preview.config,
+        changed_fields: preview.changed_fields,
+        warnings: preview.warnings,
+      });
+    }
+  );
+
+  s.tool(
+    "check_prose_styleguide_drift",
+    "Detect styleguide drift by comparing declared config conventions against observed signals in scene prose.",
+    {
+      project_id: z.string().describe("Project ID to analyze (e.g. 'the-lamb' or 'universe-1/book-1')."),
+      scene_ids: z.array(z.string()).optional().describe("Optional scene_id allowlist to analyze."),
+      part: z.number().int().optional().describe("Optional part filter."),
+      chapter: z.number().int().optional().describe("Optional chapter filter."),
+      max_scenes: z.number().int().positive().optional().describe("Maximum number of scenes to analyze (default: 50)."),
+      min_agreement: z.number().min(0).max(1).optional().describe("Minimum agreement ratio for suggested updates (default: 0.6)."),
+      include_clean_scenes: z.boolean().optional().describe("If true, include scenes with no detected drift in scene_results."),
+    },
+    async ({
+      project_id,
+      scene_ids,
+      part,
+      chapter,
+      max_scenes = 50,
+      min_agreement = 0.6,
+      include_clean_scenes = false,
+    }) => {
+      const projectIdCheck = validateProjectId(project_id);
+      if (!projectIdCheck.ok) {
+        return errorResponse("INVALID_PROJECT_ID", projectIdCheck.reason, { project_id });
+      }
+
+      const resolved = resolveStyleguideConfig({
+        syncDir: SYNC_DIR,
+        projectId: project_id,
+      });
+      if (!resolved.ok) {
+        return errorResponse(
+          resolved.error.code,
+          resolved.error.message,
+          resolved.error.details
+        );
+      }
+      if (resolved.setup_required || !resolved.resolved_config) {
+        return errorResponse(
+          "STYLEGUIDE_CONFIG_REQUIRED",
+          "Cannot check prose styleguide drift before prose-styleguide.config.yaml is set up.",
+          { project_id }
+        );
+      }
+
+      const targetResolution = resolveBatchTargetScenes(db, {
+        projectId: project_id,
+        sceneIds: scene_ids,
+        part,
+        chapter,
+        onlyStale: false,
+      });
+      if (!targetResolution.ok) {
+        return errorResponse(targetResolution.code, targetResolution.message, targetResolution.details);
+      }
+
+      const targetScenes = targetResolution.rows;
+      if (targetScenes.length > max_scenes) {
+        return errorResponse(
+          "VALIDATION_ERROR",
+          `Matched ${targetScenes.length} scenes, which exceeds max_scenes=${max_scenes}.`,
+          { matched_scenes: targetScenes.length, max_scenes, project_id }
+        );
+      }
+
+      const sceneAnalyses = [];
+      for (const scene of targetScenes) {
+        let prose = "";
+        try {
+          const raw = fs.readFileSync(scene.file_path, "utf8");
+          prose = matter(raw).content;
+        } catch {
+          sceneAnalyses.push({
+            scene_id: scene.scene_id,
+            observed: {},
+            drift: [{ field: "scene_file", declared: "readable", observed: "unreadable" }],
+          });
+          continue;
+        }
+
+        const analysis = analyzeSceneStyleguideDrift({
+          prose,
+          resolvedConfig: resolved.resolved_config,
+        });
+        sceneAnalyses.push({
+          scene_id: scene.scene_id,
+          observed: analysis.observed,
+          drift: analysis.drift,
+        });
+      }
+
+      const suggestedUpdates = suggestStyleguideUpdatesFromScenes({
+        sceneAnalyses,
+        resolvedConfig: resolved.resolved_config,
+        minAgreement: min_agreement,
+      });
+
+      const filteredScenes = include_clean_scenes
+        ? sceneAnalyses
+        : sceneAnalyses.filter((scene) => scene.drift.length > 0);
+
+      const driftByField = {};
+      for (const scene of sceneAnalyses) {
+        for (const entry of scene.drift) {
+          driftByField[entry.field] = (driftByField[entry.field] ?? 0) + 1;
+        }
+      }
+
+      return jsonResponse({
+        ok: true,
+        project_id,
+        checked_scenes: sceneAnalyses.length,
+        scenes_with_drift: sceneAnalyses.filter((scene) => scene.drift.length > 0).length,
+        drift_by_field: driftByField,
+        scene_results: filteredScenes,
+        suggested_updates: suggestedUpdates,
       });
     }
   );

--- a/index.js
+++ b/index.js
@@ -1599,7 +1599,7 @@ function createMcpServer() {
         dialogue_tags: z.enum(STYLEGUIDE_ENUMS.dialogue_tags).optional(),
         sentence_fragments: z.enum(STYLEGUIDE_ENUMS.sentence_fragments).optional(),
         voice_notes: z.string().optional(),
-      }).describe("Explicit config field changes to write at the selected scope."),
+      }).strict().describe("Explicit config field changes to write at the selected scope."),
     },
     async ({ scope, project_id, updates }) => {
       if (project_id !== undefined) {
@@ -1645,6 +1645,8 @@ function createMcpServer() {
         file_path: path.resolve(updated.file_path),
         config: updated.config,
         changed_fields: updated.changed_fields,
+        noop: Boolean(updated.noop),
+        message: updated.message,
         warnings: updated.warnings,
       });
     }
@@ -1673,7 +1675,7 @@ function createMcpServer() {
         dialogue_tags: z.enum(STYLEGUIDE_ENUMS.dialogue_tags).optional(),
         sentence_fragments: z.enum(STYLEGUIDE_ENUMS.sentence_fragments).optional(),
         voice_notes: z.string().optional(),
-      }).describe("Explicit config field changes to preview at the selected scope."),
+      }).strict().describe("Explicit config field changes to preview at the selected scope."),
     },
     async ({ scope, project_id, updates }) => {
       if (project_id !== undefined) {
@@ -1712,6 +1714,10 @@ function createMcpServer() {
         current_config: preview.current_config,
         next_config: preview.config,
         changed_fields: preview.changed_fields,
+        noop: preview.changed_fields.length === 0,
+        message: preview.changed_fields.length === 0
+          ? "No changes detected for requested styleguide updates."
+          : "Preview generated.",
         warnings: preview.warnings,
       });
     }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "scene-character-normalization.js",
     "review-bundles.js",
     "prose-styleguide.js",
+    "prose-styleguide-drift.js",
     "prose-styleguide-skill.js",
     "scripts/",
     "README.md",

--- a/prose-styleguide-drift.js
+++ b/prose-styleguide-drift.js
@@ -1,0 +1,119 @@
+function detectQuotationStyle(prose) {
+  const counts = {
+    double: (prose.match(/"[^"]{2,}"/g) ?? []).length,
+    guillemets: (prose.match(/«[^»]{2,}»/g) ?? []).length,
+    low9: (prose.match(/„[^“]{2,}“/g) ?? []).length,
+    corner_brackets: (prose.match(/「[^」]{2,}」/g) ?? []).length,
+    dialogue_dash_en: (prose.match(/^\s*–\s/mg) ?? []).length,
+    dialogue_dash_em: (prose.match(/^\s*—\s/mg) ?? []).length,
+    single: (prose.match(/'[^'\n]{2,}'/g) ?? []).length,
+  };
+
+  let best = null;
+  let bestCount = 0;
+  for (const [style, count] of Object.entries(counts)) {
+    if (count > bestCount) {
+      best = style;
+      bestCount = count;
+    }
+  }
+  return bestCount > 0 ? best : null;
+}
+
+function detectEmDashSpacing(prose) {
+  const spaced = (prose.match(/\s—\s/g) ?? []).length;
+  const closed = (prose.match(/\S—\S/g) ?? []).length;
+  if (spaced === 0 && closed === 0) return null;
+  return spaced >= closed ? "spaced" : "closed";
+}
+
+function detectSpellingVariant(prose) {
+  const lower = prose.toLowerCase();
+  const ukSignals = ["colour", "realise", "centre", "honour", "travelling"];
+  const usSignals = ["color", "realize", "center", "honor", "traveling"];
+
+  const countHits = (signals) => signals.reduce((sum, word) => {
+    const re = new RegExp(`\\b${word}\\b`, "g");
+    return sum + (lower.match(re) ?? []).length;
+  }, 0);
+
+  const uk = countHits(ukSignals);
+  const us = countHits(usSignals);
+  if (uk === 0 && us === 0) return null;
+  return uk >= us ? "uk" : "us";
+}
+
+function detectTenseHint(prose) {
+  const lower = prose.toLowerCase();
+  const past = (lower.match(/\b(was|were|had|did)\b/g) ?? []).length;
+  const present = (lower.match(/\b(is|are|has|do)\b/g) ?? []).length;
+  if (past === 0 && present === 0) return null;
+  return present >= past ? "present" : "past";
+}
+
+function mostCommonValue(values) {
+  const counts = new Map();
+  for (const value of values) {
+    if (!value) continue;
+    counts.set(value, (counts.get(value) ?? 0) + 1);
+  }
+  if (counts.size === 0) return null;
+
+  let bestValue = null;
+  let bestCount = 0;
+  for (const [value, count] of counts.entries()) {
+    if (count > bestCount) {
+      bestValue = value;
+      bestCount = count;
+    }
+  }
+  return { value: bestValue, count: bestCount, total: values.filter(Boolean).length };
+}
+
+export function detectStyleguideSignals(prose) {
+  return {
+    quotation_style: detectQuotationStyle(prose),
+    em_dash_spacing: detectEmDashSpacing(prose),
+    spelling: detectSpellingVariant(prose),
+    tense: detectTenseHint(prose),
+  };
+}
+
+export function analyzeSceneStyleguideDrift({ prose, resolvedConfig }) {
+  const observed = detectStyleguideSignals(prose);
+  const drift = [];
+
+  for (const field of ["quotation_style", "em_dash_spacing", "spelling", "tense"]) {
+    const declared = resolvedConfig?.[field];
+    const seen = observed[field];
+    if (!declared || !seen) continue;
+    if (declared !== seen) {
+      drift.push({ field, declared, observed: seen });
+    }
+  }
+
+  return { observed, drift };
+}
+
+export function suggestStyleguideUpdatesFromScenes({ sceneAnalyses, resolvedConfig, minAgreement = 0.6 }) {
+  const suggestions = {};
+
+  for (const field of ["quotation_style", "em_dash_spacing", "spelling", "tense"]) {
+    const values = sceneAnalyses.map((scene) => scene.observed?.[field] ?? null);
+    const common = mostCommonValue(values);
+    if (!common) continue;
+
+    const agreement = common.total > 0 ? common.count / common.total : 0;
+    const fieldThreshold = field === "tense" ? Math.max(minAgreement, 0.75) : minAgreement;
+    if (agreement < fieldThreshold) continue;
+    if (resolvedConfig?.[field] === common.value) continue;
+
+    suggestions[field] = {
+      suggested_value: common.value,
+      agreement,
+      based_on_scenes: common.total,
+    };
+  }
+
+  return suggestions;
+}

--- a/prose-styleguide-drift.js
+++ b/prose-styleguide-drift.js
@@ -95,13 +95,19 @@ export function analyzeSceneStyleguideDrift({ prose, resolvedConfig }) {
   return { observed, drift };
 }
 
-export function suggestStyleguideUpdatesFromScenes({ sceneAnalyses, resolvedConfig, minAgreement = 0.6 }) {
+export function suggestStyleguideUpdatesFromScenes({
+  sceneAnalyses,
+  resolvedConfig,
+  minAgreement = 0.6,
+  minEvidence = 3,
+}) {
   const suggestions = {};
 
   for (const field of ["quotation_style", "em_dash_spacing", "spelling", "tense"]) {
     const values = sceneAnalyses.map((scene) => scene.observed?.[field] ?? null);
     const common = mostCommonValue(values);
     if (!common) continue;
+    if (common.total < minEvidence) continue;
 
     const agreement = common.total > 0 ? common.count / common.total : 0;
     const fieldThreshold = field === "tense" ? Math.max(minAgreement, 0.75) : minAgreement;

--- a/prose-styleguide.js
+++ b/prose-styleguide.js
@@ -67,6 +67,25 @@ export const STYLEGUIDE_ENUMS = Object.freeze(
   )
 );
 
+const STYLEGUIDE_FIELD_ORDER = [
+  "language",
+  "spelling",
+  "quotation_style",
+  "quotation_style_nested",
+  "em_dash_spacing",
+  "ellipsis_style",
+  "abbreviation_periods",
+  "oxford_comma",
+  "numbers",
+  "date_format",
+  "time_format",
+  "tense",
+  "pov",
+  "dialogue_tags",
+  "sentence_fragments",
+  "voice_notes",
+];
+
 // Fields that are valid in a config but are not enum-constrained.
 const SPECIAL_FIELDS = new Set(["voice_notes"]);
 
@@ -344,6 +363,87 @@ function readConfigFile(filePath) {
   };
 }
 
+function configPathForScope(syncDir, scope, projectId) {
+  if (scope === "sync_root") {
+    return path.join(syncDir, STYLEGUIDE_CONFIG_BASENAME);
+  }
+  return path.join(projectRootFromId(syncDir, projectId), STYLEGUIDE_CONFIG_BASENAME);
+}
+
+function prepareStyleguideConfigUpdate({ syncDir, scope, projectId, updates = {} }) {
+  const filePath = configPathForScope(syncDir, scope, projectId);
+  const current = readConfigFile(filePath);
+
+  if (current === null) {
+    return {
+      ok: false,
+      error: {
+        code: "STYLEGUIDE_CONFIG_NOT_FOUND",
+        message: "Cannot update styleguide config because no config exists at the requested scope.",
+        details: { file_path: filePath, scope, project_id: projectId ?? null },
+      },
+    };
+  }
+
+  if (!current.ok) {
+    return {
+      ok: false,
+      error: {
+        code: "INVALID_STYLEGUIDE_CONFIG",
+        message: "Styleguide config validation failed.",
+        details: { file_path: filePath, issues: current.errors },
+      },
+    };
+  }
+
+  const validatedUpdates = validateConfig(updates, "<updates>");
+  if (validatedUpdates.errors.length > 0) {
+    return {
+      ok: false,
+      error: {
+        code: "INVALID_STYLEGUIDE_UPDATE",
+        message: "Requested styleguide updates failed validation.",
+        details: validatedUpdates.errors,
+      },
+    };
+  }
+
+  const merged = Object.create(null);
+  Object.assign(merged, current.config, validatedUpdates.normalized);
+
+  const ordered = Object.create(null);
+  for (const key of STYLEGUIDE_FIELD_ORDER) {
+    if (merged[key] !== undefined) {
+      ordered[key] = merged[key];
+    }
+  }
+
+  const changedFields = [];
+  const allKeys = new Set([...Object.keys(current.config ?? {}), ...Object.keys(ordered)]);
+  for (const key of allKeys) {
+    if (current.config?.[key] !== ordered[key]) {
+      changedFields.push({
+        field: key,
+        before: current.config?.[key],
+        after: ordered[key],
+      });
+    }
+  }
+
+  return {
+    ok: true,
+    file_path: filePath,
+    scope,
+    project_id: projectId ?? null,
+    current_config: current.config,
+    config: ordered,
+    changed_fields: changedFields,
+    warnings: {
+      unknown_fields: validatedUpdates.unknownFields,
+    },
+  };
+}
+
 function getConfigCandidates(syncDir, projectId) {
   const candidates = [
     {
@@ -440,6 +540,64 @@ export function buildStyleguideConfigDraft({ language, overrides = {}, voice_not
       unknown_fields: overrideValidation.unknownFields,
     },
   };
+}
+
+export function summarizeStyleguideConfig({ resolvedConfig, inferredDefaults = {} }) {
+  if (!resolvedConfig || typeof resolvedConfig !== "object") {
+    return {
+      ok: false,
+      error: {
+        code: "INVALID_STYLEGUIDE_CONFIG",
+        message: "Cannot summarize styleguide config without a resolved config object.",
+      },
+    };
+  }
+
+  const lines = [];
+  if (resolvedConfig.language) lines.push(`Writing language: ${resolvedConfig.language}.`);
+  if (resolvedConfig.spelling) lines.push(`Spelling variant: ${resolvedConfig.spelling}.`);
+  if (resolvedConfig.quotation_style) lines.push(`Dialogue punctuation uses ${resolvedConfig.quotation_style}.`);
+  if (resolvedConfig.quotation_style_nested) lines.push(`Nested quotations use ${resolvedConfig.quotation_style_nested}.`);
+  if (resolvedConfig.tense) lines.push(`Default narrative tense: ${resolvedConfig.tense}.`);
+  if (resolvedConfig.pov) lines.push(`Default POV: ${resolvedConfig.pov}.`);
+  if (resolvedConfig.dialogue_tags) lines.push(`Dialogue tag policy: ${resolvedConfig.dialogue_tags}.`);
+  if (resolvedConfig.sentence_fragments) lines.push(`Sentence fragments: ${resolvedConfig.sentence_fragments}.`);
+  if (resolvedConfig.date_format) lines.push(`Date format: ${resolvedConfig.date_format}.`);
+  if (resolvedConfig.time_format) lines.push(`Time format: ${resolvedConfig.time_format}.`);
+  if (resolvedConfig.voice_notes) lines.push(`Voice notes: ${resolvedConfig.voice_notes}`);
+
+  const inferred = Object.keys(inferredDefaults);
+  if (inferred.length > 0) {
+    lines.push(`Inferred defaults currently fill: ${inferred.join(", ")}.`);
+  }
+
+  return {
+    ok: true,
+    summary_text: lines.join(" "),
+    summary_lines: lines,
+  };
+}
+
+export function updateStyleguideConfig({ syncDir, scope, projectId, updates = {} }) {
+  const prepared = prepareStyleguideConfigUpdate({ syncDir, scope, projectId, updates });
+  if (!prepared.ok) return prepared;
+
+  fs.mkdirSync(path.dirname(prepared.file_path), { recursive: true });
+  fs.writeFileSync(prepared.file_path, yaml.dump(prepared.config, { lineWidth: 120 }), "utf8");
+
+  return {
+    ok: true,
+    file_path: prepared.file_path,
+    scope: prepared.scope,
+    project_id: prepared.project_id,
+    config: prepared.config,
+    changed_fields: prepared.changed_fields,
+    warnings: prepared.warnings,
+  };
+}
+
+export function previewStyleguideConfigUpdate({ syncDir, scope, projectId, updates = {} }) {
+  return prepareStyleguideConfigUpdate({ syncDir, scope, projectId, updates });
 }
 
 export function resolveStyleguideConfig({ syncDir, projectId }) {

--- a/prose-styleguide.js
+++ b/prose-styleguide.js
@@ -371,6 +371,17 @@ function configPathForScope(syncDir, scope, projectId) {
 }
 
 function prepareStyleguideConfigUpdate({ syncDir, scope, projectId, updates = {} }) {
+  if (scope === "project_root" && !projectId) {
+    return {
+      ok: false,
+      error: {
+        code: "PROJECT_ID_REQUIRED",
+        message: "project_id is required when scope=project_root.",
+        details: { scope, project_id: projectId ?? null },
+      },
+    };
+  }
+
   const filePath = configPathForScope(syncDir, scope, projectId);
   const current = readConfigFile(filePath);
 

--- a/prose-styleguide.js
+++ b/prose-styleguide.js
@@ -582,6 +582,20 @@ export function updateStyleguideConfig({ syncDir, scope, projectId, updates = {}
   const prepared = prepareStyleguideConfigUpdate({ syncDir, scope, projectId, updates });
   if (!prepared.ok) return prepared;
 
+  if (prepared.changed_fields.length === 0) {
+    return {
+      ok: true,
+      file_path: prepared.file_path,
+      scope: prepared.scope,
+      project_id: prepared.project_id,
+      config: prepared.config,
+      changed_fields: prepared.changed_fields,
+      warnings: prepared.warnings,
+      noop: true,
+      message: "No changes detected for requested styleguide updates.",
+    };
+  }
+
   fs.mkdirSync(path.dirname(prepared.file_path), { recursive: true });
   fs.writeFileSync(prepared.file_path, yaml.dump(prepared.config, { lineWidth: 120 }), "utf8");
 
@@ -593,6 +607,8 @@ export function updateStyleguideConfig({ syncDir, scope, projectId, updates = {}
     config: prepared.config,
     changed_fields: prepared.changed_fields,
     warnings: prepared.warnings,
+    noop: false,
+    message: "Styleguide config updated.",
   };
 }
 

--- a/test/integration.test.mjs
+++ b/test/integration.test.mjs
@@ -682,6 +682,37 @@ describe("update_prose_styleguide_config tool", () => {
     assert.equal(persisted.voice_notes, "Leaner and colder.");
   });
 
+  test("returns noop when requested values are unchanged", async () => {
+    fs.writeFileSync(
+      path.join(writeSyncDir, "prose-styleguide.config.yaml"),
+      "language: english_us\ndialogue_tags: minimal\n",
+      "utf8"
+    );
+
+    const text = await callWriteTool("update_prose_styleguide_config", {
+      scope: "sync_root",
+      updates: {
+        dialogue_tags: "minimal",
+      },
+    });
+    const parsed = JSON.parse(text);
+
+    assert.equal(parsed.ok, true);
+    assert.equal(parsed.noop, true);
+    assert.equal(parsed.changed_fields.length, 0);
+  });
+
+  test("rejects unknown update fields at schema boundary", async () => {
+    const text = await callWriteTool("update_prose_styleguide_config", {
+      scope: "sync_root",
+      updates: {
+        dialogue_tags: "expressive",
+        dialog_tags_typo: "minimal",
+      },
+    });
+    assert.match(text, /Unrecognized key|unrecognized_keys|invalid/i);
+  });
+
   test("requires an existing config at the selected scope", async () => {
     fs.rmSync(path.join(writeSyncDir, "prose-styleguide.config.yaml"), { force: true });
 
@@ -720,6 +751,23 @@ describe("preview_prose_styleguide_config_update tool", () => {
     const persisted = yaml.load(fs.readFileSync(configPath, "utf8"));
     assert.equal(persisted.dialogue_tags, "minimal");
   });
+
+  test("returns noop when requested preview does not change values", async () => {
+    const configPath = path.join(writeSyncDir, "prose-styleguide.config.yaml");
+    fs.writeFileSync(configPath, "language: english_us\ndialogue_tags: minimal\n", "utf8");
+
+    const text = await callWriteTool("preview_prose_styleguide_config_update", {
+      scope: "sync_root",
+      updates: {
+        dialogue_tags: "minimal",
+      },
+    });
+    const parsed = JSON.parse(text);
+
+    assert.equal(parsed.ok, true);
+    assert.equal(parsed.noop, true);
+    assert.equal(parsed.changed_fields.length, 0);
+  });
 });
 
 describe("check_prose_styleguide_drift tool", () => {
@@ -743,6 +791,36 @@ describe("check_prose_styleguide_drift tool", () => {
         "part: 1",
         "chapter: 1",
         "timeline_position: 1",
+        "---",
+        "\"I go now,\" she says. \"I do what I must.\"",
+      ].join("\n"),
+      "utf8"
+    );
+
+    fs.writeFileSync(
+      path.join(sceneDir, "sc-002.md"),
+      [
+        "---",
+        "scene_id: drift-sc-002",
+        "project_id: drift-demo",
+        "part: 1",
+        "chapter: 1",
+        "timeline_position: 2",
+        "---",
+        "\"I go now,\" she says. \"I do what I must.\"",
+      ].join("\n"),
+      "utf8"
+    );
+
+    fs.writeFileSync(
+      path.join(sceneDir, "sc-003.md"),
+      [
+        "---",
+        "scene_id: drift-sc-003",
+        "project_id: drift-demo",
+        "part: 1",
+        "chapter: 1",
+        "timeline_position: 3",
         "---",
         "\"I go now,\" she says. \"I do what I must.\"",
       ].join("\n"),

--- a/test/integration.test.mjs
+++ b/test/integration.test.mjs
@@ -631,6 +631,141 @@ describe("get_prose_styleguide_config tool", () => {
   });
 });
 
+describe("summarize_prose_styleguide_config tool", () => {
+  test("returns a plain-language summary of the resolved config", async () => {
+    fs.writeFileSync(
+      path.join(writeSyncDir, "prose-styleguide.config.yaml"),
+      [
+        "language: english_uk",
+        "dialogue_tags: minimal",
+        "voice_notes: |",
+        "  Quietly intense.",
+      ].join("\n"),
+      "utf8"
+    );
+
+    const text = await callWriteTool("summarize_prose_styleguide_config");
+    const parsed = JSON.parse(text);
+
+    assert.equal(parsed.ok, true);
+    assert.match(parsed.summary_text, /Writing language: english_uk\./);
+    assert.match(parsed.summary_text, /Dialogue tag policy: minimal\./);
+    assert.match(parsed.summary_text, /Voice notes: Quietly intense\./);
+    assert.ok(Array.isArray(parsed.summary_lines));
+  });
+});
+
+describe("update_prose_styleguide_config tool", () => {
+  test("updates an existing sync-root config", async () => {
+    fs.writeFileSync(
+      path.join(writeSyncDir, "prose-styleguide.config.yaml"),
+      "language: english_us\ndialogue_tags: minimal\n",
+      "utf8"
+    );
+
+    const text = await callWriteTool("update_prose_styleguide_config", {
+      scope: "sync_root",
+      updates: {
+        dialogue_tags: "expressive",
+        voice_notes: "Leaner and colder.",
+      },
+    });
+    const parsed = JSON.parse(text);
+
+    assert.equal(parsed.ok, true);
+    assert.equal(parsed.config.language, "english_us");
+    assert.equal(parsed.config.dialogue_tags, "expressive");
+    assert.equal(parsed.config.voice_notes, "Leaner and colder.");
+
+    const persisted = yaml.load(fs.readFileSync(path.join(writeSyncDir, "prose-styleguide.config.yaml"), "utf8"));
+    assert.equal(persisted.dialogue_tags, "expressive");
+    assert.equal(persisted.voice_notes, "Leaner and colder.");
+  });
+
+  test("requires an existing config at the selected scope", async () => {
+    fs.rmSync(path.join(writeSyncDir, "prose-styleguide.config.yaml"), { force: true });
+
+    const text = await callWriteTool("update_prose_styleguide_config", {
+      scope: "sync_root",
+      updates: {
+        dialogue_tags: "expressive",
+      },
+    });
+    const parsed = JSON.parse(text);
+
+    assert.equal(parsed.ok, false);
+    assert.equal(parsed.error.code, "STYLEGUIDE_CONFIG_NOT_FOUND");
+  });
+});
+
+describe("preview_prose_styleguide_config_update tool", () => {
+  test("returns before/after config and changed fields without persisting", async () => {
+    const configPath = path.join(writeSyncDir, "prose-styleguide.config.yaml");
+    fs.writeFileSync(configPath, "language: english_us\ndialogue_tags: minimal\n", "utf8");
+
+    const text = await callWriteTool("preview_prose_styleguide_config_update", {
+      scope: "sync_root",
+      updates: {
+        dialogue_tags: "expressive",
+      },
+    });
+    const parsed = JSON.parse(text);
+
+    assert.equal(parsed.ok, true);
+    assert.equal(parsed.current_config.dialogue_tags, "minimal");
+    assert.equal(parsed.next_config.dialogue_tags, "expressive");
+    assert.equal(parsed.changed_fields.length, 1);
+    assert.equal(parsed.changed_fields[0].field, "dialogue_tags");
+
+    const persisted = yaml.load(fs.readFileSync(configPath, "utf8"));
+    assert.equal(persisted.dialogue_tags, "minimal");
+  });
+});
+
+describe("check_prose_styleguide_drift tool", () => {
+  test("returns scene drift signals and suggested updates", async () => {
+    const projectId = "drift-demo";
+    const sceneDir = path.join(writeSyncDir, "projects", projectId, "scenes");
+    fs.mkdirSync(sceneDir, { recursive: true });
+
+    fs.writeFileSync(
+      path.join(writeSyncDir, "prose-styleguide.config.yaml"),
+      "language: english_uk\nquotation_style: single\ntense: past\n",
+      "utf8"
+    );
+
+    fs.writeFileSync(
+      path.join(sceneDir, "sc-001.md"),
+      [
+        "---",
+        "scene_id: drift-sc-001",
+        "project_id: drift-demo",
+        "part: 1",
+        "chapter: 1",
+        "timeline_position: 1",
+        "---",
+        "\"I go now,\" she says. \"I do what I must.\"",
+      ].join("\n"),
+      "utf8"
+    );
+
+    const syncText = await callWriteTool("sync");
+    assert.match(syncText, /scenes indexed/);
+
+    const text = await callWriteTool("check_prose_styleguide_drift", {
+      project_id: projectId,
+      max_scenes: 10,
+    });
+    const parsed = JSON.parse(text);
+
+    assert.equal(parsed.ok, true);
+    assert.equal(parsed.checked_scenes >= 1, true);
+    assert.equal(parsed.scenes_with_drift >= 1, true);
+    assert.equal(Array.isArray(parsed.scene_results), true);
+    assert.equal(Object.hasOwn(parsed.suggested_updates, "quotation_style"), true);
+  });
+});
+
 describe("setup_prose_styleguide_skill tool", () => {
   test("requires a styleguide config before skill generation", async () => {
     const rootConfigPath = path.join(writeSyncDir, "prose-styleguide.config.yaml");

--- a/test/unit.test.mjs
+++ b/test/unit.test.mjs
@@ -35,8 +35,9 @@ import {
 import { runSceneCharacterBatch } from "../scene-character-batch.js";
 import { buildCharacterNormalizationContext, isDistinctiveToken, normalizeSceneCharacters } from "../scene-character-normalization.js";
 import { buildReviewBundlePlan, renderReviewBundleMarkdown, ReviewBundlePlanError } from "../review-bundles.js";
-import { buildStyleguideConfigDraft, resolveStyleguideConfig } from "../prose-styleguide.js";
+import { buildStyleguideConfigDraft, previewStyleguideConfigUpdate, resolveStyleguideConfig, summarizeStyleguideConfig, updateStyleguideConfig } from "../prose-styleguide.js";
 import { buildProseStyleguideSkill } from "../prose-styleguide-skill.js";
+import { analyzeSceneStyleguideDrift, suggestStyleguideUpdatesFromScenes } from "../prose-styleguide-drift.js";
 
 function insertTestScene(db, {
   sceneId,
@@ -352,6 +353,139 @@ describe("styleguide config hardening", () => {
     } finally {
       fs.rmSync(syncDir, { recursive: true, force: true });
     }
+  });
+});
+
+describe("summarizeStyleguideConfig", () => {
+  test("renders plain-language summary lines", () => {
+    const result = summarizeStyleguideConfig({
+      resolvedConfig: {
+        language: "english_uk",
+        spelling: "uk",
+        quotation_style: "single",
+        tense: "present",
+        dialogue_tags: "minimal",
+        voice_notes: "Restrained and precise.",
+      },
+      inferredDefaults: { spelling: "uk", quotation_style: "single" },
+    });
+
+    assert.equal(result.ok, true);
+    assert.match(result.summary_text, /Writing language: english_uk\./);
+    assert.match(result.summary_text, /Spelling variant: uk\./);
+    assert.match(result.summary_text, /Dialogue punctuation uses single\./);
+    assert.match(result.summary_text, /Voice notes: Restrained and precise\./);
+    assert.match(result.summary_text, /Inferred defaults currently fill: spelling, quotation_style\./);
+  });
+});
+
+describe("updateStyleguideConfig", () => {
+  test("updates explicit fields on an existing config layer without expanding defaults", () => {
+    const syncDir = fs.mkdtempSync(path.join(os.tmpdir(), "styleguide-update-"));
+    try {
+      fs.writeFileSync(
+        path.join(syncDir, "prose-styleguide.config.yaml"),
+        "language: english_us\ndialogue_tags: minimal\n",
+        "utf8"
+      );
+
+      const result = updateStyleguideConfig({
+        syncDir,
+        scope: "sync_root",
+        updates: {
+          dialogue_tags: "expressive",
+          voice_notes: "Sharper interiority.",
+        },
+      });
+
+      assert.equal(result.ok, true);
+      assert.equal(result.config.language, "english_us");
+      assert.equal(result.config.dialogue_tags, "expressive");
+      assert.equal(result.config.voice_notes, "Sharper interiority.");
+
+      const persisted = yaml.load(fs.readFileSync(path.join(syncDir, "prose-styleguide.config.yaml"), "utf8"));
+      assert.equal(persisted.language, "english_us");
+      assert.equal(persisted.dialogue_tags, "expressive");
+      assert.equal(persisted.voice_notes, "Sharper interiority.");
+      assert.equal(persisted.spelling, undefined);
+    } finally {
+      fs.rmSync(syncDir, { recursive: true, force: true });
+    }
+  });
+
+  test("fails when the target scope has no config file yet", () => {
+    const syncDir = fs.mkdtempSync(path.join(os.tmpdir(), "styleguide-update-missing-"));
+    try {
+      const result = updateStyleguideConfig({
+        syncDir,
+        scope: "sync_root",
+        updates: { dialogue_tags: "expressive" },
+      });
+
+      assert.equal(result.ok, false);
+      assert.equal(result.error.code, "STYLEGUIDE_CONFIG_NOT_FOUND");
+    } finally {
+      fs.rmSync(syncDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("previewStyleguideConfigUpdate", () => {
+  test("returns before/after and changed fields without writing", () => {
+    const syncDir = fs.mkdtempSync(path.join(os.tmpdir(), "styleguide-preview-update-"));
+    try {
+      const filePath = path.join(syncDir, "prose-styleguide.config.yaml");
+      fs.writeFileSync(filePath, "language: english_us\ndialogue_tags: minimal\n", "utf8");
+
+      const preview = previewStyleguideConfigUpdate({
+        syncDir,
+        scope: "sync_root",
+        updates: { dialogue_tags: "expressive" },
+      });
+
+      assert.equal(preview.ok, true);
+      assert.equal(preview.current_config.dialogue_tags, "minimal");
+      assert.equal(preview.config.dialogue_tags, "expressive");
+      assert.equal(preview.changed_fields.length, 1);
+      assert.equal(preview.changed_fields[0].field, "dialogue_tags");
+
+      const persisted = yaml.load(fs.readFileSync(filePath, "utf8"));
+      assert.equal(persisted.dialogue_tags, "minimal");
+    } finally {
+      fs.rmSync(syncDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("styleguide drift analysis", () => {
+  test("detects scene-level drift from declared quotation style and tense", () => {
+    const analysis = analyzeSceneStyleguideDrift({
+      prose: '"I go now," she says. "I do what I must."',
+      resolvedConfig: {
+        quotation_style: "single",
+        tense: "past",
+      },
+    });
+
+    assert.equal(analysis.observed.quotation_style, "double");
+    assert.equal(analysis.observed.tense, "present");
+    assert.equal(analysis.drift.length >= 1, true);
+  });
+
+  test("suggests updates when observed convention agreement is strong", () => {
+    const suggestions = suggestStyleguideUpdatesFromScenes({
+      sceneAnalyses: [
+        { observed: { quotation_style: "double", tense: "present" }, drift: [] },
+        { observed: { quotation_style: "double", tense: "present" }, drift: [] },
+        { observed: { quotation_style: "double", tense: "past" }, drift: [] },
+      ],
+      resolvedConfig: { quotation_style: "single", tense: "past" },
+      minAgreement: 0.6,
+    });
+
+    assert.equal(Object.hasOwn(suggestions, "quotation_style"), true);
+    assert.equal(suggestions.quotation_style.suggested_value, "double");
+    assert.equal(Object.hasOwn(suggestions, "tense"), false);
   });
 });
 

--- a/test/unit.test.mjs
+++ b/test/unit.test.mjs
@@ -487,6 +487,20 @@ describe("styleguide drift analysis", () => {
     assert.equal(suggestions.quotation_style.suggested_value, "double");
     assert.equal(Object.hasOwn(suggestions, "tense"), false);
   });
+
+  test("requires minimum evidence before emitting suggestion", () => {
+    const suggestions = suggestStyleguideUpdatesFromScenes({
+      sceneAnalyses: [
+        { observed: { quotation_style: "double" }, drift: [] },
+        { observed: { quotation_style: "double" }, drift: [] },
+      ],
+      resolvedConfig: { quotation_style: "single" },
+      minAgreement: 0.6,
+      minEvidence: 3,
+    });
+
+    assert.equal(Object.hasOwn(suggestions, "quotation_style"), false);
+  });
 });
 
 describe("buildProseStyleguideSkill", () => {

--- a/test/unit.test.mjs
+++ b/test/unit.test.mjs
@@ -428,6 +428,22 @@ describe("updateStyleguideConfig", () => {
       fs.rmSync(syncDir, { recursive: true, force: true });
     }
   });
+
+  test("fails with PROJECT_ID_REQUIRED when scope is project_root without projectId", () => {
+    const syncDir = fs.mkdtempSync(path.join(os.tmpdir(), "styleguide-update-project-guard-"));
+    try {
+      const result = updateStyleguideConfig({
+        syncDir,
+        scope: "project_root",
+        updates: { dialogue_tags: "expressive" },
+      });
+
+      assert.equal(result.ok, false);
+      assert.equal(result.error.code, "PROJECT_ID_REQUIRED");
+    } finally {
+      fs.rmSync(syncDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("previewStyleguideConfigUpdate", () => {


### PR DESCRIPTION
## Summary

- Adds a config-update preview flow for prose styleguide settings so changes can be reviewed before writing.
- Adds prose styleguide drift analysis tooling that compares declared conventions to observed scene prose signals.
- Extends styleguide helper module with reusable summary/update-preview/update primitives.
- Adds two new MCP tools for conversational config review flow and one drift-check tool.
- Regenerates tool docs.

## Motivation

Implements the next two guideline-generation slices from the PRD roadmap:
- Conversational config review/update workflow (summarize + preview + confirm write)
- Drift detection between declared styleguide conventions and actual prose usage

## Implementation

- New module: prose-styleguide-drift.js
  - Detects observed style signals per scene (quotation_style, em_dash_spacing, spelling, tense)
  - Computes scene-level drift against resolved config
  - Produces update suggestions when agreement passes threshold
- prose-styleguide.js
  - Adds summarizeStyleguideConfig helper
  - Adds previewStyleguideConfigUpdate helper (no-write)
  - Refactors updateStyleguideConfig to share validation/merge logic and expose changed_fields
- index.js
  - Adds summarize_prose_styleguide_config
  - Adds preview_prose_styleguide_config_update
  - Adds update_prose_styleguide_config changed_fields in response
  - Adds check_prose_styleguide_drift
- Tests
  - Unit: summary helper, preview-update helper, drift analysis + suggestion threshold behavior
  - Integration: summarize/update/preview tool flows and drift-check end-to-end

## Testing

- `npm run docs`
- `npm test` (285/285 passing)

## Risks and tradeoffs

- Drift detection is heuristic (signal-based), not linguistic parsing; it is intended for guidance and questioning, not hard enforcement.
- Tense suggestions use a stricter threshold than other fields to reduce noisy recommendations.

## Follow-up

- Add per-field confidence messaging in drift output for better reviewer UX.
- Add optional scene-level explanations/snippets for each detected drift instance.
- Explore broader convention detection (dialogue tags, number style) in a later slice.
