### PR TITLE
feat(db): persist async job state to SQLite for restart recovery

### DIFF
--- a/db.js
+++ b/db.js
@@ -124,6 +124,17 @@ export const SCHEMA = `
     id      INTEGER PRIMARY KEY CHECK (id = 1),
     version INTEGER NOT NULL
   );
+
+  CREATE TABLE IF NOT EXISTS async_jobs (
+    job_id      TEXT NOT NULL PRIMARY KEY,
+    kind        TEXT NOT NULL,
+    status      TEXT NOT NULL,
+    created_at  TEXT NOT NULL,
+    started_at  TEXT,
+    finished_at TEXT,
+    error       TEXT,
+    result_json TEXT
+  );
 `;
 
 // Each function is applied exactly once, in order, when version < its index+1.
@@ -192,4 +203,49 @@ export function openDb(dbPath) {
   db.exec(SCHEMA);
   applyMigrations(db);
   return db;
+}
+
+export function checkpointJobCreate(db, job) {
+  db.prepare(`
+    INSERT OR REPLACE INTO async_jobs (job_id, kind, status, created_at, started_at)
+    VALUES (?, ?, ?, ?, ?)
+  `).run(job.id, job.kind, job.status, job.createdAt, job.startedAt ?? null);
+}
+
+export function checkpointJobFinish(db, job) {
+  db.prepare(`
+    UPDATE async_jobs
+    SET status = ?, finished_at = ?, error = ?, result_json = ?
+    WHERE job_id = ?
+  `).run(
+    job.status,
+    job.finishedAt ?? null,
+    job.error ?? null,
+    job.result != null ? JSON.stringify(job.result) : null,
+    job.id
+  );
+}
+
+export function loadStalledJobs(db) {
+  // 'cancelling' included defensively; in practice only 'running' rows exist
+  // since we never write a 'cancelling' checkpoint between create and finish.
+  return db.prepare(`
+    SELECT job_id, kind, status, created_at, started_at
+    FROM async_jobs WHERE status IN ('running', 'cancelling')
+  `).all().map(row => ({
+    id: row.job_id,
+    kind: row.kind,
+    status: row.status,
+    createdAt: row.created_at,
+    startedAt: row.started_at ?? null,
+    finishedAt: null,
+    error: null,
+    result: null,
+    progress: null,
+    child: null,
+    onComplete: null,
+    tmpDir: null,
+    requestPath: null,
+    resultPath: null,
+  }));
 }

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import matter from "gray-matter";
 import yaml from "js-yaml";
-import { openDb } from "./db.js";
+import { openDb, checkpointJobCreate, checkpointJobFinish, loadStalledJobs } from "./db.js";
 import { syncAll, isSyncDirWritable, getSyncOwnershipDiagnostics, sidecarPath, isStructuralProjectId } from "./sync.js";
 import { isGitAvailable, isGitRepository, initGitRepository, getSceneProseAtCommit } from "./git.js";
 import { renderCharacterArcTemplate, renderCharacterSheetTemplate, renderPlaceSheetTemplate, slugifyEntityName } from "./world-entity-templates.js";
@@ -240,6 +240,11 @@ function startAsyncJob({ kind, requestPayload, onComplete }) {
     child,
   };
   asyncJobs.set(id, job);
+  try {
+    checkpointJobCreate(db, job);
+  } catch (err) {
+    process.stderr.write(`[mcp-writing] WARNING: failed to checkpoint job ${id}: ${err.message}\n`);
+  }
 
   let stdoutBuffer = "";
   child.stdout.on("data", (chunk) => {
@@ -276,12 +281,14 @@ function startAsyncJob({ kind, requestPayload, onComplete }) {
       job.status = "cancelled";
       job.error = error.message;
       job.finishedAt = new Date().toISOString();
+      try { checkpointJobFinish(db, job); } catch { /* best effort */ }
       pruneAsyncJobs();
       return;
     }
     job.status = "failed";
     job.error = error.message;
     job.finishedAt = new Date().toISOString();
+    try { checkpointJobFinish(db, job); } catch { /* best effort */ }
     pruneAsyncJobs();
   });
 
@@ -322,6 +329,7 @@ function startAsyncJob({ kind, requestPayload, onComplete }) {
         job.error = cancelledBySignal
           ? `Async job cancelled by signal ${signal}.`
           : payload?.error?.message ?? payload?.error ?? "Async job cancelled.";
+        try { checkpointJobFinish(db, job); } catch { /* best effort */ }
         pruneAsyncJobs();
         return;
       }
@@ -344,6 +352,7 @@ function startAsyncJob({ kind, requestPayload, onComplete }) {
         job.error = error instanceof Error ? error.message : String(error);
       }
     }
+    try { checkpointJobFinish(db, job); } catch { /* best effort */ }
     pruneAsyncJobs();
   });
 
@@ -645,6 +654,19 @@ function createCanonicalWorldEntity({ kind, name, notes, projectId, universeId, 
 // Database setup
 // ---------------------------------------------------------------------------
 const db = openDb(DB_PATH);
+
+// Recover jobs that were in-flight when the server last exited.
+const stalledJobs = loadStalledJobs(db);
+for (const job of stalledJobs) {
+  job.status = "failed";
+  job.error = "server restarted while job was running";
+  job.finishedAt = new Date().toISOString();
+  checkpointJobFinish(db, job);
+  asyncJobs.set(job.id, job);
+}
+if (stalledJobs.length > 0) {
+  process.stderr.write(`[mcp-writing] Marked ${stalledJobs.length} stalled job(s) as failed after restart.\n`);
+}
 
 process.stderr.write(`[mcp-writing] Sync dir: ${SYNC_DIR_ABS}\n`);
 process.stderr.write(`[mcp-writing] DB path: ${DB_PATH_DISPLAY}\n`);

--- a/test/unit/db.test.mjs
+++ b/test/unit/db.test.mjs
@@ -4,7 +4,7 @@ import os from "node:os";
 import fs from "node:fs";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
-import { openDb, CURRENT_SCHEMA_VERSION, SCHEMA } from "../../db.js";
+import { openDb, CURRENT_SCHEMA_VERSION, SCHEMA, checkpointJobCreate, checkpointJobFinish, loadStalledJobs } from "../../db.js";
 
 function makeTempPath() {
   return path.join(os.tmpdir(), `mcp-writing-db-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`);
@@ -89,6 +89,127 @@ describe("openDb", () => {
       const db = openDb(dbPath);
       const row = db.prepare(`SELECT version FROM schema_version LIMIT 1`).get();
       assert.equal(row?.version, CURRENT_SCHEMA_VERSION);
+      db.close();
+    } finally {
+      fs.rmSync(dbPath, { force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// async job checkpointing
+// ---------------------------------------------------------------------------
+
+describe("checkpointJobCreate / checkpointJobFinish / loadStalledJobs", () => {
+  function makeJob(overrides = {}) {
+    return {
+      id: `job-${Math.random().toString(36).slice(2)}`,
+      kind: "import_scrivener_sync",
+      status: "running",
+      createdAt: new Date().toISOString(),
+      startedAt: new Date().toISOString(),
+      finishedAt: null,
+      error: null,
+      result: null,
+      ...overrides,
+    };
+  }
+
+  test("checkpointJobCreate persists a running job", () => {
+    const dbPath = makeTempPath();
+    try {
+      const db = openDb(dbPath);
+      const job = makeJob();
+      checkpointJobCreate(db, job);
+      const row = db.prepare(`SELECT * FROM async_jobs WHERE job_id = ?`).get(job.id);
+      assert.equal(row.job_id, job.id);
+      assert.equal(row.kind, job.kind);
+      assert.equal(row.status, "running");
+      assert.equal(row.finished_at, null);
+      db.close();
+    } finally {
+      fs.rmSync(dbPath, { force: true });
+    }
+  });
+
+  test("checkpointJobFinish updates status, finished_at, and error", () => {
+    const dbPath = makeTempPath();
+    try {
+      const db = openDb(dbPath);
+      const job = makeJob();
+      checkpointJobCreate(db, job);
+      job.status = "failed";
+      job.error = "something went wrong";
+      job.finishedAt = new Date().toISOString();
+      checkpointJobFinish(db, job);
+      const row = db.prepare(`SELECT * FROM async_jobs WHERE job_id = ?`).get(job.id);
+      assert.equal(row.status, "failed");
+      assert.equal(row.error, "something went wrong");
+      assert.ok(row.finished_at);
+      db.close();
+    } finally {
+      fs.rmSync(dbPath, { force: true });
+    }
+  });
+
+  test("checkpointJobFinish stores result_json for completed jobs", () => {
+    const dbPath = makeTempPath();
+    try {
+      const db = openDb(dbPath);
+      const job = makeJob();
+      checkpointJobCreate(db, job);
+      job.status = "completed";
+      job.finishedAt = new Date().toISOString();
+      job.result = { ok: true, scenes_changed: 3 };
+      checkpointJobFinish(db, job);
+      const row = db.prepare(`SELECT result_json FROM async_jobs WHERE job_id = ?`).get(job.id);
+      assert.deepEqual(JSON.parse(row.result_json), job.result);
+      db.close();
+    } finally {
+      fs.rmSync(dbPath, { force: true });
+    }
+  });
+
+  test("loadStalledJobs returns running and cancelling jobs only", () => {
+    const dbPath = makeTempPath();
+    try {
+      const db = openDb(dbPath);
+      const running = makeJob({ status: "running" });
+      const cancelling = makeJob({ status: "cancelling" });
+      const completed = makeJob({ status: "completed" });
+      for (const j of [running, cancelling, completed]) {
+        checkpointJobCreate(db, j);
+      }
+      const stalled = loadStalledJobs(db);
+      const ids = stalled.map(j => j.id);
+      assert.ok(ids.includes(running.id));
+      assert.ok(ids.includes(cancelling.id));
+      assert.ok(!ids.includes(completed.id));
+      db.close();
+    } finally {
+      fs.rmSync(dbPath, { force: true });
+    }
+  });
+
+  test("loadStalledJobs returns empty array when no stalled jobs", () => {
+    const dbPath = makeTempPath();
+    try {
+      const db = openDb(dbPath);
+      assert.deepEqual(loadStalledJobs(db), []);
+      db.close();
+    } finally {
+      fs.rmSync(dbPath, { force: true });
+    }
+  });
+
+  test("async_jobs table exists on fresh database", () => {
+    const dbPath = makeTempPath();
+    try {
+      const db = openDb(dbPath);
+      const row = db.prepare(
+        `SELECT name FROM sqlite_master WHERE type='table' AND name='async_jobs'`
+      ).get();
+      assert.ok(row, "async_jobs table should exist");
       db.close();
     } finally {
       fs.rmSync(dbPath, { force: true });


### PR DESCRIPTION
## Summary

- Adds an `async_jobs` table to the SQLite schema to checkpoint in-flight job state.
- Writes a row on job creation and updates it on completion/failure/cancellation.
- On startup, any jobs that were `running` when the server last exited are marked `failed` with `"server restarted while job was running"`, so callers get a clean error from `get_async_job_status` instead of `NOT_FOUND`.

## Motivation

Async jobs lived entirely in a `Map` in the server process. A crash, deploy, or SIGKILL past the graceful-shutdown timeout silently discarded all job state. A caller polling `get_async_job_status` after a restart received `NOT_FOUND` rather than a meaningful error. This is a prerequisite for the OpenClaw deployment where server restarts are expected.

## Implementation

Three new exports in `db.js`:
- `checkpointJobCreate(db, job)` — `INSERT OR REPLACE` at job creation
- `checkpointJobFinish(db, job)` — `UPDATE` with final status, `finished_at`, error, and result JSON
- `loadStalledJobs(db)` — `SELECT` rows with `status IN ('running', 'cancelling')` for startup recovery

Checkpoint writes in `startAsyncJob` (`index.js`) use try/catch so a DB failure cannot prevent the job from starting or orphan a running child process. Finish checkpoints in event handlers are best-effort for the same reason.

Checkpoint-only approach (create + finish) avoids per-progress-update I/O overhead on large batch jobs.

## Testing

- `npm test` (324 tests, all passing)
- 6 new unit tests in `test/unit/db.test.mjs` covering: create persists row, finish updates status/error, finish stores result JSON, stalled filter returns only running/cancelling, empty-table case, table exists on fresh DB.

## Risks and tradeoffs

- Result payloads are stored as JSON text in `result_json`. For a large import job this could be several hundred KB per row. Acceptable for local SQLite; worth revisiting if row volume grows significantly.
- Completed/failed jobs from a previous server session are not reloaded into the in-memory Map on restart — only stalled (running) jobs are recovered. Callers cannot poll results from a prior server session after restart. Matches the PRD spec and the existing TTL-based pruning model.

## Follow-up

- Integration test: seed a running job in the DB, start the server, assert `get_async_job_status` returns `failed`.
- Phase F: large domain module investigation (`review-bundles.js`, `prose-styleguide.js`).