### PR TITLE
fix(ci): update publish workflow to use npm test

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
         run: npm ci
 
       - name: Run tests
-        run: node --experimental-sqlite --test test/unit.test.mjs test/integration.test.mjs
+        run: npm test
 
       - name: Publish
         run: npm publish --provenance --access public

--- a/docs/prd/todo/refactoring.md
+++ b/docs/prd/todo/refactoring.md
@@ -1,6 +1,6 @@
 # Targets for refactoring
 
-**Status:** 🚧 In Progress — Phases A, B done; Phase C started (sync group extracted)
+**Status:** 🚧 In Progress — Phases A, B done; Phase C in progress (sync + search groups extracted)
 
 ---
 
@@ -29,7 +29,7 @@ Highest-risk work. One tool group per PR, full integration suite after each. Nev
 
 Extraction order (simplest first, highest-risk last):
 1. ✅ `registerSyncTools`
-2. `registerSearchTools` — read-only, no side effects
+2. ✅ `registerSearchTools` — read-only, no side effects
 3. `registerMetadataTools` — sidecar writes, low interaction surface
 4. `registerReviewBundleTools`
 5. `registerStyleguideTools`


### PR DESCRIPTION
## Summary

- Updates `publish.yml` to run `npm test` instead of the deleted monolithic test files
- Marks `registerSearchTools` as done in the Phase C extraction list and updates the status line

## Motivation

The Phase B test split (PR #94) removed `test/unit.test.mjs` and `test/integration.test.mjs` and updated `ci.yml` to use `npm test`, but `publish.yml` was missed. This caused the last two releases to fail at the publish step.

The docs update rode along because the PRD commit was on local main when the fix branch was cut — grouping it here rather than opening a third PR.

## Implementation

- `publish.yml`: replace the hardcoded `node --experimental-sqlite --test ...` call with `npm test`, matching `ci.yml`
- `docs/prd/todo/refactoring.md`: tick `registerSearchTools` in Phase C and update the status line

## Testing

- Not run: workflow and documentation changes only. `npm test` is already validated by `ci.yml` on every push and passes on Node 22.x and 24.x.

## Risks and tradeoffs

None for the workflow fix. The docs change is a status update with no functional impact.

## Follow-up

Re-tag the releases that failed to publish once this is merged.