### PR TITLE
feat: publish mcp-writing to the MCP Registry

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish to npm
+name: Publish package and MCP Registry metadata
 
 on:
   push:
@@ -6,7 +6,7 @@ on:
       - 'v*.*.*'
 
 jobs:
-  publish:
+  publish_npm:
     name: npm publish
     runs-on: ubuntu-latest
     permissions:
@@ -37,3 +37,32 @@ jobs:
         run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  publish_mcp_registry:
+    name: MCP Registry publish
+    needs: publish_npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+
+      - name: Sync server.json version to tag
+        run: node scripts/sync-server-json-version.mjs "${GITHUB_REF#refs/tags/v}"
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Authenticate to MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish server to MCP Registry
+        run: ./mcp-publisher publish

--- a/.release-it.json
+++ b/.release-it.json
@@ -15,6 +15,6 @@
   },
   "hooks": {
     "before:init": "npm run lint && npm run test",
-    "after:bump": "npx auto-changelog -p"
+    "after:bump": "npm run sync:server-json-version && npx auto-changelog -p"
   }
 }

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -15,15 +15,17 @@ How it works:
    - `feat:` -> minor
    - everything else -> patch
 4. `release-it` creates a `Release x.y.z` commit and `vx.y.z` tag.
-5. Tag push triggers `.github/workflows/publish.yml` to publish to npm.
+5. Tag push triggers `.github/workflows/publish.yml` to publish to npm, then publish `server.json` metadata to the MCP Registry.
 
 ## Required setup
 
 - Repository secret: `RELEASE_DEPLOY_KEY` (private SSH key for a repo deploy key with write access)
 - Environment secret `NPM_TOKEN`: npm publish token required by `.github/workflows/publish.yml` (exposed as `NODE_AUTH_TOKEN` for `npm publish`); define it in the `npm` GitHub Actions environment on the repository (Settings → Environments → npm → Secrets)
+- No dedicated MCP Registry secret is required for the default GitHub OIDC flow; the publish workflow authenticates with `mcp-publisher login github-oidc`
 - Optional secret: `RELEASE_DEPLOY_KNOWN_HOSTS` (additional strict host keys; GitHub host key is already handled)
 - Branch rules must allow the Deploy Key actor to bypass PR-only rule for release commit/tag push
 - Repository URL in `package.json` must remain valid for npm provenance
+- `package.json:mcpName` and `server.json:name` must stay aligned for MCP Registry validation
 
 Local dry-run (optional):
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@ An MCP service for AI-assisted reasoning and editing on long-form fiction projec
 
 Designed to work with [OpenClaw](https://github.com/openclaw/openclaw) but compatible with any MCP-capable AI gateway.
 
+## Quick launch
+
+For local stdio MCP clients, run the published package directly:
+
+```sh
+WRITING_SYNC_DIR=/path/to/sync-dir DB_PATH=./writing.db npx -y @hanna84/mcp-writing
+```
+
+The CLI wrapper defaults to stdio transport and adds the Node 22 SQLite flag automatically when needed.
+
 ## What it does
 
 Instead of feeding an entire manuscript to an AI and hoping it fits in the context window, `mcp-writing` builds a structured index from your scene files. The AI queries that index first — finding relevant characters, beats, and loglines — then loads only the specific prose it needs.

--- a/bin/mcp-writing.js
+++ b/bin/mcp-writing.js
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const indexPath = path.join(__dirname, "..", "index.js");
+const nodeMajorVersion = Number.parseInt(process.versions.node.split(".")[0] ?? "0", 10);
+
+if (!process.env.MCP_TRANSPORT) {
+  process.env.MCP_TRANSPORT = "stdio";
+}
+
+if (nodeMajorVersion < 23) {
+  const child = spawn(process.execPath, ["--experimental-sqlite", indexPath, ...process.argv.slice(2)], {
+    env: process.env,
+    stdio: "inherit",
+  });
+
+  child.on("error", (error) => {
+    process.stderr.write(`[mcp-writing] FATAL: failed to launch stdio server: ${error.message}\n`);
+    process.exit(1);
+  });
+
+  child.on("exit", (code, signal) => {
+    if (signal) {
+      process.kill(process.pid, signal);
+      return;
+    }
+    process.exit(code ?? 0);
+  });
+} else {
+  await import(pathToFileURL(indexPath).href);
+}

--- a/docs/development.md
+++ b/docs/development.md
@@ -17,6 +17,14 @@ WRITING_SYNC_DIR=./my-manuscript DB_PATH=./writing.db npm start
 
 The `npm start` script automatically includes the `--experimental-sqlite` flag needed for SQLite support in Node.js 22+.
 
+For stdio MCP hosts, you can also launch the published CLI directly:
+
+```sh
+WRITING_SYNC_DIR=./my-manuscript DB_PATH=./writing.db npx -y @hanna84/mcp-writing
+```
+
+The CLI wrapper defaults `MCP_TRANSPORT=stdio` and adds the Node 22 SQLite flag automatically when needed.
+
 ---
 
 ## Verify your setup

--- a/package.json
+++ b/package.json
@@ -5,7 +5,12 @@
   "homepage": "https://hannasdev.github.io/mcp-writing/",
   "type": "module",
   "main": "index.js",
+  "bin": {
+    "mcp-writing": "./bin/mcp-writing.js"
+  },
+  "mcpName": "io.github.hannasdev/mcp-writing",
   "files": [
+    "bin/",
     "index.js",
     "async-jobs.js",
     "async-progress.js",
@@ -50,6 +55,7 @@
     "lint": "eslint *.js scripts/ tools/",
     "docs": "node scripts/generate-tool-docs.mjs",
     "lint:metadata": "node scripts/lint-metadata.mjs",
+    "sync:server-json-version": "node scripts/sync-server-json-version.mjs",
     "test:unit": "node --experimental-sqlite --test test/unit/*.test.mjs",
     "test:integration": "node --experimental-sqlite --test --test-concurrency=1 test/integration/*.test.mjs",
     "test": "npm run test:unit && npm run test:integration"

--- a/scripts/sync-server-json-version.mjs
+++ b/scripts/sync-server-json-version.mjs
@@ -1,0 +1,26 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT = path.resolve(__dirname, "..");
+const packageJsonPath = path.join(ROOT, "package.json");
+const serverJsonPath = path.join(ROOT, "server.json");
+
+const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+const serverJson = JSON.parse(fs.readFileSync(serverJsonPath, "utf8"));
+const requestedVersion = process.argv[2]?.trim();
+const nextVersion = requestedVersion || packageJson.version;
+
+if (!nextVersion) {
+  throw new Error("Unable to determine target version for server.json");
+}
+
+serverJson.version = nextVersion;
+serverJson.packages = (serverJson.packages ?? []).map((pkg) => ({
+  ...pkg,
+  version: nextVersion,
+}));
+
+fs.writeFileSync(serverJsonPath, `${JSON.stringify(serverJson, null, 2)}\n`, "utf8");

--- a/server.json
+++ b/server.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.hannasdev/mcp-writing",
+  "title": "Writing MCP",
+  "description": "Metadata-first fiction editing and reasoning tools for long-form writing projects.",
+  "websiteUrl": "https://hannasdev.github.io/mcp-writing/",
+  "repository": {
+    "url": "https://github.com/hannasdev/mcp-writing",
+    "source": "github"
+  },
+  "version": "2.11.1",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@hanna84/mcp-writing",
+      "version": "2.11.1",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "WRITING_SYNC_DIR",
+          "description": "Path to the manuscript sync folder that mcp-writing indexes and edits.",
+          "format": "filepath",
+          "isRequired": true,
+          "placeholder": "/path/to/your/scrivener-sync"
+        },
+        {
+          "name": "DB_PATH",
+          "description": "Optional path for the SQLite index database used by the server.",
+          "format": "filepath",
+          "isRequired": false,
+          "placeholder": "/path/to/writing.db"
+        },
+        {
+          "name": "OWNERSHIP_GUARD_MODE",
+          "description": "Startup ownership policy for sync-folder files.",
+          "choices": [
+            "warn",
+            "fail"
+          ],
+          "default": "warn",
+          "isRequired": false
+        }
+      ]
+    }
+  ]
+}

--- a/test/integration/stdio-cli.test.mjs
+++ b/test/integration/stdio-cli.test.mjs
@@ -1,0 +1,46 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { createTestSyncFixture } from "../helpers/fixtures.js";
+
+const ROOT = path.resolve(import.meta.dirname, "../..");
+
+test("CLI wrapper serves MCP over stdio by default", async () => {
+  const syncDir = fs.mkdtempSync(path.join(os.tmpdir(), "mcp-writing-stdio-"));
+  createTestSyncFixture(syncDir);
+
+  const client = new Client({ name: "integration-stdio-client", version: "1.0.0" });
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [path.join(ROOT, "bin", "mcp-writing.js")],
+    cwd: ROOT,
+    env: {
+      ...process.env,
+      WRITING_SYNC_DIR: syncDir,
+      DB_PATH: ":memory:",
+    },
+    stderr: "pipe",
+  });
+
+  let stderr = "";
+  transport.stderr?.on("data", (chunk) => {
+    stderr += chunk.toString("utf8");
+  });
+
+  try {
+    await client.connect(transport);
+    const result = await client.callTool({ name: "get_runtime_config", arguments: {} });
+    const text = result.content?.[0]?.text ?? "";
+    const payload = JSON.parse(text);
+
+    assert.equal(payload.sync_dir, syncDir, `CLI wrapper should initialize successfully. stderr:\n${stderr}`);
+    assert.equal(payload.db_path, ":memory:");
+  } finally {
+    await client.close().catch(() => {});
+    fs.rmSync(syncDir, { recursive: true, force: true });
+  }
+});

--- a/test/unit/registry-metadata.test.mjs
+++ b/test/unit/registry-metadata.test.mjs
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const ROOT = path.resolve(import.meta.dirname, "../..");
+const packageJson = JSON.parse(fs.readFileSync(path.join(ROOT, "package.json"), "utf8"));
+const serverJson = JSON.parse(fs.readFileSync(path.join(ROOT, "server.json"), "utf8"));
+
+test("registry metadata stays aligned with package metadata", () => {
+  assert.equal(packageJson.mcpName, serverJson.name);
+  assert.equal(serverJson.packages?.length, 1);
+  assert.equal(serverJson.packages[0].registryType, "npm");
+  assert.equal(serverJson.packages[0].identifier, packageJson.name);
+  assert.equal(serverJson.version, packageJson.version);
+  assert.equal(serverJson.packages[0].version, packageJson.version);
+  assert.equal(packageJson.bin?.["mcp-writing"], "./bin/mcp-writing.js");
+  assert.equal(serverJson.packages[0].transport?.type, "stdio");
+});


### PR DESCRIPTION
## Summary

- add MCP Registry metadata and npm package metadata needed to publish mcp-writing as a local stdio MCP server
- add a stdio-focused CLI wrapper plus tests that verify registry metadata alignment and CLI startup
- extend the existing tag publish workflow to publish npm first, then publish server.json to the MCP Registry via GitHub OIDC

## Motivation

This project already publishes releases to npm, but it was not yet discoverable through the official MCP Registry and the npm package was not packaged for straightforward stdio execution by registry-aware clients.

## Implementation

- added package.json mcpName, bin, and packaged the new bin/mcp-writing.js launcher that defaults to stdio and adds the Node 22 SQLite flag when needed
- added committed server.json metadata plus scripts/sync-server-json-version.mjs, and wired the same version sync into release-it and the publish workflow
- split .github/workflows/publish.yml into npm publish and MCP Registry publish jobs, with the registry publish job waiting for npm success and authenticating via mcp-publisher login github-oidc
- documented the new maintainer and local-launch flow in MAINTAINERS.md, README.md, and docs/development.md

## Testing

- `npm run lint`
- `node scripts/sync-server-json-version.mjs`
- `node --experimental-sqlite --test test/unit/registry-metadata.test.mjs test/integration/stdio-cli.test.mjs`
- `npm test`

## Risks and tradeoffs

- MCP Registry publishing now depends on GitHub OIDC working in Actions and outbound access to the registry release binary and registry API
- registry clients will rely on the npm package launcher path, so future package metadata changes need to keep package.json, server.json, and the bin entry aligned

## Follow-up

- None
