### PR TITLE
refactor(tools): extract registerReviewBundleTools into tools/review-bundles.js

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -34,6 +34,8 @@
 - [`update_character_sheet`](#update_character_sheet)
 - [`update_place_sheet`](#update_place_sheet)
 - [`flag_scene`](#flag_scene)
+- [`preview_review_bundle`](#preview_review_bundle)
+- [`create_review_bundle`](#create_review_bundle)
 - [`get_runtime_config`](#get_runtime_config)
 - [`setup_prose_styleguide_config`](#setup_prose_styleguide_config)
 - [`get_prose_styleguide_config`](#get_prose_styleguide_config)
@@ -43,8 +45,6 @@
 - [`preview_prose_styleguide_config_update`](#preview_prose_styleguide_config_update)
 - [`check_prose_styleguide_drift`](#check_prose_styleguide_drift)
 - [`setup_prose_styleguide_skill`](#setup_prose_styleguide_skill)
-- [`preview_review_bundle`](#preview_review_bundle)
-- [`create_review_bundle`](#create_review_bundle)
 - [`propose_edit`](#propose_edit)
 - [`commit_edit`](#commit_edit)
 - [`discard_edit`](#discard_edit)
@@ -408,6 +408,52 @@ Attach a continuity or review note to a scene. Flags are appended to the sidecar
 
 ---
 
+## preview_review_bundle
+
+Dry-run planning tool for review bundles. Resolves scene scope, deterministic ordering, warnings, and planned output filenames without writing files. Rendering options are accepted for API consistency and reflected in resolved_scope.options, but do not change planning output.
+
+| Parameter | Type | Required | Description |
+| --- | --- | :---: | --- |
+| `project_id` | `string` | Yes | Project ID to scope the review bundle (e.g. 'test-novel'). |
+| `profile` | `enum` | Yes | Bundle profile: outline_discussion, editor_detailed, or beta_reader_personalized. |
+| `part` | `integer` | No | Optional part filter. |
+| `chapter` | `integer` | No | Optional chapter filter. |
+| `tag` | `string` | No | Optional tag filter (exact match). |
+| `scene_ids` | `string[]` | No | Optional explicit scene_id allowlist. Intersects with other filters. |
+| `strictness` | `enum` | No | Strictness mode: warn (default) or fail. |
+| `include_scene_ids` | `boolean` | No | Rendering option (default true). Echoed in resolved_scope.options for downstream rendering; does not change planning results. |
+| `include_metadata_sidebar` | `boolean` | No | Rendering option (default false). Echoed in resolved_scope.options for downstream rendering; does not change planning results. |
+| `include_paragraph_anchors` | `boolean` | No | Rendering option (default false). Echoed in resolved_scope.options for downstream rendering; does not change planning results. |
+| `recipient_name` | `string` | No | Optional recipient display name for beta_reader_personalized profile. |
+| `bundle_name` | `string` | No | Optional output bundle base name override (slugified in planned outputs). |
+| `format` | `enum("pdf","markdown","both")` | No | Planned output format: pdf (default), markdown, or both. Affects planned_outputs filenames only; preview_review_bundle does not render artifacts. |
+
+---
+
+## create_review_bundle
+
+Generate review bundle artifacts (PDF/markdown) from planned scene scope. Writes files only under output_dir and returns manifest/provenance details.
+
+| Parameter | Type | Required | Description |
+| --- | --- | :---: | --- |
+| `project_id` | `string` | Yes | Project ID to scope the review bundle (e.g. 'test-novel'). |
+| `profile` | `enum` | Yes | Bundle profile: outline_discussion, editor_detailed, or beta_reader_personalized. |
+| `output_dir` | `string` | Yes | Directory path to write bundle artifacts into. |
+| `part` | `integer` | No | Optional part filter. |
+| `chapter` | `integer` | No | Optional chapter filter. |
+| `tag` | `string` | No | Optional tag filter (exact match). |
+| `scene_ids` | `string[]` | No | Optional explicit scene_id allowlist. Intersects with other filters. |
+| `strictness` | `enum` | No | Strictness mode: warn (default) or fail. |
+| `include_scene_ids` | `boolean` | No | Include scene IDs in headings (default true). Applies to both PDF and markdown. |
+| `include_metadata_sidebar` | `boolean` | No | Include metadata sidebar in markdown output (default false). Markdown only — no effect on PDF. |
+| `include_paragraph_anchors` | `boolean` | No | Include paragraph anchors in markdown output (default false). Markdown only — no effect on PDF. |
+| `recipient_name` | `string` | No | Optional recipient display name for beta_reader_personalized profile. |
+| `bundle_name` | `string` | No | Optional output bundle base name override (slugified in filenames). |
+| `source_commit` | `string` | No | Optional explicit source commit for provenance. Defaults to current HEAD when available. |
+| `format` | `enum("pdf","markdown","both")` | No | Output format: pdf (default), markdown, or both. |
+
+---
+
 ## get_runtime_config
 
 Show the active runtime paths and capabilities for this server instance (server version, sync dir, database path, writability, permission diagnostics, and git availability). Use this to verify which manuscript location is currently connected.
@@ -516,52 +562,6 @@ Generate skills/prose-styleguide.md from the resolved prose styleguide config an
 | --- | --- | :---: | --- |
 | `project_id` | `string` | No | Optional project ID for scoped config resolution (e.g. 'the-lamb' or 'universe-1/book-1'). |
 | `overwrite` | `boolean` | No | If true, replaces an existing skills/prose-styleguide.md file. |
-
----
-
-## preview_review_bundle
-
-Dry-run planning tool for review bundles. Resolves scene scope, deterministic ordering, warnings, and planned output filenames without writing files. Rendering options are accepted for API consistency and reflected in resolved_scope.options, but do not change planning output.
-
-| Parameter | Type | Required | Description |
-| --- | --- | :---: | --- |
-| `project_id` | `string` | Yes | Project ID to scope the review bundle (e.g. 'test-novel'). |
-| `profile` | `enum` | Yes | Bundle profile: outline_discussion, editor_detailed, or beta_reader_personalized. |
-| `part` | `integer` | No | Optional part filter. |
-| `chapter` | `integer` | No | Optional chapter filter. |
-| `tag` | `string` | No | Optional tag filter (exact match). |
-| `scene_ids` | `string[]` | No | Optional explicit scene_id allowlist. Intersects with other filters. |
-| `strictness` | `enum` | No | Strictness mode: warn (default) or fail. |
-| `include_scene_ids` | `boolean` | No | Rendering option (default true). Echoed in resolved_scope.options for downstream rendering; does not change planning results. |
-| `include_metadata_sidebar` | `boolean` | No | Rendering option (default false). Echoed in resolved_scope.options for downstream rendering; does not change planning results. |
-| `include_paragraph_anchors` | `boolean` | No | Rendering option (default false). Echoed in resolved_scope.options for downstream rendering; does not change planning results. |
-| `recipient_name` | `string` | No | Optional recipient display name for beta_reader_personalized profile. |
-| `bundle_name` | `string` | No | Optional output bundle base name override (slugified in planned outputs). |
-| `format` | `enum("pdf","markdown","both")` | No | Planned output format: pdf (default), markdown, or both. Affects planned_outputs filenames only; preview_review_bundle does not render artifacts. |
-
----
-
-## create_review_bundle
-
-Generate review bundle artifacts (PDF/markdown) from planned scene scope. Writes files only under output_dir and returns manifest/provenance details.
-
-| Parameter | Type | Required | Description |
-| --- | --- | :---: | --- |
-| `project_id` | `string` | Yes | Project ID to scope the review bundle (e.g. 'test-novel'). |
-| `profile` | `enum` | Yes | Bundle profile: outline_discussion, editor_detailed, or beta_reader_personalized. |
-| `output_dir` | `string` | Yes | Directory path to write bundle artifacts into. |
-| `part` | `integer` | No | Optional part filter. |
-| `chapter` | `integer` | No | Optional chapter filter. |
-| `tag` | `string` | No | Optional tag filter (exact match). |
-| `scene_ids` | `string[]` | No | Optional explicit scene_id allowlist. Intersects with other filters. |
-| `strictness` | `enum` | No | Strictness mode: warn (default) or fail. |
-| `include_scene_ids` | `boolean` | No | Include scene IDs in headings (default true). Applies to both PDF and markdown. |
-| `include_metadata_sidebar` | `boolean` | No | Include metadata sidebar in markdown output (default false). Markdown only — no effect on PDF. |
-| `include_paragraph_anchors` | `boolean` | No | Include paragraph anchors in markdown output (default false). Markdown only — no effect on PDF. |
-| `recipient_name` | `string` | No | Optional recipient display name for beta_reader_personalized profile. |
-| `bundle_name` | `string` | No | Optional output bundle base name override (slugified in filenames). |
-| `source_commit` | `string` | No | Optional explicit source commit for provenance. Defaults to current HEAD when available. |
-| `format` | `enum("pdf","markdown","both")` | No | Output format: pdf (default), markdown, or both. |
 
 ---
 

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ import yaml from "js-yaml";
 import { z } from "zod";
 import { openDb } from "./db.js";
 import { syncAll, isSyncDirWritable, getSyncOwnershipDiagnostics, getFileWriteDiagnostics, readMeta, indexSceneFile, sidecarPath, isStructuralProjectId } from "./sync.js";
-import { isGitAvailable, isGitRepository, initGitRepository, createSnapshot, listSnapshots, getSceneProseAtCommit, getHeadCommitHash } from "./git.js";
+import { isGitAvailable, isGitRepository, initGitRepository, createSnapshot, listSnapshots, getSceneProseAtCommit } from "./git.js";
 import { renderCharacterArcTemplate, renderCharacterSheetTemplate, renderPlaceSheetTemplate, slugifyEntityName } from "./world-entity-templates.js";
 import { validateProjectId } from "./importer.js";
 import { ASYNC_PROGRESS_PREFIX } from "./async-progress.js";
@@ -36,16 +36,11 @@ import {
   PROSE_STYLEGUIDE_SKILL_DIRNAME,
   buildProseStyleguideSkill,
 } from "./prose-styleguide-skill.js";
-import {
-  REVIEW_BUNDLE_PROFILES,
-  REVIEW_BUNDLE_STRICTNESS,
-  ReviewBundlePlanError,
-  buildReviewBundlePlan,
-  createReviewBundleArtifacts,
-} from "./review-bundles.js";
+import { ReviewBundlePlanError } from "./review-bundles.js";
 import { registerSyncTools } from "./tools/sync.js";
 import { registerSearchTools } from "./tools/search.js";
 import { registerMetadataTools } from "./tools/metadata.js";
+import { registerReviewBundleTools } from "./tools/review-bundles.js";
 
 const SYNC_DIR = process.env.WRITING_SYNC_DIR ?? "./sync";
 const DB_PATH = process.env.DB_PATH ?? "./writing.db";
@@ -1043,10 +1038,12 @@ function createMcpServer() {
     readSupportingNotesForEntity,
     readEntityMetadata,
     createCanonicalWorldEntity,
+    resolveOutputDirWithinSync,
   };
   registerSyncTools(s, toolContext);
   registerSearchTools(s, toolContext);
   registerMetadataTools(s, toolContext);
+  registerReviewBundleTools(s, toolContext);
 
   // ---- get_runtime_config --------------------------------------------------
   s.tool(
@@ -1717,192 +1714,6 @@ function createMcpServer() {
         injected_rules: generated.injected_rules,
         source_count: resolved.sources.length,
       });
-    }
-  );
-
-  // ---- preview_review_bundle ----------------------------------------------
-  s.tool(
-    "preview_review_bundle",
-    "Dry-run planning tool for review bundles. Resolves scene scope, deterministic ordering, warnings, and planned output filenames without writing files. Rendering options are accepted for API consistency and reflected in resolved_scope.options, but do not change planning output.",
-    {
-      project_id: z.string().describe("Project ID to scope the review bundle (e.g. 'test-novel')."),
-      profile: z.enum(REVIEW_BUNDLE_PROFILES).describe("Bundle profile: outline_discussion, editor_detailed, or beta_reader_personalized."),
-      part: z.number().int().optional().describe("Optional part filter."),
-      chapter: z.number().int().optional().describe("Optional chapter filter."),
-      tag: z.string().optional().describe("Optional tag filter (exact match)."),
-      scene_ids: z.array(z.string()).optional().describe("Optional explicit scene_id allowlist. Intersects with other filters."),
-      strictness: z.enum(REVIEW_BUNDLE_STRICTNESS).optional().describe("Strictness mode: warn (default) or fail."),
-      include_scene_ids: z.boolean().optional().describe("Rendering option (default true). Echoed in resolved_scope.options for downstream rendering; does not change planning results."),
-      include_metadata_sidebar: z.boolean().optional().describe("Rendering option (default false). Echoed in resolved_scope.options for downstream rendering; does not change planning results."),
-      include_paragraph_anchors: z.boolean().optional().describe("Rendering option (default false). Echoed in resolved_scope.options for downstream rendering; does not change planning results."),
-      recipient_name: z.string().optional().describe("Optional recipient display name for beta_reader_personalized profile."),
-      bundle_name: z.string().optional().describe("Optional output bundle base name override (slugified in planned outputs)."),
-      format: z.enum(["pdf", "markdown", "both"]).optional().describe("Planned output format: pdf (default), markdown, or both. Affects planned_outputs filenames only; preview_review_bundle does not render artifacts."),
-    },
-    async ({
-      project_id,
-      profile,
-      part,
-      chapter,
-      tag,
-      scene_ids,
-      strictness = "warn",
-      include_scene_ids = true,
-      include_metadata_sidebar = false,
-      include_paragraph_anchors = false,
-      recipient_name,
-      bundle_name,
-      format = "pdf",
-    }) => {
-      const projectIdCheck = validateProjectId(project_id);
-      if (!projectIdCheck.ok) {
-        return errorResponse("INVALID_PROJECT_ID", projectIdCheck.reason, { project_id });
-      }
-
-      try {
-        const plan = buildReviewBundlePlan(db, {
-          project_id,
-          profile,
-          part,
-          chapter,
-          tag,
-          scene_ids,
-          strictness,
-          include_scene_ids,
-          include_metadata_sidebar,
-          include_paragraph_anchors,
-          recipient_name,
-          bundle_name,
-          format,
-        });
-        return jsonResponse(plan);
-      } catch (error) {
-        if (error instanceof ReviewBundlePlanError) {
-          return errorResponse(error.code, error.message, error.details);
-        }
-        return errorResponse(
-          "PREVIEW_FAILED",
-          error instanceof Error ? error.message : "Failed to generate review bundle preview."
-        );
-      }
-    }
-  );
-
-  // ---- create_review_bundle -----------------------------------------------
-  s.tool(
-    "create_review_bundle",
-    "Generate review bundle artifacts (PDF/markdown) from planned scene scope. Writes files only under output_dir and returns manifest/provenance details.",
-    {
-      project_id: z.string().describe("Project ID to scope the review bundle (e.g. 'test-novel')."),
-      profile: z.enum(REVIEW_BUNDLE_PROFILES).describe("Bundle profile: outline_discussion, editor_detailed, or beta_reader_personalized."),
-      output_dir: z.string().describe("Directory path to write bundle artifacts into."),
-      part: z.number().int().optional().describe("Optional part filter."),
-      chapter: z.number().int().optional().describe("Optional chapter filter."),
-      tag: z.string().optional().describe("Optional tag filter (exact match)."),
-      scene_ids: z.array(z.string()).optional().describe("Optional explicit scene_id allowlist. Intersects with other filters."),
-      strictness: z.enum(REVIEW_BUNDLE_STRICTNESS).optional().describe("Strictness mode: warn (default) or fail."),
-      include_scene_ids: z.boolean().optional().describe("Include scene IDs in headings (default true). Applies to both PDF and markdown."),
-      include_metadata_sidebar: z.boolean().optional().describe("Include metadata sidebar in markdown output (default false). Markdown only — no effect on PDF."),
-      include_paragraph_anchors: z.boolean().optional().describe("Include paragraph anchors in markdown output (default false). Markdown only — no effect on PDF."),
-      recipient_name: z.string().optional().describe("Optional recipient display name for beta_reader_personalized profile."),
-      bundle_name: z.string().optional().describe("Optional output bundle base name override (slugified in filenames)."),
-      source_commit: z.string().optional().describe("Optional explicit source commit for provenance. Defaults to current HEAD when available."),
-      format: z.enum(["pdf", "markdown", "both"]).optional().describe("Output format: pdf (default), markdown, or both."),
-    },
-    async ({
-      project_id,
-      profile,
-      output_dir,
-      part,
-      chapter,
-      tag,
-      scene_ids,
-      strictness = "warn",
-      include_scene_ids = true,
-      include_metadata_sidebar = false,
-      include_paragraph_anchors = false,
-      recipient_name,
-      bundle_name,
-      source_commit,
-      format = "pdf",
-    }) => {
-      const projectIdCheck = validateProjectId(project_id);
-      if (!projectIdCheck.ok) {
-        return errorResponse("INVALID_PROJECT_ID", projectIdCheck.reason, { project_id });
-      }
-
-      try {
-        const { resolvedOutputDir, relativeToSyncDir } = resolveOutputDirWithinSync(output_dir);
-        const outputDirSegments = relativeToSyncDir
-          .split(path.sep)
-          .filter(Boolean)
-          .map(segment => segment.toLowerCase());
-        if (outputDirSegments.includes("scenes")) {
-          return errorResponse(
-            "INVALID_OUTPUT_DIR",
-            "output_dir cannot be inside a scenes directory. Choose a dedicated export folder under WRITING_SYNC_DIR.",
-            { output_dir: resolvedOutputDir }
-          );
-        }
-
-        const plan = buildReviewBundlePlan(db, {
-          project_id,
-          profile,
-          part,
-          chapter,
-          tag,
-          scene_ids,
-          strictness,
-          include_scene_ids,
-          include_metadata_sidebar,
-          include_paragraph_anchors,
-          recipient_name,
-          bundle_name,
-          format,
-        });
-
-        if (!plan.strictness_result.can_proceed) {
-          return errorResponse(
-            "STRICTNESS_BLOCKED",
-            "Bundle generation blocked by strictness policy.",
-            { strictness_result: plan.strictness_result, warning_summary: plan.warning_summary }
-          );
-        }
-
-        const provenanceCommit = source_commit ?? (GIT_ENABLED ? getHeadCommitHash(SYNC_DIR) : null);
-        const artifacts = await createReviewBundleArtifacts(db, {
-          plan,
-          output_dir: resolvedOutputDir,
-          source_commit: provenanceCommit,
-          syncDir: SYNC_DIR_ABS,
-        });
-
-        return jsonResponse({
-          ok: true,
-          bundle_id: artifacts.bundle_id,
-          output_paths: artifacts.output_paths,
-          summary: {
-            scene_count: plan.summary.scene_count,
-            profile: plan.profile,
-            applied_filters: plan.resolved_scope.filters,
-          },
-          warnings: plan.warnings,
-          warning_summary: plan.warning_summary,
-          provenance: {
-            source_commit: provenanceCommit,
-            generated_at: artifacts.generated_at,
-            project_id: plan.resolved_scope.project_id,
-          },
-        });
-      } catch (error) {
-        if (error instanceof ReviewBundlePlanError) {
-          return errorResponse(error.code, error.message, error.details);
-        }
-        return errorResponse(
-          "CREATE_BUNDLE_FAILED",
-          error instanceof Error ? error.message : "Failed to create review bundle artifacts."
-        );
-      }
     }
   );
 

--- a/tools/review-bundles.js
+++ b/tools/review-bundles.js
@@ -1,0 +1,207 @@
+import { z } from "zod";
+import path from "node:path";
+import {
+  REVIEW_BUNDLE_PROFILES,
+  REVIEW_BUNDLE_STRICTNESS,
+  ReviewBundlePlanError,
+  buildReviewBundlePlan,
+  createReviewBundleArtifacts,
+} from "../review-bundles.js";
+import { validateProjectId } from "../importer.js";
+import { getHeadCommitHash } from "../git.js";
+
+export function registerReviewBundleTools(s, {
+  db,
+  SYNC_DIR,
+  SYNC_DIR_ABS,
+  GIT_ENABLED,
+  errorResponse,
+  jsonResponse,
+  resolveOutputDirWithinSync,
+}) {
+  // ---- preview_review_bundle ----------------------------------------------
+  s.tool(
+    "preview_review_bundle",
+    "Dry-run planning tool for review bundles. Resolves scene scope, deterministic ordering, warnings, and planned output filenames without writing files. Rendering options are accepted for API consistency and reflected in resolved_scope.options, but do not change planning output.",
+    {
+      project_id: z.string().describe("Project ID to scope the review bundle (e.g. 'test-novel')."),
+      profile: z.enum(REVIEW_BUNDLE_PROFILES).describe("Bundle profile: outline_discussion, editor_detailed, or beta_reader_personalized."),
+      part: z.number().int().optional().describe("Optional part filter."),
+      chapter: z.number().int().optional().describe("Optional chapter filter."),
+      tag: z.string().optional().describe("Optional tag filter (exact match)."),
+      scene_ids: z.array(z.string()).optional().describe("Optional explicit scene_id allowlist. Intersects with other filters."),
+      strictness: z.enum(REVIEW_BUNDLE_STRICTNESS).optional().describe("Strictness mode: warn (default) or fail."),
+      include_scene_ids: z.boolean().optional().describe("Rendering option (default true). Echoed in resolved_scope.options for downstream rendering; does not change planning results."),
+      include_metadata_sidebar: z.boolean().optional().describe("Rendering option (default false). Echoed in resolved_scope.options for downstream rendering; does not change planning results."),
+      include_paragraph_anchors: z.boolean().optional().describe("Rendering option (default false). Echoed in resolved_scope.options for downstream rendering; does not change planning results."),
+      recipient_name: z.string().optional().describe("Optional recipient display name for beta_reader_personalized profile."),
+      bundle_name: z.string().optional().describe("Optional output bundle base name override (slugified in planned outputs)."),
+      format: z.enum(["pdf", "markdown", "both"]).optional().describe("Planned output format: pdf (default), markdown, or both. Affects planned_outputs filenames only; preview_review_bundle does not render artifacts."),
+    },
+    async ({
+      project_id,
+      profile,
+      part,
+      chapter,
+      tag,
+      scene_ids,
+      strictness = "warn",
+      include_scene_ids = true,
+      include_metadata_sidebar = false,
+      include_paragraph_anchors = false,
+      recipient_name,
+      bundle_name,
+      format = "pdf",
+    }) => {
+      const projectIdCheck = validateProjectId(project_id);
+      if (!projectIdCheck.ok) {
+        return errorResponse("INVALID_PROJECT_ID", projectIdCheck.reason, { project_id });
+      }
+
+      try {
+        const plan = buildReviewBundlePlan(db, {
+          project_id,
+          profile,
+          part,
+          chapter,
+          tag,
+          scene_ids,
+          strictness,
+          include_scene_ids,
+          include_metadata_sidebar,
+          include_paragraph_anchors,
+          recipient_name,
+          bundle_name,
+          format,
+        });
+        return jsonResponse(plan);
+      } catch (error) {
+        if (error instanceof ReviewBundlePlanError) {
+          return errorResponse(error.code, error.message, error.details);
+        }
+        return errorResponse(
+          "PREVIEW_FAILED",
+          error instanceof Error ? error.message : "Failed to generate review bundle preview."
+        );
+      }
+    }
+  );
+
+  // ---- create_review_bundle -----------------------------------------------
+  s.tool(
+    "create_review_bundle",
+    "Generate review bundle artifacts (PDF/markdown) from planned scene scope. Writes files only under output_dir and returns manifest/provenance details.",
+    {
+      project_id: z.string().describe("Project ID to scope the review bundle (e.g. 'test-novel')."),
+      profile: z.enum(REVIEW_BUNDLE_PROFILES).describe("Bundle profile: outline_discussion, editor_detailed, or beta_reader_personalized."),
+      output_dir: z.string().describe("Directory path to write bundle artifacts into."),
+      part: z.number().int().optional().describe("Optional part filter."),
+      chapter: z.number().int().optional().describe("Optional chapter filter."),
+      tag: z.string().optional().describe("Optional tag filter (exact match)."),
+      scene_ids: z.array(z.string()).optional().describe("Optional explicit scene_id allowlist. Intersects with other filters."),
+      strictness: z.enum(REVIEW_BUNDLE_STRICTNESS).optional().describe("Strictness mode: warn (default) or fail."),
+      include_scene_ids: z.boolean().optional().describe("Include scene IDs in headings (default true). Applies to both PDF and markdown."),
+      include_metadata_sidebar: z.boolean().optional().describe("Include metadata sidebar in markdown output (default false). Markdown only — no effect on PDF."),
+      include_paragraph_anchors: z.boolean().optional().describe("Include paragraph anchors in markdown output (default false). Markdown only — no effect on PDF."),
+      recipient_name: z.string().optional().describe("Optional recipient display name for beta_reader_personalized profile."),
+      bundle_name: z.string().optional().describe("Optional output bundle base name override (slugified in filenames)."),
+      source_commit: z.string().optional().describe("Optional explicit source commit for provenance. Defaults to current HEAD when available."),
+      format: z.enum(["pdf", "markdown", "both"]).optional().describe("Output format: pdf (default), markdown, or both."),
+    },
+    async ({
+      project_id,
+      profile,
+      output_dir,
+      part,
+      chapter,
+      tag,
+      scene_ids,
+      strictness = "warn",
+      include_scene_ids = true,
+      include_metadata_sidebar = false,
+      include_paragraph_anchors = false,
+      recipient_name,
+      bundle_name,
+      source_commit,
+      format = "pdf",
+    }) => {
+      const projectIdCheck = validateProjectId(project_id);
+      if (!projectIdCheck.ok) {
+        return errorResponse("INVALID_PROJECT_ID", projectIdCheck.reason, { project_id });
+      }
+
+      try {
+        const { resolvedOutputDir, relativeToSyncDir } = resolveOutputDirWithinSync(output_dir);
+        const outputDirSegments = relativeToSyncDir
+          .split(path.sep)
+          .filter(Boolean)
+          .map(segment => segment.toLowerCase());
+        if (outputDirSegments.includes("scenes")) {
+          return errorResponse(
+            "INVALID_OUTPUT_DIR",
+            "output_dir cannot be inside a scenes directory. Choose a dedicated export folder under WRITING_SYNC_DIR.",
+            { output_dir: resolvedOutputDir }
+          );
+        }
+
+        const plan = buildReviewBundlePlan(db, {
+          project_id,
+          profile,
+          part,
+          chapter,
+          tag,
+          scene_ids,
+          strictness,
+          include_scene_ids,
+          include_metadata_sidebar,
+          include_paragraph_anchors,
+          recipient_name,
+          bundle_name,
+          format,
+        });
+
+        if (!plan.strictness_result.can_proceed) {
+          return errorResponse(
+            "STRICTNESS_BLOCKED",
+            "Bundle generation blocked by strictness policy.",
+            { strictness_result: plan.strictness_result, warning_summary: plan.warning_summary }
+          );
+        }
+
+        const provenanceCommit = source_commit ?? (GIT_ENABLED ? getHeadCommitHash(SYNC_DIR) : null);
+        const artifacts = await createReviewBundleArtifacts(db, {
+          plan,
+          output_dir: resolvedOutputDir,
+          source_commit: provenanceCommit,
+          syncDir: SYNC_DIR_ABS,
+        });
+
+        return jsonResponse({
+          ok: true,
+          bundle_id: artifacts.bundle_id,
+          output_paths: artifacts.output_paths,
+          summary: {
+            scene_count: plan.summary.scene_count,
+            profile: plan.profile,
+            applied_filters: plan.resolved_scope.filters,
+          },
+          warnings: plan.warnings,
+          warning_summary: plan.warning_summary,
+          provenance: {
+            source_commit: provenanceCommit,
+            generated_at: artifacts.generated_at,
+            project_id: plan.resolved_scope.project_id,
+          },
+        });
+      } catch (error) {
+        if (error instanceof ReviewBundlePlanError) {
+          return errorResponse(error.code, error.message, error.details);
+        }
+        return errorResponse(
+          "CREATE_BUNDLE_FAILED",
+          error instanceof Error ? error.message : "Failed to create review bundle artifacts."
+        );
+      }
+    }
+  );
+}


### PR DESCRIPTION
## Summary

- Extracts `preview_review_bundle` and `create_review_bundle` from `index.js` into `tools/review-bundles.js` as `registerReviewBundleTools(s, ctx)`.
- `resolveOutputDirWithinSync` (a private `index.js` function closing over `SYNC_DIR_REAL` and `SYNC_DIR_ABS`) is passed through `toolContext`, same pattern used for `createCanonicalWorldEntity` in the previous PR.
- Removes `REVIEW_BUNDLE_PROFILES`, `REVIEW_BUNDLE_STRICTNESS`, `buildReviewBundlePlan`, `createReviewBundleArtifacts`, and `getHeadCommitHash` from `index.js` imports. `ReviewBundlePlanError` is retained — `resolveOutputDirWithinSync` still uses it directly in `index.js`.

## Motivation

Phase C item 4 of the `index.js` refactoring plan. Follows `registerMetadataTools` (#98).

## Implementation

- `tools/review-bundles.js` imports `REVIEW_BUNDLE_PROFILES`, `REVIEW_BUNDLE_STRICTNESS`, `ReviewBundlePlanError`, `buildReviewBundlePlan`, `createReviewBundleArtifacts` from `../review-bundles.js`; `validateProjectId` from `../importer.js`; `getHeadCommitHash` from `../git.js`.
- `getHeadCommitHash` receives `SYNC_DIR` (not `SYNC_DIR_ABS`) to match the original call site exactly.
- `createReviewBundleArtifacts` receives `syncDir: SYNC_DIR_ABS`, also matching the original.

## Testing

- `npm run lint` — clean
- `npm test` — 178 unit + 137 integration, all pass

## Risks and tradeoffs

No behavior changes. `resolveOutputDirWithinSync` remains in `index.js` for now — it could eventually move to `review-bundles.js` as a named export, but that's a separate concern and would mix behavioral refactor with structural move.

## Follow-up

Next: Phase C item 5 — `registerStyleguideTools` (8 tools).