### PR TITLE
chore: update GitHub Actions for Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
         node-version: [22.x, 24.x]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
@@ -36,10 +36,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Use Node.js 22.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22.x
           cache: npm
@@ -55,10 +55,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Use Node.js 22.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22.x
           cache: npm

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -22,7 +22,7 @@ jobs:
     environment: github-pages
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Check required sections and testing content
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const body = context.payload.pull_request.body || "";

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,10 +18,10 @@ jobs:
       url: https://www.npmjs.com/package/@hanna84/mcp-writing
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Use Node.js 22.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22.x
           cache: npm
@@ -47,10 +47,10 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Use Node.js 22.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22.x
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -62,7 +62,7 @@ jobs:
           ssh-strict: true
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 'lts/*'
           cache: 'npm'


### PR DESCRIPTION
## Summary

- update GitHub-hosted workflow actions to Node 24-compatible major versions
- replace checkout and setup-node v4 usages with v6 across CI, release, publish, and pages workflows
- replace github-script v7 with v8 in the PR template validation workflow

## Motivation

GitHub is deprecating Node.js 20 for JavaScript-based Actions. The publish job is already warning that checkout and setup-node are still running on Node 20, so we should move the repo to the supported major versions before the runner default changes.

## Implementation

- updated actions/checkout from v4 to v6 in all workflow files that use it
- updated actions/setup-node from v4 to v6 in CI, publish, and release workflows
- updated actions/github-script from v7 to v8 in the PR description validation workflow
- kept the change limited to workflow dependency versions only, with no changes to app code or release logic

## Testing

- Manual review of workflow diffs to confirm only action version references changed
- Manually verified all workflow action references now point to checkout v6, setup-node v6, and github-script v8 where applicable

## Risks and tradeoffs

- this relies on the newer action major versions behaving compatibly with the repository’s existing workflow inputs
- the real confirmation will come from the next CI, PR template check, release, and publish runs on GitHub-hosted runners

## Follow-up

- None
