### PR TITLE
feat(workflows): add describe_workflows entry-point tool

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -234,3 +234,4 @@ See [ideas-and-questions.md](docs/prd/inbox/ideas-and-questions.md) for:
 - [Review Bundles](docs/prd/done/review-bundles.md) — editorial workflows, profiles, known issues
 - [Scrivener Direct Extraction](docs/prd/done/scrivener-direct-extraction-beta.md) — direct .scriv ingestion
 - [Open Ideas](docs/prd/inbox/ideas-and-questions.md) — design questions, feature ideas
+- [Workflow Discovery](docs/prd/todo/describe-workflows.md) — `describe_workflows` tool, entry-point for AI navigation

--- a/PRD.md
+++ b/PRD.md
@@ -234,4 +234,4 @@ See [ideas-and-questions.md](docs/prd/inbox/ideas-and-questions.md) for:
 - [Review Bundles](docs/prd/done/review-bundles.md) — editorial workflows, profiles, known issues
 - [Scrivener Direct Extraction](docs/prd/done/scrivener-direct-extraction-beta.md) — direct .scriv ingestion
 - [Open Ideas](docs/prd/inbox/ideas-and-questions.md) — design questions, feature ideas
-- [Workflow Discovery](docs/prd/todo/describe-workflows.md) — `describe_workflows` tool, entry-point for AI navigation
+- [Workflow Discovery](docs/prd/done/describe-workflows.md) — `describe_workflows` tool, entry-point for AI navigation

--- a/docs/prd/done/describe-workflows.md
+++ b/docs/prd/done/describe-workflows.md
@@ -1,6 +1,6 @@
 # Workflow Discovery: `describe_workflows` Tool
 
-**Status:** 📋 Todo
+**Status:** ✅ Complete
 
 ---
 
@@ -221,9 +221,9 @@ The `context` object is computed at call time and reflects current server state.
 
 ## Completion Checklist
 
-- [ ] Implement `describe_workflows` tool in `index.js` (or extracted tool group module)
-- [ ] Implement `context` fields: `project_id`, `scene_count`, `styleguide_exists`, `git_available`, `pending_proposals`, `sync_dir`
-- [ ] Define static `WORKFLOW_CATALOGUE` constant with all 8 workflows from this PRD
-- [ ] Register tool first in tool registration order
-- [ ] Add integration test: call returns `ok: true`, `context.scene_count` matches db, all workflow ids present
-- [ ] Update `PRD.md` overview to reference this feature
+- [x] Implement `describe_workflows` tool in `index.js`
+- [x] Implement `context` fields: `project_id`, `scene_count`, `styleguide_exists`, `git_available`, `pending_proposals`, `sync_dir`
+- [x] Define static `WORKFLOW_CATALOGUE` constant with all 9 workflows
+- [x] Register tool first in tool registration order
+- [x] Add integration tests: shape, all workflow ids, `scene_count` vs db, per-workflow structural validity
+- [x] Update `PRD.md` overview to reference this feature

--- a/docs/prd/done/describe-workflows.md
+++ b/docs/prd/done/describe-workflows.md
@@ -54,6 +54,7 @@ None.
     "sync_dir": "/path/to/sync",
     "styleguide_exists": {
       "sync_root": true,
+      "universe_root": false,
       "project_root": false
     },
     "git_available": true,
@@ -190,6 +191,7 @@ The `context` object is computed at call time and reflects current server state.
 | `scene_count` | `SELECT COUNT(*) FROM scenes` | Lets the AI set `max_scenes` correctly without guessing |
 | `sync_dir` | `SYNC_DIR_ABS` | Path confirmation |
 | `styleguide_exists.sync_root` | File existence check | Skips `setup_prose_styleguide_config` if already created |
+| `styleguide_exists.universe_root` | File existence check at universe segment of project_id (null if no `/` in project_id) | Same, at universe scope |
 | `styleguide_exists.project_root` | File existence check per derived project_id | Same, at project scope |
 | `git_available` | `GIT_AVAILABLE` runtime flag | Tells the AI whether snapshot/version tools will work |
 | `pending_proposals` | `pendingProposals.size` | Alerts the AI if uncommitted proposals exist |
@@ -213,9 +215,9 @@ The `context` object is computed at call time and reflects current server state.
 ## Implementation Notes
 
 - The tool has no schema parameters (empty `{}`).
-- `styleguide_exists` checks use `fs.existsSync` on the two standard config paths; no file parsing.
-- `project_id` derivation: `SELECT project_id, COUNT(*) as c FROM scenes GROUP BY project_id ORDER BY c DESC LIMIT 1`.
-- `pending_proposals` reads from the module-scoped `pendingProposals` Map in the edit proposal state, consistent with how `db` is accessed.
+- `styleguide_exists` checks use `fs.existsSync` on the three standard config paths (sync_root, universe_root, project_root); no file parsing. `universe_root` is derived from the universe segment of `project_id` (present when `project_id` contains `/`).
+- `project_id` derivation: `SELECT project_id, COUNT(*) as c FROM scenes GROUP BY project_id ORDER BY c DESC, project_id ASC LIMIT 1`.
+- `pending_proposals` reads from the module-scoped `pendingProposals` Map, consistent with how `db` is accessed.
 - The workflow catalogue is a static constant defined once; it does not need to be regenerated per call.
 - This tool should be listed first in the tool registration order so it appears at the top of tool lists in clients that preserve insertion order.
 

--- a/docs/prd/done/describe-workflows.md
+++ b/docs/prd/done/describe-workflows.md
@@ -47,6 +47,7 @@ None.
 
 ```json
 {
+  "ok": true,
   "context": {
     "project_id": "universe-1/book-1-the-lamb",
     "scene_count": 104,
@@ -72,8 +73,9 @@ None.
   ],
   "notes": [
     "Never write JavaScript or shell scripts to invoke tools. Call them directly.",
-    "If a tool returns an error with a next_step field, follow it before trying anything else.",
-    "Use find_scenes without filters to discover what project_ids are indexed."
+    "If a tool returns a next_step field (in a success or error response), follow it before trying anything else.",
+    "Use find_scenes without filters to discover what project_ids are indexed.",
+    "When calling bootstrap_prose_styleguide_config or check_prose_styleguide_drift, set max_scenes to context.scene_count to avoid the default limit."
   ]
 }
 ```
@@ -184,7 +186,7 @@ The `context` object is computed at call time and reflects current server state.
 
 | Field | Source | Purpose |
 |---|---|---|
-| `project_id` | Derived from `WRITING_SYNC_DIR` path or most common project in db | Tells the AI what project is connected |
+| `project_id` | Most frequent `project_id` in the scenes table (secondary sort: alphabetical for stability), or null if db is empty | Tells the AI what project is connected |
 | `scene_count` | `SELECT COUNT(*) FROM scenes` | Lets the AI set `max_scenes` correctly without guessing |
 | `sync_dir` | `SYNC_DIR_ABS` | Path confirmation |
 | `styleguide_exists.sync_root` | File existence check | Skips `setup_prose_styleguide_config` if already created |
@@ -200,7 +202,7 @@ The `context` object is computed at call time and reflects current server state.
 
 **No parameters.** The tool is a zero-friction entry point. Any parameter requirement risks the AI not calling it when it should.
 
-**`project_id` in context is best-effort.** The server has no explicit "current project" setting — the sync dir implicitly scopes it. The derived value is the most frequent `project_id` in the scenes table, or null if the db is empty. This is informational only; the AI should confirm with the user if unsure.
+**`project_id` in context is best-effort.** The server has no explicit "current project" setting. The derived value is the most frequent `project_id` in the scenes table (ties broken alphabetically for stability), or null if the db is empty. This is informational only; the AI should confirm with the user if unsure.
 
 **`notes` array, not prose.** Machine-readable rules the AI can act on directly, not narrative explanation.
 

--- a/docs/prd/done/describe-workflows.md
+++ b/docs/prd/done/describe-workflows.md
@@ -215,7 +215,7 @@ The `context` object is computed at call time and reflects current server state.
 - The tool has no schema parameters (empty `{}`).
 - `styleguide_exists` checks use `fs.existsSync` on the two standard config paths; no file parsing.
 - `project_id` derivation: `SELECT project_id, COUNT(*) as c FROM scenes GROUP BY project_id ORDER BY c DESC LIMIT 1`.
-- `pending_proposals` requires access to the `pendingProposals` Map in the edit proposal state — pass it in the tool registration context alongside `db`.
+- `pending_proposals` reads from the module-scoped `pendingProposals` Map in the edit proposal state, consistent with how `db` is accessed.
 - The workflow catalogue is a static constant defined once; it does not need to be regenerated per call.
 - This tool should be listed first in the tool registration order so it appears at the top of tool lists in clients that preserve insertion order.
 

--- a/docs/prd/todo/describe-workflows.md
+++ b/docs/prd/todo/describe-workflows.md
@@ -1,0 +1,229 @@
+# Workflow Discovery: `describe_workflows` Tool
+
+**Status:** 📋 Todo
+
+---
+
+## Problem
+
+The server exposes 44 tools. An AI entering a session has no map: no hierarchy, no starting point, no indication of which tools belong together in a flow. The result observed in practice is that the AI tries to guess sequences, gets stuck on missing preconditions (e.g. running `update_prose_styleguide_config` before a config exists), and falls back to writing Node.js scripts to invoke tools indirectly. This defeats the purpose of the MCP.
+
+The root cause is not model quality. It is a missing affordance: the server provides primitives but no workflows.
+
+---
+
+## Goal
+
+Add a single `describe_workflows` tool that gives an AI everything it needs to orient itself in a new session: what workflows are available, which tools belong to each, what the current project context looks like, and what the correct entry point is for any common task.
+
+This is not documentation. It is a runtime affordance — a call the AI can make whenever it is uncertain, and that always returns current state alongside the workflow map.
+
+---
+
+## Non-goals
+
+- Composite tools that execute multi-step workflows automatically. That is a separate feature (see [ideas-and-questions.md](../inbox/ideas-and-questions.md)).
+- MCP Prompts (protocol-level). Client support in VS Code Copilot is incomplete. Tools work everywhere.
+- Replacing `get_runtime_config`. That tool is for path diagnostics. This one is for navigation.
+- Documenting every tool. The workflow map covers task-level flows, not individual tool parameters.
+
+---
+
+## Tool Specification
+
+### Name
+
+`describe_workflows`
+
+### Description (shown to the AI in the tool list)
+
+> Return a map of available task workflows and the current project context. Call this at the start of a session or whenever you are unsure what to do next. Never write scripts to invoke tools — call them directly.
+
+### Parameters
+
+None.
+
+### Response shape
+
+```json
+{
+  "context": {
+    "project_id": "universe-1/book-1-the-lamb",
+    "scene_count": 104,
+    "sync_dir": "/path/to/sync",
+    "styleguide_exists": {
+      "sync_root": true,
+      "project_root": false
+    },
+    "git_available": true,
+    "pending_proposals": 0
+  },
+  "workflows": [
+    {
+      "id": "first_time_setup",
+      "label": "First-time setup",
+      "use_when": "Connecting to a project for the first time or verifying the runtime is correctly configured.",
+      "steps": [
+        { "tool": "get_runtime_config", "note": "Verify sync dir and capabilities." },
+        { "tool": "sync", "note": "Index scenes from disk." }
+      ]
+    },
+    ...
+  ],
+  "notes": [
+    "Never write JavaScript or shell scripts to invoke tools. Call them directly.",
+    "If a tool returns an error with a next_step field, follow it before trying anything else.",
+    "Use find_scenes without filters to discover what project_ids are indexed."
+  ]
+}
+```
+
+---
+
+## Workflow Catalogue
+
+These are the workflows the tool must document. Each entry maps to a `steps` array in the response.
+
+### first_time_setup
+
+**Use when:** Connecting to a project for the first time.
+
+1. `get_runtime_config` — verify sync dir, writability, git availability
+2. `sync` — index scenes from disk
+
+---
+
+### styleguide_setup_new
+
+**Use when:** No prose styleguide config exists and you want to create one from the manuscript's existing conventions.
+
+1. `describe_workflows` — check `context.scene_count`; use that value as `max_scenes`
+2. `bootstrap_prose_styleguide_config` — detect dominant conventions; confirm suggestions with user
+3. `setup_prose_styleguide_config` — create config at `project_root` scope if `context.styleguide_exists.project_root` is false
+4. `update_prose_styleguide_config` — apply accepted fields from bootstrap suggestions
+
+---
+
+### styleguide_drift_check
+
+**Use when:** A styleguide config exists and you want to check whether recent scenes conform to it.
+
+1. `get_prose_styleguide_config` — confirm current resolved config
+2. `check_prose_styleguide_drift` — detect non-conforming scenes; set `max_scenes` from `context.scene_count`
+3. `update_prose_styleguide_config` — if drift found and user approves, update config or note the outliers
+
+---
+
+### manuscript_exploration
+
+**Use when:** Answering questions about the manuscript, finding scenes, or getting an overview.
+
+1. `find_scenes` — filter by character, beat, tag, part, chapter, or POV; no filters returns all
+2. `get_scene_prose` — load prose for specific scenes
+3. `get_chapter_prose` — load all prose for a chapter (use sparingly; large chapters overflow context)
+4. `search_metadata` — full-text search across scene metadata fields
+
+---
+
+### prose_editing
+
+**Use when:** Revising scene prose. All edits require explicit user confirmation before writing.
+
+1. `find_scenes` + `get_scene_prose` — identify the target scene
+2. `propose_edit` — stage a revision; returns a diff preview and a `proposal_id`
+3. User reviews diff
+4. `commit_edit` — write the revision (runs preflight checks)
+5. `discard_edit` — reject the revision if unwanted
+
+---
+
+### character_management
+
+**Use when:** Working with characters — finding them, reading their sheets, or updating details.
+
+1. `list_characters` — find `character_id` values
+2. `get_character_sheet` — read full character details
+3. `create_character_sheet` — create a new character (requires `project_id` or `universe_id`, not both)
+4. `update_character_sheet` — edit character metadata
+
+---
+
+### place_management
+
+**Use when:** Working with locations.
+
+1. `list_places` — find `place_id` values
+2. `get_place_sheet` — read full place details
+3. `create_place_sheet` — create a new place (requires `project_id` or `universe_id`, not both)
+4. `update_place_sheet` — edit place metadata
+
+---
+
+### review_bundle
+
+**Use when:** Preparing a formatted bundle for human review (outline, editorial, or beta read).
+
+1. `preview_review_bundle` — check which scenes would be included and estimated size
+2. `create_review_bundle` — generate the bundle
+
+---
+
+### async_job_tracking
+
+**Use when:** A tool returns a `job_id` instead of an immediate result (e.g. `import_scrivener_sync_async`).
+
+1. Call `get_async_job_status` with the `job_id` — poll until `status` is `completed` or `failed`
+2. On `failed`: inspect `error` field; do not retry automatically without user confirmation
+3. On `completed`: use the `result` field; call `sync` if the job modified files on disk
+
+---
+
+## Context Fields
+
+The `context` object is computed at call time and reflects current server state.
+
+| Field | Source | Purpose |
+|---|---|---|
+| `project_id` | Derived from `WRITING_SYNC_DIR` path or most common project in db | Tells the AI what project is connected |
+| `scene_count` | `SELECT COUNT(*) FROM scenes` | Lets the AI set `max_scenes` correctly without guessing |
+| `sync_dir` | `SYNC_DIR_ABS` | Path confirmation |
+| `styleguide_exists.sync_root` | File existence check | Skips `setup_prose_styleguide_config` if already created |
+| `styleguide_exists.project_root` | File existence check per derived project_id | Same, at project scope |
+| `git_available` | `GIT_AVAILABLE` runtime flag | Tells the AI whether snapshot/version tools will work |
+| `pending_proposals` | `pendingProposals.size` | Alerts the AI if uncommitted proposals exist |
+
+---
+
+## Design Decisions
+
+**Static workflow list, dynamic context.** The workflow catalogue does not change between calls. The context does. Separating them in the response makes it easy for an AI to re-call only for context refresh without re-reading the whole catalogue.
+
+**No parameters.** The tool is a zero-friction entry point. Any parameter requirement risks the AI not calling it when it should.
+
+**`project_id` in context is best-effort.** The server has no explicit "current project" setting — the sync dir implicitly scopes it. The derived value is the most frequent `project_id` in the scenes table, or null if the db is empty. This is informational only; the AI should confirm with the user if unsure.
+
+**`notes` array, not prose.** Machine-readable rules the AI can act on directly, not narrative explanation.
+
+**Workflow steps use `note` for inline guidance.** This replaces the need to look up individual tool descriptions for sequencing decisions.
+
+---
+
+## Implementation Notes
+
+- The tool has no schema parameters (empty `{}`).
+- `styleguide_exists` checks use `fs.existsSync` on the two standard config paths; no file parsing.
+- `project_id` derivation: `SELECT project_id, COUNT(*) as c FROM scenes GROUP BY project_id ORDER BY c DESC LIMIT 1`.
+- `pending_proposals` requires access to the `pendingProposals` Map in the edit proposal state — pass it in the tool registration context alongside `db`.
+- The workflow catalogue is a static constant defined once; it does not need to be regenerated per call.
+- This tool should be listed first in the tool registration order so it appears at the top of tool lists in clients that preserve insertion order.
+
+---
+
+## Completion Checklist
+
+- [ ] Implement `describe_workflows` tool in `index.js` (or extracted tool group module)
+- [ ] Implement `context` fields: `project_id`, `scene_count`, `styleguide_exists`, `git_available`, `pending_proposals`, `sync_dir`
+- [ ] Define static `WORKFLOW_CATALOGUE` constant with all 8 workflows from this PRD
+- [ ] Register tool first in tool registration order
+- [ ] Add integration test: call returns `ok: true`, `context.scene_count` matches db, all workflow ids present
+- [ ] Update `PRD.md` overview to reference this feature

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -5,6 +5,7 @@
 
 ## Tools
 
+- [`describe_workflows`](#describe_workflows)
 - [`sync`](#sync)
 - [`import_scrivener_sync`](#import_scrivener_sync)
 - [`import_scrivener_sync_async`](#import_scrivener_sync_async)
@@ -49,6 +50,14 @@
 - [`discard_edit`](#discard_edit)
 - [`snapshot_scene`](#snapshot_scene)
 - [`list_snapshots`](#list_snapshots)
+
+---
+
+## describe_workflows
+
+Return a map of available task workflows and the current project context. Call this at the start of a session or whenever you are unsure what to do next. Never write scripts to invoke tools — call them directly.
+
+_No parameters._
 
 ---
 

--- a/index.js
+++ b/index.js
@@ -866,7 +866,7 @@ const WORKFLOW_CATALOGUE = [
     steps: [
       { tool: "describe_workflows", note: "Check context.scene_count; use that value as max_scenes in the next call." },
       { tool: "bootstrap_prose_styleguide_config", note: "Detect dominant conventions. Confirm suggestions with the user before applying." },
-      { tool: "setup_prose_styleguide_config", note: "Create config at project_root scope if context.styleguide_exists.project_root is false. Requires language (e.g. 'en')." },
+      { tool: "setup_prose_styleguide_config", note: "Create config at project_root scope if context.styleguide_exists.project_root is false. Requires language (e.g. 'english_us')." },
       { tool: "update_prose_styleguide_config", note: "Apply the fields accepted from bootstrap suggestions." },
     ],
   },
@@ -876,7 +876,7 @@ const WORKFLOW_CATALOGUE = [
     use_when: "A styleguide config exists and you want to check whether recent scenes conform to it.",
     steps: [
       { tool: "get_prose_styleguide_config", note: "Confirm the currently resolved config." },
-      { tool: "check_prose_styleguide_drift", note: "Detect non-conforming scenes. Set max_scenes from context.scene_count." },
+      { tool: "check_prose_styleguide_drift", note: "Detect non-conforming scenes. Pass project_id from context.project_id and set max_scenes from context.scene_count." },
       { tool: "update_prose_styleguide_config", note: "If drift found and user approves, update config or note the outliers." },
     ],
   },
@@ -930,8 +930,8 @@ const WORKFLOW_CATALOGUE = [
     label: "Review bundle",
     use_when: "Preparing a formatted bundle for human review (outline, editorial, or beta read profile).",
     steps: [
-      { tool: "preview_review_bundle", note: "Check which scenes would be included and the estimated size." },
-      { tool: "create_review_bundle", note: "Generate the bundle." },
+      { tool: "preview_review_bundle", note: "Check which scenes would be included and the estimated size. Requires project_id and profile." },
+      { tool: "create_review_bundle", note: "Generate the bundle. Requires project_id." },
     ],
   },
   {
@@ -958,7 +958,7 @@ function createMcpServer() {
     {},
     async () => {
       const projectRow = db.prepare(
-        `SELECT project_id FROM scenes GROUP BY project_id ORDER BY COUNT(*) DESC LIMIT 1`
+        `SELECT project_id FROM scenes GROUP BY project_id ORDER BY COUNT(*) DESC, project_id ASC LIMIT 1`
       ).get();
       const project_id = projectRow?.project_id ?? null;
 

--- a/index.js
+++ b/index.js
@@ -849,11 +849,150 @@ function maxScenesNextStep(matchedCount) {
   return `Re-run with max_scenes set to at least ${matchedCount}.`;
 }
 
+const WORKFLOW_CATALOGUE = [
+  {
+    id: "first_time_setup",
+    label: "First-time setup",
+    use_when: "Connecting to a project for the first time or verifying the runtime is correctly configured.",
+    steps: [
+      { tool: "get_runtime_config", note: "Verify sync dir, writability, and git availability." },
+      { tool: "sync", note: "Index scenes from disk." },
+    ],
+  },
+  {
+    id: "styleguide_setup_new",
+    label: "Styleguide setup (new project)",
+    use_when: "No prose styleguide config exists and you want to create one based on the manuscript's existing conventions.",
+    steps: [
+      { tool: "describe_workflows", note: "Check context.scene_count; use that value as max_scenes in the next call." },
+      { tool: "bootstrap_prose_styleguide_config", note: "Detect dominant conventions. Confirm suggestions with the user before applying." },
+      { tool: "setup_prose_styleguide_config", note: "Create config at project_root scope if context.styleguide_exists.project_root is false. Requires language (e.g. 'en')." },
+      { tool: "update_prose_styleguide_config", note: "Apply the fields accepted from bootstrap suggestions." },
+    ],
+  },
+  {
+    id: "styleguide_drift_check",
+    label: "Styleguide drift check",
+    use_when: "A styleguide config exists and you want to check whether recent scenes conform to it.",
+    steps: [
+      { tool: "get_prose_styleguide_config", note: "Confirm the currently resolved config." },
+      { tool: "check_prose_styleguide_drift", note: "Detect non-conforming scenes. Set max_scenes from context.scene_count." },
+      { tool: "update_prose_styleguide_config", note: "If drift found and user approves, update config or note the outliers." },
+    ],
+  },
+  {
+    id: "manuscript_exploration",
+    label: "Manuscript exploration",
+    use_when: "Answering questions about the manuscript, finding scenes, or getting an overview.",
+    steps: [
+      { tool: "find_scenes", note: "Filter by character, beat, tag, part, chapter, or POV. No filters returns all scenes." },
+      { tool: "get_scene_prose", note: "Load prose for specific scenes identified by find_scenes." },
+      { tool: "get_chapter_prose", note: "Load all prose for a chapter. Use sparingly — large chapters can overflow context." },
+      { tool: "search_metadata", note: "Full-text search across scene metadata fields." },
+    ],
+  },
+  {
+    id: "prose_editing",
+    label: "Prose editing",
+    use_when: "Revising scene prose. All edits require explicit user confirmation before writing.",
+    steps: [
+      { tool: "find_scenes", note: "Identify the target scene." },
+      { tool: "get_scene_prose", note: "Load the current prose." },
+      { tool: "propose_edit", note: "Stage a revision; returns a diff preview and a proposal_id." },
+      { tool: "commit_edit", note: "Write the revision after the user confirms. Runs preflight checks before writing." },
+      { tool: "discard_edit", note: "Reject the revision if the user does not approve." },
+    ],
+  },
+  {
+    id: "character_management",
+    label: "Character management",
+    use_when: "Finding characters, reading their sheets, or updating character details.",
+    steps: [
+      { tool: "list_characters", note: "Find character_id values." },
+      { tool: "get_character_sheet", note: "Read full character details." },
+      { tool: "create_character_sheet", note: "Create a new character. Requires exactly one of project_id or universe_id." },
+      { tool: "update_character_sheet", note: "Edit character metadata." },
+    ],
+  },
+  {
+    id: "place_management",
+    label: "Place management",
+    use_when: "Finding locations, reading place sheets, or updating place details.",
+    steps: [
+      { tool: "list_places", note: "Find place_id values." },
+      { tool: "get_place_sheet", note: "Read full place details." },
+      { tool: "create_place_sheet", note: "Create a new place. Requires exactly one of project_id or universe_id." },
+      { tool: "update_place_sheet", note: "Edit place metadata." },
+    ],
+  },
+  {
+    id: "review_bundle",
+    label: "Review bundle",
+    use_when: "Preparing a formatted bundle for human review (outline, editorial, or beta read profile).",
+    steps: [
+      { tool: "preview_review_bundle", note: "Check which scenes would be included and the estimated size." },
+      { tool: "create_review_bundle", note: "Generate the bundle." },
+    ],
+  },
+  {
+    id: "async_job_tracking",
+    label: "Async job tracking",
+    use_when: "A tool returned a job_id instead of an immediate result (e.g. import_scrivener_sync_async).",
+    steps: [
+      { tool: "get_async_job_status", note: "Poll with the job_id until status is 'completed' or 'failed'." },
+      { tool: "sync", note: "Call after a completed job that modified files on disk." },
+    ],
+  },
+];
+
 // ---------------------------------------------------------------------------
 // MCP server factory
 // ---------------------------------------------------------------------------
 function createMcpServer() {
   const s = new McpServer({ name: "mcp-writing", version: MCP_SERVER_VERSION });
+
+  // ---- describe_workflows --------------------------------------------------
+  s.tool(
+    "describe_workflows",
+    "Return a map of available task workflows and the current project context. Call this at the start of a session or whenever you are unsure what to do next. Never write scripts to invoke tools — call them directly.",
+    {},
+    async () => {
+      const projectRow = db.prepare(
+        `SELECT project_id FROM scenes GROUP BY project_id ORDER BY COUNT(*) DESC LIMIT 1`
+      ).get();
+      const project_id = projectRow?.project_id ?? null;
+
+      const sceneCountRow = db.prepare(`SELECT COUNT(*) as count FROM scenes`).get();
+      const scene_count = sceneCountRow?.count ?? 0;
+
+      const syncRootConfigPath = path.join(SYNC_DIR, STYLEGUIDE_CONFIG_BASENAME);
+      const projectRootConfigPath = project_id
+        ? path.join(resolveProjectRoot(project_id), STYLEGUIDE_CONFIG_BASENAME)
+        : null;
+
+      return jsonResponse({
+        ok: true,
+        context: {
+          project_id,
+          scene_count,
+          sync_dir: SYNC_DIR_ABS,
+          styleguide_exists: {
+            sync_root: fs.existsSync(syncRootConfigPath),
+            project_root: projectRootConfigPath !== null && fs.existsSync(projectRootConfigPath),
+          },
+          git_available: GIT_AVAILABLE,
+          pending_proposals: pendingProposals.size,
+        },
+        workflows: WORKFLOW_CATALOGUE,
+        notes: [
+          "Never write JavaScript or shell scripts to invoke tools. Call them directly.",
+          "If a tool returns a next_step field (in a success or error response), follow it before trying anything else.",
+          "Use find_scenes without filters to discover what project_ids are indexed.",
+          "When calling bootstrap_prose_styleguide_config or check_prose_styleguide_drift, set max_scenes to context.scene_count to avoid the default limit.",
+        ],
+      });
+    }
+  );
 
   // ---- sync ----------------------------------------------------------------
   s.tool("sync", "Re-scan the sync folder and update the scene/character/place index from disk. Call this after making edits in Scrivener or updating sidecar files outside the MCP.", {}, async () => {

--- a/index.js
+++ b/index.js
@@ -969,6 +969,10 @@ function createMcpServer() {
       const projectRootConfigPath = project_id
         ? path.join(resolveProjectRoot(project_id), STYLEGUIDE_CONFIG_BASENAME)
         : null;
+      const universeSegment = project_id?.includes("/") ? project_id.split("/")[0] : null;
+      const universeRootConfigPath = universeSegment
+        ? path.join(SYNC_DIR, "universes", universeSegment, STYLEGUIDE_CONFIG_BASENAME)
+        : null;
 
       return jsonResponse({
         ok: true,
@@ -978,6 +982,7 @@ function createMcpServer() {
           sync_dir: SYNC_DIR_ABS,
           styleguide_exists: {
             sync_root: fs.existsSync(syncRootConfigPath),
+            universe_root: universeRootConfigPath !== null && fs.existsSync(universeRootConfigPath),
             project_root: projectRootConfigPath !== null && fs.existsSync(projectRootConfigPath),
           },
           git_available: GIT_AVAILABLE,

--- a/test/integration.test.mjs
+++ b/test/integration.test.mjs
@@ -3246,7 +3246,8 @@ describe("describe_workflows tool", () => {
     const workflowText = await callWriteTool("describe_workflows");
     const parsed = JSON.parse(workflowText);
 
-    const scenesText = await callWriteTool("find_scenes");
+    // page_size forces total_count to always appear in the response regardless of result set size
+    const scenesText = await callWriteTool("find_scenes", { page_size: 1, page: 1 });
     const scenes = JSON.parse(scenesText);
 
     assert.equal(parsed.context.scene_count, scenes.total_count);

--- a/test/integration.test.mjs
+++ b/test/integration.test.mjs
@@ -3197,3 +3197,74 @@ describe("commit_edit preflight diagnostics", () => {
     }
   });
 });
+
+describe("describe_workflows tool", () => {
+  test("returns ok with context, workflows, and notes", async () => {
+    const text = await callWriteTool("describe_workflows");
+    const parsed = JSON.parse(text);
+
+    assert.equal(parsed.ok, true);
+    assert.ok(typeof parsed.context === "object");
+    assert.ok(typeof parsed.context.scene_count === "number");
+    assert.ok(typeof parsed.context.sync_dir === "string");
+    assert.ok(typeof parsed.context.git_available === "boolean");
+    assert.ok(typeof parsed.context.pending_proposals === "number");
+    assert.ok(typeof parsed.context.styleguide_exists === "object");
+    assert.ok(typeof parsed.context.styleguide_exists.sync_root === "boolean");
+    assert.ok(typeof parsed.context.styleguide_exists.project_root === "boolean");
+    assert.ok(Array.isArray(parsed.workflows));
+    assert.ok(parsed.workflows.length > 0);
+    assert.ok(Array.isArray(parsed.notes));
+    assert.ok(parsed.notes.length > 0);
+  });
+
+  test("includes all expected workflow ids", async () => {
+    const text = await callWriteTool("describe_workflows");
+    const parsed = JSON.parse(text);
+    const ids = parsed.workflows.map(w => w.id);
+
+    const expected = [
+      "first_time_setup",
+      "styleguide_setup_new",
+      "styleguide_drift_check",
+      "manuscript_exploration",
+      "prose_editing",
+      "character_management",
+      "place_management",
+      "review_bundle",
+      "async_job_tracking",
+    ];
+    for (const id of expected) {
+      assert.ok(ids.includes(id), `Missing workflow: ${id}`);
+    }
+  });
+
+  test("context.scene_count matches indexed scenes", async () => {
+    const syncText = await callWriteTool("sync");
+    assert.match(syncText, /scenes indexed/);
+
+    const workflowText = await callWriteTool("describe_workflows");
+    const parsed = JSON.parse(workflowText);
+
+    const scenesText = await callWriteTool("find_scenes");
+    const scenes = JSON.parse(scenesText);
+
+    assert.equal(parsed.context.scene_count, scenes.total_count);
+  });
+
+  test("each workflow has id, label, use_when, and non-empty steps", async () => {
+    const text = await callWriteTool("describe_workflows");
+    const parsed = JSON.parse(text);
+
+    for (const workflow of parsed.workflows) {
+      assert.ok(typeof workflow.id === "string" && workflow.id.length > 0, `workflow missing id`);
+      assert.ok(typeof workflow.label === "string" && workflow.label.length > 0, `${workflow.id} missing label`);
+      assert.ok(typeof workflow.use_when === "string" && workflow.use_when.length > 0, `${workflow.id} missing use_when`);
+      assert.ok(Array.isArray(workflow.steps) && workflow.steps.length > 0, `${workflow.id} missing steps`);
+      for (const step of workflow.steps) {
+        assert.ok(typeof step.tool === "string" && step.tool.length > 0, `${workflow.id} step missing tool`);
+        assert.ok(typeof step.note === "string" && step.note.length > 0, `${workflow.id} step missing note`);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a `describe_workflows` tool as the first registered tool in the server, giving an AI a map of all available task workflows and the current project context at the start of any session
- Adds a static `WORKFLOW_CATALOGUE` constant covering 9 task flows (first-time setup, styleguide setup, drift check, manuscript exploration, prose editing, character/place management, review bundles, async job tracking)
- Adds integration tests covering shape, workflow completeness, scene_count accuracy, and step structure

## Motivation

With 44 tools and no entry point, AIs entering a session cold have no map. In practice this caused AIs to guess tool sequences, get stuck on missing preconditions, and fall back to writing Node.js scripts to invoke tools indirectly — defeating the purpose of the MCP. See PRD: `docs/prd/todo/describe-workflows.md`.

## Implementation

**Context (computed at call time):**
- `project_id` — most frequent project_id in the scenes table, or null if empty
- `scene_count` — total indexed scenes; lets the AI set `max_scenes` correctly before calling `bootstrap_prose_styleguide_config` or `check_prose_styleguide_drift`
- `sync_dir` — resolved `WRITING_SYNC_DIR` path
- `styleguide_exists` — `fs.existsSync` checks at both sync_root and project_root scopes
- `git_available` — `GIT_AVAILABLE` runtime flag
- `pending_proposals` — count of uncommitted edit proposals

**Workflows (static catalogue):**
`first_time_setup`, `styleguide_setup_new`, `styleguide_drift_check`, `manuscript_exploration`, `prose_editing`, `character_management`, `place_management`, `review_bundle`, `async_job_tracking`

Each entry has `id`, `label`, `use_when`, and `steps` (ordered tool names with inline notes).

**Notes array:** Four machine-readable rules returned with every response, including "never write scripts" and "set max_scenes to context.scene_count."

**Registration order:** Tool is registered first in `createMcpServer` so it appears at the top of tool lists in clients that preserve insertion order.

## Testing

- `npm test` (integration): 136/136 pass
- 4 new integration tests: response shape, all 9 workflow ids present, `scene_count` matches `find_scenes` total, each workflow has valid `id`/`label`/`use_when`/`steps`

## Risks and tradeoffs

- `project_id` derivation is best-effort (most frequent in scenes table). Correct for single-project setups; informational for multi-project setups where the user should confirm.
- The workflow catalogue is static — it does not adapt to runtime state (e.g. it always shows `styleguide_setup_new` even if a config exists). The `context.styleguide_exists` fields let the AI skip irrelevant steps without the catalogue needing to change.

## Follow-up

- Update `docs/prd/todo/describe-workflows.md` status to done after merge
- Consider composite workflow tools as the next usability layer (see `docs/prd/inbox/ideas-and-questions.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)