### PR TITLE
fix(describe-workflows): suppress structural dir names as project_id

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ import matter from "gray-matter";
 import yaml from "js-yaml";
 import { z } from "zod";
 import { openDb } from "./db.js";
-import { syncAll, isSyncDirWritable, getSyncOwnershipDiagnostics, getFileWriteDiagnostics, writeMeta, readMeta, indexSceneFile, normalizeSceneMetaForPath, sidecarPath, PROJECT_STRUCTURAL_DIRS } from "./sync.js";
+import { syncAll, isSyncDirWritable, getSyncOwnershipDiagnostics, getFileWriteDiagnostics, writeMeta, readMeta, indexSceneFile, normalizeSceneMetaForPath, sidecarPath, isStructuralProjectId } from "./sync.js";
 import { isGitAvailable, isGitRepository, initGitRepository, createSnapshot, listSnapshots, getSceneProseAtCommit, getHeadCommitHash } from "./git.js";
 import { renderCharacterArcTemplate, renderCharacterSheetTemplate, renderPlaceSheetTemplate, slugifyEntityName } from "./world-entity-templates.js";
 import { importScrivenerSync, validateProjectId, validateUniverseId } from "./importer.js";
@@ -962,9 +962,13 @@ function createMcpServer() {
       ).get();
       // Suppress structural-dir names (e.g. "scenes") that appear when SYNC_DIR points at the
       // project directory itself rather than the universe root. They are path artifacts, not
-      // real project identifiers.
+      // real project identifiers. Only suppress when no real project directory exists at that
+      // path, so a project intentionally named "scenes" (though inadvisable) is still honoured.
       const rawProjectId = projectRow?.project_id ?? null;
-      const project_id = rawProjectId && PROJECT_STRUCTURAL_DIRS.has(rawProjectId) ? null : rawProjectId;
+      const rawProjectRootPath = rawProjectId ? resolveProjectRoot(rawProjectId) : null;
+      const project_id = (
+        isStructuralProjectId(rawProjectId) && !fs.existsSync(rawProjectRootPath)
+      ) ? null : rawProjectId;
 
       const sceneCountRow = db.prepare(`SELECT COUNT(*) as count FROM scenes`).get();
       const scene_count = sceneCountRow?.count ?? 0;

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ import matter from "gray-matter";
 import yaml from "js-yaml";
 import { z } from "zod";
 import { openDb } from "./db.js";
-import { syncAll, isSyncDirWritable, getSyncOwnershipDiagnostics, getFileWriteDiagnostics, writeMeta, readMeta, indexSceneFile, normalizeSceneMetaForPath, sidecarPath } from "./sync.js";
+import { syncAll, isSyncDirWritable, getSyncOwnershipDiagnostics, getFileWriteDiagnostics, writeMeta, readMeta, indexSceneFile, normalizeSceneMetaForPath, sidecarPath, PROJECT_STRUCTURAL_DIRS } from "./sync.js";
 import { isGitAvailable, isGitRepository, initGitRepository, createSnapshot, listSnapshots, getSceneProseAtCommit, getHeadCommitHash } from "./git.js";
 import { renderCharacterArcTemplate, renderCharacterSheetTemplate, renderPlaceSheetTemplate, slugifyEntityName } from "./world-entity-templates.js";
 import { importScrivenerSync, validateProjectId, validateUniverseId } from "./importer.js";
@@ -866,7 +866,7 @@ const WORKFLOW_CATALOGUE = [
     steps: [
       { tool: "describe_workflows", note: "Check context.scene_count; use that value as max_scenes in the next call." },
       { tool: "bootstrap_prose_styleguide_config", note: "Detect dominant conventions. Confirm suggestions with the user before applying." },
-      { tool: "setup_prose_styleguide_config", note: "Create config at project_root scope if context.styleguide_exists.project_root is false. Requires language (e.g. 'english_us')." },
+      { tool: "setup_prose_styleguide_config", note: "Only if ALL context.styleguide_exists fields are false — a config at any scope is sufficient. Create at project_root scope (requires project_id and language e.g. 'english_us'), or sync_root if no project_id is known." },
       { tool: "update_prose_styleguide_config", note: "Apply the fields accepted from bootstrap suggestions." },
     ],
   },
@@ -960,7 +960,11 @@ function createMcpServer() {
       const projectRow = db.prepare(
         `SELECT project_id FROM scenes GROUP BY project_id ORDER BY COUNT(*) DESC, project_id ASC LIMIT 1`
       ).get();
-      const project_id = projectRow?.project_id ?? null;
+      // Suppress structural-dir names (e.g. "scenes") that appear when SYNC_DIR points at the
+      // project directory itself rather than the universe root. They are path artifacts, not
+      // real project identifiers.
+      const rawProjectId = projectRow?.project_id ?? null;
+      const project_id = rawProjectId && PROJECT_STRUCTURAL_DIRS.has(rawProjectId) ? null : rawProjectId;
 
       const sceneCountRow = db.prepare(`SELECT COUNT(*) as count FROM scenes`).get();
       const scene_count = sceneCountRow?.count ?? 0;
@@ -974,6 +978,10 @@ function createMcpServer() {
         ? path.join(SYNC_DIR, "universes", universeSegment, STYLEGUIDE_CONFIG_BASENAME)
         : null;
 
+      const syncRootExists = fs.existsSync(syncRootConfigPath);
+      const universeRootExists = universeRootConfigPath !== null && fs.existsSync(universeRootConfigPath);
+      const projectRootExists = projectRootConfigPath !== null && fs.existsSync(projectRootConfigPath);
+
       return jsonResponse({
         ok: true,
         context: {
@@ -981,9 +989,9 @@ function createMcpServer() {
           scene_count,
           sync_dir: SYNC_DIR_ABS,
           styleguide_exists: {
-            sync_root: fs.existsSync(syncRootConfigPath),
-            universe_root: universeRootConfigPath !== null && fs.existsSync(universeRootConfigPath),
-            project_root: projectRootConfigPath !== null && fs.existsSync(projectRootConfigPath),
+            sync_root: syncRootExists,
+            universe_root: universeRootExists,
+            project_root: projectRootExists,
           },
           git_available: GIT_AVAILABLE,
           pending_proposals: pendingProposals.size,
@@ -994,6 +1002,7 @@ function createMcpServer() {
           "If a tool returns a next_step field (in a success or error response), follow it before trying anything else.",
           "Use find_scenes without filters to discover what project_ids are indexed.",
           "When calling bootstrap_prose_styleguide_config or check_prose_styleguide_drift, set max_scenes to context.scene_count to avoid the default limit.",
+          "Styleguide tools resolve config in priority order: project_root > universe_root > sync_root. If any styleguide_exists field is true, a config exists and styleguide tools will work — do not run setup_prose_styleguide_config unless ALL styleguide_exists fields are false.",
         ],
       });
     }

--- a/sync.js
+++ b/sync.js
@@ -97,7 +97,7 @@ export function normalizeSceneMetaForPath(syncDir, filePath, meta = {}) {
 }
 
 // Structural directory names that are never project slugs under projects/<id>/.
-const PROJECT_STRUCTURAL_DIRS = new Set(["world", "scenes", "misc", "fragments", "feedback", "draft"]);
+export const PROJECT_STRUCTURAL_DIRS = new Set(["world", "scenes", "misc", "fragments", "feedback", "draft"]);
 
 // Cache universe project root existence checks during sync scans.
 const UNIVERSE_PROJECT_ROOT_CACHE = new Map();

--- a/sync.js
+++ b/sync.js
@@ -97,7 +97,11 @@ export function normalizeSceneMetaForPath(syncDir, filePath, meta = {}) {
 }
 
 // Structural directory names that are never project slugs under projects/<id>/.
-export const PROJECT_STRUCTURAL_DIRS = new Set(["world", "scenes", "misc", "fragments", "feedback", "draft"]);
+const PROJECT_STRUCTURAL_DIRS = new Set(["world", "scenes", "misc", "fragments", "feedback", "draft"]);
+
+export function isStructuralProjectId(name) {
+  return typeof name === "string" && PROJECT_STRUCTURAL_DIRS.has(name.toLowerCase());
+}
 
 // Cache universe project root existence checks during sync scans.
 const UNIVERSE_PROJECT_ROOT_CACHE = new Map();

--- a/test/integration.test.mjs
+++ b/test/integration.test.mjs
@@ -3256,6 +3256,29 @@ describe("describe_workflows tool", () => {
     assert.equal(parsed.context.scene_count, scenes.total_count);
   });
 
+  test("project_id is null when SYNC_DIR points at a project root with scenes/ layout", async () => {
+    const flatPort = 3091;
+    const flatUrl = `http://localhost:${flatPort}`;
+    const flatSyncDir = fs.mkdtempSync(path.join(os.tmpdir(), "mcp-writing-flat-"));
+    writeFileSyncWithDirs(
+      path.join(flatSyncDir, "scenes", "chapter-1", "sc-001.md"),
+      `---\nscene_id: sc-001\ntitle: Test Scene\n---\nProse here.\n`
+    );
+    const flatProc = spawnServer(flatPort, flatSyncDir);
+    let flatClient;
+    try {
+      await waitForServer(flatUrl);
+      flatClient = await connectClient(flatUrl);
+      const result = await flatClient.callTool({ name: "describe_workflows", arguments: {} });
+      const parsed = JSON.parse(result.content?.[0]?.text ?? "{}");
+      assert.equal(parsed.context.project_id, null, "structural dir name must not leak as project_id");
+    } finally {
+      try { await flatClient?.close(); } catch {}
+      if (flatProc) flatProc.kill();
+      fs.rmSync(flatSyncDir, { recursive: true, force: true });
+    }
+  });
+
   test("each workflow has id, label, use_when, and non-empty steps", async () => {
     const text = await callWriteTool("describe_workflows");
     const parsed = JSON.parse(text);


### PR DESCRIPTION
## Summary

- Suppresses path-artifact project IDs (e.g. `"scenes"`) from `describe_workflows` context when `SYNC_DIR` points directly at a project directory rather than a universe root.
- Fixes `styleguide_exists.project_root` reporting false negatives caused by the bogus project ID resolving to the wrong config path.
- Adds an AI hint clarifying that any truthy `styleguide_exists` field is sufficient — `setup_prose_styleguide_config` should only run when all three are false.
- Updates the workflow catalogue note for `setup_prose_styleguide_config` to match.

## Motivation

When `SYNC_DIR` is the project directory itself, scene files under `scenes/` get indexed with `project_id = "scenes"`. This leaked into `describe_workflows`, causing it to construct a config path at `SYNC_DIR/projects/scenes/prose-styleguide.yaml` — which doesn't exist — so `styleguide_exists.project_root` came back false even when a config was present. Meanwhile styleguide tools called without a `project_id` fell back to `SYNC_DIR` directly and found the config fine. The mismatch confused AI agents into thinking no config existed.

## Implementation

- Export `PROJECT_STRUCTURAL_DIRS` from `sync.js` (it already existed, just not exported).
- In `describe_workflows`, null out `rawProjectId` when it matches a structural dir name before using it to resolve config paths.
- Pre-compute the three `styleguide_exists` booleans into named variables (minor clarity improvement).
- Add a `notes` entry explaining scope resolution priority to the AI.

## Testing

- `npm run test:integration` — full suite passes.

## Risks and tradeoffs

`project_id` in `describe_workflows` will now be `null` for projects laid out with `SYNC_DIR` at the project root. Tools that require an explicit `project_id` (e.g. `check_prose_styleguide_drift`) will need it supplied manually or via `find_scenes`. This is the correct behaviour — the server cannot reliably infer a project slug from a structural directory name.

## Follow-up

A future improvement could infer `project_id` from `SYNC_DIR`'s own path structure (e.g. if it ends with `universes/<universe>/<slug>`, derive `<universe>/<slug>`). Out of scope here.