### PR TITLE
fix: detect no-op commit_edit proposals

### DIFF
--- a/test/integration/editing.test.mjs
+++ b/test/integration/editing.test.mjs
@@ -100,6 +100,47 @@ describe("commit_edit behavior", () => {
     assert.equal(after, normalizedRaw);
   });
 
+  test("treats trailing CRLF in revised prose as noop", async () => {
+    const scenePath = path.join(writeSyncDir, "projects", "test-novel", "part-1", "chapter-1", "sc-002.md");
+
+    const seedProposalText = await callWriteTool("propose_edit", {
+      scene_id: "sc-002",
+      instruction: "Seed prose for CRLF noop coverage",
+      revised_prose: "CRLF newline normalization coverage.",
+    });
+    const seedProposal = JSON.parse(seedProposalText);
+    await callWriteTool("commit_edit", {
+      scene_id: "sc-002",
+      proposal_id: seedProposal.proposal_id,
+    });
+
+    const normalizedRaw = fs.readFileSync(scenePath, "utf8");
+    const normalizedProse = matter(normalizedRaw).content.trim();
+
+    const proposalText = await callWriteTool("propose_edit", {
+      scene_id: "sc-002",
+      instruction: "Retry identical edit with trailing CRLF",
+      revised_prose: `${normalizedProse}\r\n`,
+    });
+    const proposal = JSON.parse(proposalText);
+
+    assert.equal(proposal.noop, true);
+    assert.equal(proposal.diff_preview, "(no changes)");
+
+    const commitText = await callWriteTool("commit_edit", {
+      scene_id: "sc-002",
+      proposal_id: proposal.proposal_id,
+    });
+    const commitResult = JSON.parse(commitText);
+    const after = fs.readFileSync(scenePath, "utf8");
+
+    assert.equal(commitResult.ok, true);
+    assert.equal(commitResult.noop, true);
+    assert.equal(commitResult.snapshot_commit, null);
+    assert.match(commitResult.message, /Nothing was written\./);
+    assert.equal(after, normalizedRaw);
+  });
+
   test("reindexes scene metadata on noop commit when prose changed out-of-band", async () => {
     const scenePath = path.join(writeSyncDir, "projects", "test-novel", "part-1", "chapter-1", "sc-001.md");
 

--- a/test/integration/editing.test.mjs
+++ b/test/integration/editing.test.mjs
@@ -1,26 +1,26 @@
-import { test, describe, before, after } from "node:test";
+import { test, describe, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
 import matter from "gray-matter";
 import { createTestContext } from "../helpers/server.js";
 
-const ctx = createTestContext(3069, 3068);
-let writeSyncDir, readSyncDir;
+let nextPort = 3068;
+let ctx;
+let writeSyncDir;
 
-before(async () => {
+beforeEach(async () => {
+  ctx = createTestContext(nextPort + 1, nextPort);
+  nextPort += 2;
   await ctx.setup();
   writeSyncDir = ctx.writeSyncDir;
-  readSyncDir = ctx.readSyncDir;
 });
 
-after(async () => {
+afterEach(async () => {
   await ctx.teardown();
 });
 
-const callTool = (n, a) => ctx.callTool(n, a);
 const callWriteTool = (n, a) => ctx.callWriteTool(n, a);
-const waitForAsyncJob = (id, t) => ctx.waitForAsyncJob(id, t);
 describe("commit_edit preflight diagnostics", () => {
   test("applies a revised scene file on commit", async () => {
     const scenePath = path.join(writeSyncDir, "projects", "test-novel", "part-1", "chapter-1", "sc-001.md");

--- a/test/integration/editing.test.mjs
+++ b/test/integration/editing.test.mjs
@@ -1,232 +1,224 @@
-import { test, describe } from "node:test";
+import { test, describe, before, after } from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
 import matter from "gray-matter";
 import { createTestContext } from "../helpers/server.js";
 
-let nextPort = 3068;
+const ctx = createTestContext(3069, 3068);
+let writeSyncDir;
+const callWriteTool = (n, a) => ctx.callWriteTool(n, a);
 
-async function withTestContext(run) {
-  const ctx = createTestContext(nextPort + 1, nextPort);
-  nextPort += 2;
-  await ctx.setup();
-  const callWriteTool = (n, a) => ctx.callWriteTool(n, a);
+before(async () => {
   try {
-    await run({
-      callWriteTool,
-      writeSyncDir: ctx.writeSyncDir,
-    });
+    await ctx.setup();
+    writeSyncDir = ctx.writeSyncDir;
   } finally {
-    await ctx.teardown();
+    if (!writeSyncDir) {
+      await ctx.teardown();
+    }
   }
-}
+});
 
-describe("commit_edit preflight diagnostics", () => {
+after(async () => {
+  await ctx.teardown();
+});
+
+describe("commit_edit behavior", () => {
   test("applies a revised scene file on commit", async () => {
-    await withTestContext(async ({ callWriteTool, writeSyncDir }) => {
-      const scenePath = path.join(writeSyncDir, "projects", "test-novel", "part-1", "chapter-1", "sc-001.md");
-      const before = fs.readFileSync(scenePath, "utf8");
+    const scenePath = path.join(writeSyncDir, "projects", "test-novel", "part-1", "chapter-1", "sc-001.md");
+    const before = fs.readFileSync(scenePath, "utf8");
 
-      const proposalText = await callWriteTool("propose_edit", {
-        scene_id: "sc-001",
-        instruction: "Tighten opening paragraph",
-        revised_prose: "Rewritten opening line.\nSecond line.",
-      });
-      const proposal = JSON.parse(proposalText);
-
-      assert.equal(proposal.noop, false);
-
-      const commitText = await callWriteTool("commit_edit", {
-        scene_id: "sc-001",
-        proposal_id: proposal.proposal_id,
-      });
-      const commitResult = JSON.parse(commitText);
-      const after = fs.readFileSync(scenePath, "utf8");
-
-      assert.equal(commitResult.ok, true);
-      assert.equal(commitResult.noop, false);
-      assert.match(commitResult.message, /Applied edit to scene 'sc-001'/);
-      assert.ok(
-        commitResult.snapshot_commit === null || typeof commitResult.snapshot_commit === "string",
-        "snapshot_commit should be either null or a commit hash string",
-      );
-      if (typeof commitResult.snapshot_commit === "string") {
-        assert.notEqual(commitResult.snapshot_commit, "");
-      }
-      assert.notEqual(after, before);
-      assert.match(after, /Rewritten opening line\.\nSecond line\./);
+    const proposalText = await callWriteTool("propose_edit", {
+      scene_id: "sc-001",
+      instruction: "Tighten opening paragraph",
+      revised_prose: "Rewritten opening line.\nSecond line.",
     });
+    const proposal = JSON.parse(proposalText);
+
+    assert.equal(proposal.noop, false);
+
+    const commitText = await callWriteTool("commit_edit", {
+      scene_id: "sc-001",
+      proposal_id: proposal.proposal_id,
+    });
+    const commitResult = JSON.parse(commitText);
+    const after = fs.readFileSync(scenePath, "utf8");
+
+    assert.equal(commitResult.ok, true);
+    assert.equal(commitResult.noop, false);
+    assert.match(commitResult.message, /Applied edit to scene 'sc-001'/);
+    assert.ok(
+      commitResult.snapshot_commit === null || typeof commitResult.snapshot_commit === "string",
+      "snapshot_commit should be either null or a commit hash string",
+    );
+    if (typeof commitResult.snapshot_commit === "string") {
+      assert.notEqual(commitResult.snapshot_commit, "");
+    }
+    assert.notEqual(after, before);
+    assert.match(after, /Rewritten opening line\.\nSecond line\./);
   });
 
   test("returns noop when the proposal matches the current scene file", async () => {
-    await withTestContext(async ({ callWriteTool, writeSyncDir }) => {
-      const scenePath = path.join(writeSyncDir, "projects", "test-novel", "part-1", "chapter-1", "sc-002.md");
+    const scenePath = path.join(writeSyncDir, "projects", "test-novel", "part-1", "chapter-1", "sc-002.md");
 
-      const seedProposalText = await callWriteTool("propose_edit", {
-        scene_id: "sc-002",
-        instruction: "Normalize scene formatting",
-        revised_prose: "Fresh prose for noop detection.",
-      });
-      const seedProposal = JSON.parse(seedProposalText);
-      await callWriteTool("commit_edit", {
-        scene_id: "sc-002",
-        proposal_id: seedProposal.proposal_id,
-      });
-
-      const normalizedRaw = fs.readFileSync(scenePath, "utf8");
-      const normalizedProse = matter(normalizedRaw).content.trim();
-
-      const proposalText = await callWriteTool("propose_edit", {
-        scene_id: "sc-002",
-        instruction: "Retry identical edit",
-        revised_prose: normalizedProse,
-      });
-      const proposal = JSON.parse(proposalText);
-
-      assert.equal(proposal.noop, true);
-      assert.equal(proposal.diff_preview, "(no changes)");
-
-      const commitText = await callWriteTool("commit_edit", {
-        scene_id: "sc-002",
-        proposal_id: proposal.proposal_id,
-      });
-      const commitResult = JSON.parse(commitText);
-      const after = fs.readFileSync(scenePath, "utf8");
-
-      assert.equal(commitResult.ok, true);
-      assert.equal(commitResult.noop, true);
-      assert.equal(commitResult.snapshot_commit, null);
-      assert.match(commitResult.message, /Nothing was written\./);
-      assert.equal(after, normalizedRaw);
+    const seedProposalText = await callWriteTool("propose_edit", {
+      scene_id: "sc-002",
+      instruction: "Normalize scene formatting",
+      revised_prose: "Fresh prose for noop detection.",
     });
+    const seedProposal = JSON.parse(seedProposalText);
+    await callWriteTool("commit_edit", {
+      scene_id: "sc-002",
+      proposal_id: seedProposal.proposal_id,
+    });
+
+    const normalizedRaw = fs.readFileSync(scenePath, "utf8");
+    const normalizedProse = matter(normalizedRaw).content.trim();
+
+    const proposalText = await callWriteTool("propose_edit", {
+      scene_id: "sc-002",
+      instruction: "Retry identical edit",
+      revised_prose: normalizedProse,
+    });
+    const proposal = JSON.parse(proposalText);
+
+    assert.equal(proposal.noop, true);
+    assert.equal(proposal.diff_preview, "(no changes)");
+
+    const commitText = await callWriteTool("commit_edit", {
+      scene_id: "sc-002",
+      proposal_id: proposal.proposal_id,
+    });
+    const commitResult = JSON.parse(commitText);
+    const after = fs.readFileSync(scenePath, "utf8");
+
+    assert.equal(commitResult.ok, true);
+    assert.equal(commitResult.noop, true);
+    assert.equal(commitResult.snapshot_commit, null);
+    assert.match(commitResult.message, /Nothing was written\./);
+    assert.equal(after, normalizedRaw);
   });
 
   test("reindexes scene metadata on noop commit when prose changed out-of-band", async () => {
-    await withTestContext(async ({ callWriteTool, writeSyncDir }) => {
-      const scenePath = path.join(writeSyncDir, "projects", "test-novel", "part-1", "chapter-1", "sc-001.md");
+    const scenePath = path.join(writeSyncDir, "projects", "test-novel", "part-1", "chapter-1", "sc-001.md");
 
-      const seedProposalText = await callWriteTool("propose_edit", {
-        scene_id: "sc-001",
-        instruction: "Normalize scene formatting",
-        revised_prose: "Seed prose for noop reindex coverage.",
-      });
-      const seedProposal = JSON.parse(seedProposalText);
-      await callWriteTool("commit_edit", {
-        scene_id: "sc-001",
-        proposal_id: seedProposal.proposal_id,
-      });
+    const seedProposalText = await callWriteTool("propose_edit", {
+      scene_id: "sc-001",
+      instruction: "Normalize scene formatting",
+      revised_prose: "Seed prose for noop reindex coverage.",
+    });
+    const seedProposal = JSON.parse(seedProposalText);
+    await callWriteTool("commit_edit", {
+      scene_id: "sc-001",
+      proposal_id: seedProposal.proposal_id,
+    });
 
-      const normalizedRaw = fs.readFileSync(scenePath, "utf8");
-      const frontmatterPrefix = normalizedRaw.match(/^---\n[\s\S]*?---\n\n/u)?.[0];
-      assert.ok(frontmatterPrefix, "expected canonical frontmatter prefix");
+    const normalizedRaw = fs.readFileSync(scenePath, "utf8");
+    const frontmatterPrefix = normalizedRaw.match(/^---\n[\s\S]*?---\n\n/u)?.[0];
+    assert.ok(frontmatterPrefix, "expected canonical frontmatter prefix");
 
-      const outOfBandProse = "One two three four five six seven eight nine ten.";
-      fs.writeFileSync(scenePath, `${frontmatterPrefix}${outOfBandProse}\n`, "utf8");
+    const outOfBandProse = "One two three four five six seven eight nine ten.";
+    fs.writeFileSync(scenePath, `${frontmatterPrefix}${outOfBandProse}\n`, "utf8");
 
-      const beforeText = await callWriteTool("find_scenes", {
-        project_id: "test-novel",
-        part: 1,
-        chapter: 1,
-      });
-      const beforeRows = JSON.parse(beforeText);
-      const beforeScene = beforeRows.find((row) => row.scene_id === "sc-001");
-      assert.ok(beforeScene);
-      assert.notEqual(beforeScene.word_count, 10);
+    const beforeText = await callWriteTool("find_scenes", {
+      project_id: "test-novel",
+      part: 1,
+      chapter: 1,
+    });
+    const beforeRows = JSON.parse(beforeText);
+    const beforeScene = beforeRows.find((row) => row.scene_id === "sc-001");
+    assert.ok(beforeScene);
+    assert.notEqual(beforeScene.word_count, 10);
 
-      const proposalText = await callWriteTool("propose_edit", {
-        scene_id: "sc-001",
-        instruction: "Retry identical edit after external change",
-        revised_prose: outOfBandProse,
-      });
-      const proposal = JSON.parse(proposalText);
-      assert.equal(proposal.noop, true);
+    const proposalText = await callWriteTool("propose_edit", {
+      scene_id: "sc-001",
+      instruction: "Retry identical edit after external change",
+      revised_prose: outOfBandProse,
+    });
+    const proposal = JSON.parse(proposalText);
+    assert.equal(proposal.noop, true);
+
+    const commitText = await callWriteTool("commit_edit", {
+      scene_id: "sc-001",
+      proposal_id: proposal.proposal_id,
+    });
+    const commitResult = JSON.parse(commitText);
+    assert.equal(commitResult.ok, true);
+    assert.equal(commitResult.noop, true);
+
+    const afterText = await callWriteTool("find_scenes", {
+      project_id: "test-novel",
+      part: 1,
+      chapter: 1,
+    });
+    const afterRows = JSON.parse(afterText);
+    const afterScene = afterRows.find((row) => row.scene_id === "sc-001");
+    assert.ok(afterScene);
+    assert.equal(afterScene.word_count, 10);
+  });
+
+  test("returns STALE_PATH when indexed prose file is missing", async () => {
+    const proposalText = await callWriteTool("propose_edit", {
+      scene_id: "sc-001",
+      instruction: "Tighten opening paragraph",
+      revised_prose: "Revised prose for stale path test.",
+    });
+    const proposal = JSON.parse(proposalText);
+    assert.ok(proposal.proposal_id);
+
+    const scenePath = path.join(writeSyncDir, "projects", "test-novel", "part-1", "chapter-1", "sc-001.md");
+    const originalContent = fs.readFileSync(scenePath, "utf8");
+    try {
+      fs.unlinkSync(scenePath);
 
       const commitText = await callWriteTool("commit_edit", {
         scene_id: "sc-001",
         proposal_id: proposal.proposal_id,
       });
       const commitResult = JSON.parse(commitText);
-      assert.equal(commitResult.ok, true);
-      assert.equal(commitResult.noop, true);
 
-      const afterText = await callWriteTool("find_scenes", {
-        project_id: "test-novel",
-        part: 1,
-        chapter: 1,
-      });
-      const afterRows = JSON.parse(afterText);
-      const afterScene = afterRows.find((row) => row.scene_id === "sc-001");
-      assert.ok(afterScene);
-      assert.equal(afterScene.word_count, 10);
-    });
-  });
-
-  test("returns STALE_PATH when indexed prose file is missing", async () => {
-    await withTestContext(async ({ callWriteTool, writeSyncDir }) => {
-      const proposalText = await callWriteTool("propose_edit", {
-        scene_id: "sc-001",
-        instruction: "Tighten opening paragraph",
-        revised_prose: "Revised prose for stale path test.",
-      });
-      const proposal = JSON.parse(proposalText);
-      assert.ok(proposal.proposal_id);
-
-      const scenePath = path.join(writeSyncDir, "projects", "test-novel", "part-1", "chapter-1", "sc-001.md");
-      const originalContent = fs.readFileSync(scenePath, "utf8");
-      try {
-        fs.unlinkSync(scenePath);
-
-        const commitText = await callWriteTool("commit_edit", {
-          scene_id: "sc-001",
-          proposal_id: proposal.proposal_id,
-        });
-        const commitResult = JSON.parse(commitText);
-
-        assert.equal(commitResult.ok, false);
-        assert.equal(commitResult.error.code, "STALE_PATH");
-        assert.equal(commitResult.error.details?.prose_write_diagnostics?.exists, false);
-      } finally {
-        if (!fs.existsSync(scenePath)) {
-          fs.writeFileSync(scenePath, originalContent, "utf8");
-        }
+      assert.equal(commitResult.ok, false);
+      assert.equal(commitResult.error.code, "STALE_PATH");
+      assert.equal(commitResult.error.details?.prose_write_diagnostics?.exists, false);
+    } finally {
+      if (!fs.existsSync(scenePath)) {
+        fs.writeFileSync(scenePath, originalContent, "utf8");
       }
-    });
+    }
   });
 
   test("returns INVALID_PROSE_PATH when indexed prose path points to a directory", async () => {
-    await withTestContext(async ({ callWriteTool, writeSyncDir }) => {
-      const proposalText = await callWriteTool("propose_edit", {
-        scene_id: "sc-003",
-        instruction: "Try writing to non-file path",
-        revised_prose: "Revised prose for invalid path test.",
-      });
-      const proposal = JSON.parse(proposalText);
-      assert.ok(proposal.proposal_id);
-
-      const originalScenePath = path.join(writeSyncDir, "projects", "test-novel", "part-1", "chapter-2", "sc-003.md");
-      const replacementPath = path.join(writeSyncDir, "projects", "test-novel", "part-1", "chapter-2", "sc-003-original.md");
-      try {
-        fs.renameSync(originalScenePath, replacementPath);
-        fs.mkdirSync(originalScenePath, { recursive: true });
-
-        const commitText = await callWriteTool("commit_edit", {
-          scene_id: "sc-003",
-          proposal_id: proposal.proposal_id,
-        });
-        const commitResult = JSON.parse(commitText);
-
-        assert.equal(commitResult.ok, false);
-        assert.equal(commitResult.error.code, "INVALID_PROSE_PATH");
-        assert.equal(commitResult.error.details?.prose_write_diagnostics?.is_file, false);
-      } finally {
-        if (fs.existsSync(originalScenePath) && fs.statSync(originalScenePath).isDirectory()) {
-          fs.rmSync(originalScenePath, { recursive: true, force: true });
-        }
-        if (fs.existsSync(replacementPath) && !fs.existsSync(originalScenePath)) {
-          fs.renameSync(replacementPath, originalScenePath);
-        }
-      }
+    const proposalText = await callWriteTool("propose_edit", {
+      scene_id: "sc-003",
+      instruction: "Try writing to non-file path",
+      revised_prose: "Revised prose for invalid path test.",
     });
+    const proposal = JSON.parse(proposalText);
+    assert.ok(proposal.proposal_id);
+
+    const originalScenePath = path.join(writeSyncDir, "projects", "test-novel", "part-1", "chapter-2", "sc-003.md");
+    const replacementPath = path.join(writeSyncDir, "projects", "test-novel", "part-1", "chapter-2", "sc-003-original.md");
+    try {
+      fs.renameSync(originalScenePath, replacementPath);
+      fs.mkdirSync(originalScenePath, { recursive: true });
+
+      const commitText = await callWriteTool("commit_edit", {
+        scene_id: "sc-003",
+        proposal_id: proposal.proposal_id,
+      });
+      const commitResult = JSON.parse(commitText);
+
+      assert.equal(commitResult.ok, false);
+      assert.equal(commitResult.error.code, "INVALID_PROSE_PATH");
+      assert.equal(commitResult.error.details?.prose_write_diagnostics?.is_file, false);
+    } finally {
+      if (fs.existsSync(originalScenePath) && fs.statSync(originalScenePath).isDirectory()) {
+        fs.rmSync(originalScenePath, { recursive: true, force: true });
+      }
+      if (fs.existsSync(replacementPath) && !fs.existsSync(originalScenePath)) {
+        fs.renameSync(replacementPath, originalScenePath);
+      }
+    }
   });
 });

--- a/test/integration/editing.test.mjs
+++ b/test/integration/editing.test.mjs
@@ -24,7 +24,7 @@ after(async () => {
   await ctx.teardown();
 });
 
-describe("commit_edit behavior", () => {
+describe("commit_edit behavior", { concurrency: 1 }, () => {
   test("applies a revised scene file on commit", async () => {
     const scenePath = path.join(writeSyncDir, "projects", "test-novel", "part-1", "chapter-1", "sc-001.md");
     const before = fs.readFileSync(scenePath, "utf8");

--- a/test/integration/editing.test.mjs
+++ b/test/integration/editing.test.mjs
@@ -2,7 +2,7 @@ import { test, describe, before, after } from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
-import os from "node:os";
+import matter from "gray-matter";
 import { createTestContext } from "../helpers/server.js";
 
 const ctx = createTestContext(3069, 3068);
@@ -22,6 +22,75 @@ const callTool = (n, a) => ctx.callTool(n, a);
 const callWriteTool = (n, a) => ctx.callWriteTool(n, a);
 const waitForAsyncJob = (id, t) => ctx.waitForAsyncJob(id, t);
 describe("commit_edit preflight diagnostics", () => {
+  test("applies a revised scene file on commit", async () => {
+    const scenePath = path.join(writeSyncDir, "projects", "test-novel", "part-1", "chapter-1", "sc-001.md");
+    const before = fs.readFileSync(scenePath, "utf8");
+
+    const proposalText = await callWriteTool("propose_edit", {
+      scene_id: "sc-001",
+      instruction: "Tighten opening paragraph",
+      revised_prose: "Rewritten opening line.\nSecond line.",
+    });
+    const proposal = JSON.parse(proposalText);
+
+    assert.equal(proposal.noop, false);
+
+    const commitText = await callWriteTool("commit_edit", {
+      scene_id: "sc-001",
+      proposal_id: proposal.proposal_id,
+    });
+    const commitResult = JSON.parse(commitText);
+    const after = fs.readFileSync(scenePath, "utf8");
+
+    assert.equal(commitResult.ok, true);
+    assert.equal(commitResult.noop, false);
+    assert.match(commitResult.message, /Applied edit to scene 'sc-001'/);
+    assert.notEqual(commitResult.snapshot_commit, null);
+    assert.notEqual(after, before);
+    assert.match(after, /Rewritten opening line\.\nSecond line\./);
+  });
+
+  test("returns noop when the proposal matches the current scene file", async () => {
+    const scenePath = path.join(writeSyncDir, "projects", "test-novel", "part-1", "chapter-1", "sc-002.md");
+
+    const seedProposalText = await callWriteTool("propose_edit", {
+      scene_id: "sc-002",
+      instruction: "Normalize scene formatting",
+      revised_prose: "Fresh prose for noop detection.",
+    });
+    const seedProposal = JSON.parse(seedProposalText);
+    await callWriteTool("commit_edit", {
+      scene_id: "sc-002",
+      proposal_id: seedProposal.proposal_id,
+    });
+
+    const normalizedRaw = fs.readFileSync(scenePath, "utf8");
+    const normalizedProse = matter(normalizedRaw).content.trim();
+
+    const proposalText = await callWriteTool("propose_edit", {
+      scene_id: "sc-002",
+      instruction: "Retry identical edit",
+      revised_prose: normalizedProse,
+    });
+    const proposal = JSON.parse(proposalText);
+
+    assert.equal(proposal.noop, true);
+    assert.equal(proposal.diff_preview, "(no changes)");
+
+    const commitText = await callWriteTool("commit_edit", {
+      scene_id: "sc-002",
+      proposal_id: proposal.proposal_id,
+    });
+    const commitResult = JSON.parse(commitText);
+    const after = fs.readFileSync(scenePath, "utf8");
+
+    assert.equal(commitResult.ok, true);
+    assert.equal(commitResult.noop, true);
+    assert.equal(commitResult.snapshot_commit, null);
+    assert.match(commitResult.message, /Nothing was written\./);
+    assert.equal(after, normalizedRaw);
+  });
+
   test("returns STALE_PATH when indexed prose file is missing", async () => {
     const proposalText = await callWriteTool("propose_edit", {
       scene_id: "sc-001",

--- a/test/integration/editing.test.mjs
+++ b/test/integration/editing.test.mjs
@@ -97,6 +97,64 @@ describe("commit_edit preflight diagnostics", () => {
     assert.equal(after, normalizedRaw);
   });
 
+  test("reindexes scene metadata on noop commit when prose changed out-of-band", async () => {
+    const scenePath = path.join(writeSyncDir, "projects", "test-novel", "part-1", "chapter-1", "sc-001.md");
+
+    const seedProposalText = await callWriteTool("propose_edit", {
+      scene_id: "sc-001",
+      instruction: "Normalize scene formatting",
+      revised_prose: "Seed prose for noop reindex coverage.",
+    });
+    const seedProposal = JSON.parse(seedProposalText);
+    await callWriteTool("commit_edit", {
+      scene_id: "sc-001",
+      proposal_id: seedProposal.proposal_id,
+    });
+
+    const normalizedRaw = fs.readFileSync(scenePath, "utf8");
+    const frontmatterPrefix = normalizedRaw.match(/^---\n[\s\S]*?---\n\n/u)?.[0];
+    assert.ok(frontmatterPrefix, "expected canonical frontmatter prefix");
+
+    const outOfBandProse = "One two three four five six seven eight nine ten.";
+    fs.writeFileSync(scenePath, `${frontmatterPrefix}${outOfBandProse}\n`, "utf8");
+
+    const beforeText = await callWriteTool("find_scenes", {
+      project_id: "test-novel",
+      part: 1,
+      chapter: 1,
+    });
+    const beforeRows = JSON.parse(beforeText);
+    const beforeScene = beforeRows.find((row) => row.scene_id === "sc-001");
+    assert.ok(beforeScene);
+    assert.notEqual(beforeScene.word_count, 10);
+
+    const proposalText = await callWriteTool("propose_edit", {
+      scene_id: "sc-001",
+      instruction: "Retry identical edit after external change",
+      revised_prose: outOfBandProse,
+    });
+    const proposal = JSON.parse(proposalText);
+    assert.equal(proposal.noop, true);
+
+    const commitText = await callWriteTool("commit_edit", {
+      scene_id: "sc-001",
+      proposal_id: proposal.proposal_id,
+    });
+    const commitResult = JSON.parse(commitText);
+    assert.equal(commitResult.ok, true);
+    assert.equal(commitResult.noop, true);
+
+    const afterText = await callWriteTool("find_scenes", {
+      project_id: "test-novel",
+      part: 1,
+      chapter: 1,
+    });
+    const afterRows = JSON.parse(afterText);
+    const afterScene = afterRows.find((row) => row.scene_id === "sc-001");
+    assert.ok(afterScene);
+    assert.equal(afterScene.word_count, 10);
+  });
+
   test("returns STALE_PATH when indexed prose file is missing", async () => {
     const proposalText = await callWriteTool("propose_edit", {
       scene_id: "sc-001",

--- a/test/integration/editing.test.mjs
+++ b/test/integration/editing.test.mjs
@@ -1,4 +1,4 @@
-import { test, describe, beforeEach, afterEach } from "node:test";
+import { test, describe } from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
@@ -6,216 +6,227 @@ import matter from "gray-matter";
 import { createTestContext } from "../helpers/server.js";
 
 let nextPort = 3068;
-let ctx;
-let writeSyncDir;
 
-beforeEach(async () => {
-  ctx = createTestContext(nextPort + 1, nextPort);
+async function withTestContext(run) {
+  const ctx = createTestContext(nextPort + 1, nextPort);
   nextPort += 2;
   await ctx.setup();
-  writeSyncDir = ctx.writeSyncDir;
-});
+  const callWriteTool = (n, a) => ctx.callWriteTool(n, a);
+  try {
+    await run({
+      callWriteTool,
+      writeSyncDir: ctx.writeSyncDir,
+    });
+  } finally {
+    await ctx.teardown();
+  }
+}
 
-afterEach(async () => {
-  await ctx.teardown();
-});
-
-const callWriteTool = (n, a) => ctx.callWriteTool(n, a);
 describe("commit_edit preflight diagnostics", () => {
   test("applies a revised scene file on commit", async () => {
-    const scenePath = path.join(writeSyncDir, "projects", "test-novel", "part-1", "chapter-1", "sc-001.md");
-    const before = fs.readFileSync(scenePath, "utf8");
+    await withTestContext(async ({ callWriteTool, writeSyncDir }) => {
+      const scenePath = path.join(writeSyncDir, "projects", "test-novel", "part-1", "chapter-1", "sc-001.md");
+      const before = fs.readFileSync(scenePath, "utf8");
 
-    const proposalText = await callWriteTool("propose_edit", {
-      scene_id: "sc-001",
-      instruction: "Tighten opening paragraph",
-      revised_prose: "Rewritten opening line.\nSecond line.",
-    });
-    const proposal = JSON.parse(proposalText);
+      const proposalText = await callWriteTool("propose_edit", {
+        scene_id: "sc-001",
+        instruction: "Tighten opening paragraph",
+        revised_prose: "Rewritten opening line.\nSecond line.",
+      });
+      const proposal = JSON.parse(proposalText);
 
-    assert.equal(proposal.noop, false);
-
-    const commitText = await callWriteTool("commit_edit", {
-      scene_id: "sc-001",
-      proposal_id: proposal.proposal_id,
-    });
-    const commitResult = JSON.parse(commitText);
-    const after = fs.readFileSync(scenePath, "utf8");
-
-    assert.equal(commitResult.ok, true);
-    assert.equal(commitResult.noop, false);
-    assert.match(commitResult.message, /Applied edit to scene 'sc-001'/);
-    assert.ok(
-      commitResult.snapshot_commit === null || typeof commitResult.snapshot_commit === "string",
-      "snapshot_commit should be either null or a commit hash string",
-    );
-    if (typeof commitResult.snapshot_commit === "string") {
-      assert.notEqual(commitResult.snapshot_commit, "");
-    }
-    assert.notEqual(after, before);
-    assert.match(after, /Rewritten opening line\.\nSecond line\./);
-  });
-
-  test("returns noop when the proposal matches the current scene file", async () => {
-    const scenePath = path.join(writeSyncDir, "projects", "test-novel", "part-1", "chapter-1", "sc-002.md");
-
-    const seedProposalText = await callWriteTool("propose_edit", {
-      scene_id: "sc-002",
-      instruction: "Normalize scene formatting",
-      revised_prose: "Fresh prose for noop detection.",
-    });
-    const seedProposal = JSON.parse(seedProposalText);
-    await callWriteTool("commit_edit", {
-      scene_id: "sc-002",
-      proposal_id: seedProposal.proposal_id,
-    });
-
-    const normalizedRaw = fs.readFileSync(scenePath, "utf8");
-    const normalizedProse = matter(normalizedRaw).content.trim();
-
-    const proposalText = await callWriteTool("propose_edit", {
-      scene_id: "sc-002",
-      instruction: "Retry identical edit",
-      revised_prose: normalizedProse,
-    });
-    const proposal = JSON.parse(proposalText);
-
-    assert.equal(proposal.noop, true);
-    assert.equal(proposal.diff_preview, "(no changes)");
-
-    const commitText = await callWriteTool("commit_edit", {
-      scene_id: "sc-002",
-      proposal_id: proposal.proposal_id,
-    });
-    const commitResult = JSON.parse(commitText);
-    const after = fs.readFileSync(scenePath, "utf8");
-
-    assert.equal(commitResult.ok, true);
-    assert.equal(commitResult.noop, true);
-    assert.equal(commitResult.snapshot_commit, null);
-    assert.match(commitResult.message, /Nothing was written\./);
-    assert.equal(after, normalizedRaw);
-  });
-
-  test("reindexes scene metadata on noop commit when prose changed out-of-band", async () => {
-    const scenePath = path.join(writeSyncDir, "projects", "test-novel", "part-1", "chapter-1", "sc-001.md");
-
-    const seedProposalText = await callWriteTool("propose_edit", {
-      scene_id: "sc-001",
-      instruction: "Normalize scene formatting",
-      revised_prose: "Seed prose for noop reindex coverage.",
-    });
-    const seedProposal = JSON.parse(seedProposalText);
-    await callWriteTool("commit_edit", {
-      scene_id: "sc-001",
-      proposal_id: seedProposal.proposal_id,
-    });
-
-    const normalizedRaw = fs.readFileSync(scenePath, "utf8");
-    const frontmatterPrefix = normalizedRaw.match(/^---\n[\s\S]*?---\n\n/u)?.[0];
-    assert.ok(frontmatterPrefix, "expected canonical frontmatter prefix");
-
-    const outOfBandProse = "One two three four five six seven eight nine ten.";
-    fs.writeFileSync(scenePath, `${frontmatterPrefix}${outOfBandProse}\n`, "utf8");
-
-    const beforeText = await callWriteTool("find_scenes", {
-      project_id: "test-novel",
-      part: 1,
-      chapter: 1,
-    });
-    const beforeRows = JSON.parse(beforeText);
-    const beforeScene = beforeRows.find((row) => row.scene_id === "sc-001");
-    assert.ok(beforeScene);
-    assert.notEqual(beforeScene.word_count, 10);
-
-    const proposalText = await callWriteTool("propose_edit", {
-      scene_id: "sc-001",
-      instruction: "Retry identical edit after external change",
-      revised_prose: outOfBandProse,
-    });
-    const proposal = JSON.parse(proposalText);
-    assert.equal(proposal.noop, true);
-
-    const commitText = await callWriteTool("commit_edit", {
-      scene_id: "sc-001",
-      proposal_id: proposal.proposal_id,
-    });
-    const commitResult = JSON.parse(commitText);
-    assert.equal(commitResult.ok, true);
-    assert.equal(commitResult.noop, true);
-
-    const afterText = await callWriteTool("find_scenes", {
-      project_id: "test-novel",
-      part: 1,
-      chapter: 1,
-    });
-    const afterRows = JSON.parse(afterText);
-    const afterScene = afterRows.find((row) => row.scene_id === "sc-001");
-    assert.ok(afterScene);
-    assert.equal(afterScene.word_count, 10);
-  });
-
-  test("returns STALE_PATH when indexed prose file is missing", async () => {
-    const proposalText = await callWriteTool("propose_edit", {
-      scene_id: "sc-001",
-      instruction: "Tighten opening paragraph",
-      revised_prose: "Revised prose for stale path test.",
-    });
-    const proposal = JSON.parse(proposalText);
-    assert.ok(proposal.proposal_id);
-
-    const scenePath = path.join(writeSyncDir, "projects", "test-novel", "part-1", "chapter-1", "sc-001.md");
-    const originalContent = fs.readFileSync(scenePath, "utf8");
-    try {
-      fs.unlinkSync(scenePath);
+      assert.equal(proposal.noop, false);
 
       const commitText = await callWriteTool("commit_edit", {
         scene_id: "sc-001",
         proposal_id: proposal.proposal_id,
       });
       const commitResult = JSON.parse(commitText);
+      const after = fs.readFileSync(scenePath, "utf8");
 
-      assert.equal(commitResult.ok, false);
-      assert.equal(commitResult.error.code, "STALE_PATH");
-      assert.equal(commitResult.error.details?.prose_write_diagnostics?.exists, false);
-    } finally {
-      if (!fs.existsSync(scenePath)) {
-        fs.writeFileSync(scenePath, originalContent, "utf8");
+      assert.equal(commitResult.ok, true);
+      assert.equal(commitResult.noop, false);
+      assert.match(commitResult.message, /Applied edit to scene 'sc-001'/);
+      assert.ok(
+        commitResult.snapshot_commit === null || typeof commitResult.snapshot_commit === "string",
+        "snapshot_commit should be either null or a commit hash string",
+      );
+      if (typeof commitResult.snapshot_commit === "string") {
+        assert.notEqual(commitResult.snapshot_commit, "");
       }
-    }
+      assert.notEqual(after, before);
+      assert.match(after, /Rewritten opening line\.\nSecond line\./);
+    });
   });
 
-  test("returns INVALID_PROSE_PATH when indexed prose path points to a directory", async () => {
-    const proposalText = await callWriteTool("propose_edit", {
-      scene_id: "sc-003",
-      instruction: "Try writing to non-file path",
-      revised_prose: "Revised prose for invalid path test.",
-    });
-    const proposal = JSON.parse(proposalText);
-    assert.ok(proposal.proposal_id);
+  test("returns noop when the proposal matches the current scene file", async () => {
+    await withTestContext(async ({ callWriteTool, writeSyncDir }) => {
+      const scenePath = path.join(writeSyncDir, "projects", "test-novel", "part-1", "chapter-1", "sc-002.md");
 
-    const originalScenePath = path.join(writeSyncDir, "projects", "test-novel", "part-1", "chapter-2", "sc-003.md");
-    const replacementPath = path.join(writeSyncDir, "projects", "test-novel", "part-1", "chapter-2", "sc-003-original.md");
-    try {
-      fs.renameSync(originalScenePath, replacementPath);
-      fs.mkdirSync(originalScenePath, { recursive: true });
+      const seedProposalText = await callWriteTool("propose_edit", {
+        scene_id: "sc-002",
+        instruction: "Normalize scene formatting",
+        revised_prose: "Fresh prose for noop detection.",
+      });
+      const seedProposal = JSON.parse(seedProposalText);
+      await callWriteTool("commit_edit", {
+        scene_id: "sc-002",
+        proposal_id: seedProposal.proposal_id,
+      });
+
+      const normalizedRaw = fs.readFileSync(scenePath, "utf8");
+      const normalizedProse = matter(normalizedRaw).content.trim();
+
+      const proposalText = await callWriteTool("propose_edit", {
+        scene_id: "sc-002",
+        instruction: "Retry identical edit",
+        revised_prose: normalizedProse,
+      });
+      const proposal = JSON.parse(proposalText);
+
+      assert.equal(proposal.noop, true);
+      assert.equal(proposal.diff_preview, "(no changes)");
 
       const commitText = await callWriteTool("commit_edit", {
-        scene_id: "sc-003",
+        scene_id: "sc-002",
         proposal_id: proposal.proposal_id,
       });
       const commitResult = JSON.parse(commitText);
+      const after = fs.readFileSync(scenePath, "utf8");
 
-      assert.equal(commitResult.ok, false);
-      assert.equal(commitResult.error.code, "INVALID_PROSE_PATH");
-      assert.equal(commitResult.error.details?.prose_write_diagnostics?.is_file, false);
-    } finally {
-      if (fs.existsSync(originalScenePath) && fs.statSync(originalScenePath).isDirectory()) {
-        fs.rmSync(originalScenePath, { recursive: true, force: true });
+      assert.equal(commitResult.ok, true);
+      assert.equal(commitResult.noop, true);
+      assert.equal(commitResult.snapshot_commit, null);
+      assert.match(commitResult.message, /Nothing was written\./);
+      assert.equal(after, normalizedRaw);
+    });
+  });
+
+  test("reindexes scene metadata on noop commit when prose changed out-of-band", async () => {
+    await withTestContext(async ({ callWriteTool, writeSyncDir }) => {
+      const scenePath = path.join(writeSyncDir, "projects", "test-novel", "part-1", "chapter-1", "sc-001.md");
+
+      const seedProposalText = await callWriteTool("propose_edit", {
+        scene_id: "sc-001",
+        instruction: "Normalize scene formatting",
+        revised_prose: "Seed prose for noop reindex coverage.",
+      });
+      const seedProposal = JSON.parse(seedProposalText);
+      await callWriteTool("commit_edit", {
+        scene_id: "sc-001",
+        proposal_id: seedProposal.proposal_id,
+      });
+
+      const normalizedRaw = fs.readFileSync(scenePath, "utf8");
+      const frontmatterPrefix = normalizedRaw.match(/^---\n[\s\S]*?---\n\n/u)?.[0];
+      assert.ok(frontmatterPrefix, "expected canonical frontmatter prefix");
+
+      const outOfBandProse = "One two three four five six seven eight nine ten.";
+      fs.writeFileSync(scenePath, `${frontmatterPrefix}${outOfBandProse}\n`, "utf8");
+
+      const beforeText = await callWriteTool("find_scenes", {
+        project_id: "test-novel",
+        part: 1,
+        chapter: 1,
+      });
+      const beforeRows = JSON.parse(beforeText);
+      const beforeScene = beforeRows.find((row) => row.scene_id === "sc-001");
+      assert.ok(beforeScene);
+      assert.notEqual(beforeScene.word_count, 10);
+
+      const proposalText = await callWriteTool("propose_edit", {
+        scene_id: "sc-001",
+        instruction: "Retry identical edit after external change",
+        revised_prose: outOfBandProse,
+      });
+      const proposal = JSON.parse(proposalText);
+      assert.equal(proposal.noop, true);
+
+      const commitText = await callWriteTool("commit_edit", {
+        scene_id: "sc-001",
+        proposal_id: proposal.proposal_id,
+      });
+      const commitResult = JSON.parse(commitText);
+      assert.equal(commitResult.ok, true);
+      assert.equal(commitResult.noop, true);
+
+      const afterText = await callWriteTool("find_scenes", {
+        project_id: "test-novel",
+        part: 1,
+        chapter: 1,
+      });
+      const afterRows = JSON.parse(afterText);
+      const afterScene = afterRows.find((row) => row.scene_id === "sc-001");
+      assert.ok(afterScene);
+      assert.equal(afterScene.word_count, 10);
+    });
+  });
+
+  test("returns STALE_PATH when indexed prose file is missing", async () => {
+    await withTestContext(async ({ callWriteTool, writeSyncDir }) => {
+      const proposalText = await callWriteTool("propose_edit", {
+        scene_id: "sc-001",
+        instruction: "Tighten opening paragraph",
+        revised_prose: "Revised prose for stale path test.",
+      });
+      const proposal = JSON.parse(proposalText);
+      assert.ok(proposal.proposal_id);
+
+      const scenePath = path.join(writeSyncDir, "projects", "test-novel", "part-1", "chapter-1", "sc-001.md");
+      const originalContent = fs.readFileSync(scenePath, "utf8");
+      try {
+        fs.unlinkSync(scenePath);
+
+        const commitText = await callWriteTool("commit_edit", {
+          scene_id: "sc-001",
+          proposal_id: proposal.proposal_id,
+        });
+        const commitResult = JSON.parse(commitText);
+
+        assert.equal(commitResult.ok, false);
+        assert.equal(commitResult.error.code, "STALE_PATH");
+        assert.equal(commitResult.error.details?.prose_write_diagnostics?.exists, false);
+      } finally {
+        if (!fs.existsSync(scenePath)) {
+          fs.writeFileSync(scenePath, originalContent, "utf8");
+        }
       }
-      if (fs.existsSync(replacementPath) && !fs.existsSync(originalScenePath)) {
-        fs.renameSync(replacementPath, originalScenePath);
+    });
+  });
+
+  test("returns INVALID_PROSE_PATH when indexed prose path points to a directory", async () => {
+    await withTestContext(async ({ callWriteTool, writeSyncDir }) => {
+      const proposalText = await callWriteTool("propose_edit", {
+        scene_id: "sc-003",
+        instruction: "Try writing to non-file path",
+        revised_prose: "Revised prose for invalid path test.",
+      });
+      const proposal = JSON.parse(proposalText);
+      assert.ok(proposal.proposal_id);
+
+      const originalScenePath = path.join(writeSyncDir, "projects", "test-novel", "part-1", "chapter-2", "sc-003.md");
+      const replacementPath = path.join(writeSyncDir, "projects", "test-novel", "part-1", "chapter-2", "sc-003-original.md");
+      try {
+        fs.renameSync(originalScenePath, replacementPath);
+        fs.mkdirSync(originalScenePath, { recursive: true });
+
+        const commitText = await callWriteTool("commit_edit", {
+          scene_id: "sc-003",
+          proposal_id: proposal.proposal_id,
+        });
+        const commitResult = JSON.parse(commitText);
+
+        assert.equal(commitResult.ok, false);
+        assert.equal(commitResult.error.code, "INVALID_PROSE_PATH");
+        assert.equal(commitResult.error.details?.prose_write_diagnostics?.is_file, false);
+      } finally {
+        if (fs.existsSync(originalScenePath) && fs.statSync(originalScenePath).isDirectory()) {
+          fs.rmSync(originalScenePath, { recursive: true, force: true });
+        }
+        if (fs.existsSync(replacementPath) && !fs.existsSync(originalScenePath)) {
+          fs.renameSync(replacementPath, originalScenePath);
+        }
       }
-    }
+    });
   });
 });

--- a/test/integration/editing.test.mjs
+++ b/test/integration/editing.test.mjs
@@ -45,7 +45,13 @@ describe("commit_edit preflight diagnostics", () => {
     assert.equal(commitResult.ok, true);
     assert.equal(commitResult.noop, false);
     assert.match(commitResult.message, /Applied edit to scene 'sc-001'/);
-    assert.notEqual(commitResult.snapshot_commit, null);
+    assert.ok(
+      commitResult.snapshot_commit === null || typeof commitResult.snapshot_commit === "string",
+      "snapshot_commit should be either null or a commit hash string",
+    );
+    if (typeof commitResult.snapshot_commit === "string") {
+      assert.notEqual(commitResult.snapshot_commit, "");
+    }
     assert.notEqual(after, before);
     assert.match(after, /Rewritten opening line\.\nSecond line\./);
   });

--- a/tools/editing.js
+++ b/tools/editing.js
@@ -5,6 +5,13 @@ import yaml from "js-yaml";
 import { createSnapshot, listSnapshots } from "../git.js";
 import { getFileWriteDiagnostics, readMeta, indexSceneFile } from "../sync.js";
 
+function renderSceneContent(metadata, revisedProse) {
+  const hasFrontmatter = metadata && Object.keys(metadata).length > 0;
+  return hasFrontmatter
+    ? `---\n${yaml.dump(metadata)}---\n\n${revisedProse}\n`
+    : `${revisedProse}\n`;
+}
+
 export function registerEditingTools(s, {
   db,
   SYNC_DIR,
@@ -36,6 +43,7 @@ export function registerEditingTools(s, {
       try {
         const raw = fs.readFileSync(scene.file_path, "utf8");
         const { data: metadata, content: currentProse } = matter(raw);
+        const renderedContent = renderSceneContent(metadata, revised_prose);
 
         const currentLines = currentProse.trim().split("\n");
         const revisedLines = revised_prose.trim().split("\n");
@@ -60,17 +68,28 @@ export function registerEditingTools(s, {
           scene_file_path: scene.file_path,
           instruction,
           revised_prose,
+          rendered_content: renderedContent,
           original_prose: currentProse,
           metadata,
           created_at: new Date().toISOString(),
         });
 
+        const noop = renderedContent === raw;
+        const diffPreview = noop
+          ? "(no changes)"
+          : diffLines.length > 0
+            ? diffLines.join("\n")
+            : "(changes occur after the previewed lines)";
+
         return jsonResponse({
           proposal_id: proposalId,
           scene_id,
           instruction,
-          diff_preview: diffLines.join("\n"),
-          note: "Review the diff above. Call commit_edit with this proposal_id to apply the change.",
+          diff_preview: diffPreview,
+          noop,
+          note: noop
+            ? "This proposal matches the current scene file. Calling commit_edit will be a no-op."
+            : "Review the diff above. Call commit_edit with this proposal_id to apply the change.",
         });
       } catch (err) {
         if (err.code === "ENOENT") {
@@ -152,10 +171,21 @@ export function registerEditingTools(s, {
           );
         }
 
-        const hasFrontmatter = proposal.metadata && Object.keys(proposal.metadata).length > 0;
-        const content = hasFrontmatter
-          ? `---\n${yaml.dump(proposal.metadata)}---\n\n${proposal.revised_prose}\n`
-          : `${proposal.revised_prose}\n`;
+        const content = proposal.rendered_content ?? renderSceneContent(proposal.metadata, proposal.revised_prose);
+        const currentRaw = fs.readFileSync(proposal.scene_file_path, "utf8");
+
+        if (currentRaw === content) {
+          pendingProposals.delete(proposal_id);
+
+          return jsonResponse({
+            ok: true,
+            scene_id,
+            proposal_id,
+            snapshot_commit: null,
+            noop: true,
+            message: `Proposal for scene '${scene_id}' matches the current file. Nothing was written.`,
+          });
+        }
 
         const snapshot = createSnapshot(SYNC_DIR, proposal.scene_file_path, scene_id, proposal.instruction);
 
@@ -172,7 +202,8 @@ export function registerEditingTools(s, {
           scene_id,
           proposal_id,
           snapshot_commit: snapshot.commit_hash,
-          message: `Committed edit for scene '${scene_id}'${snapshot.commit_hash ? ` (snapshot: ${snapshot.commit_hash.substring(0, 7)})` : " (no changes to snapshot)"}`,
+          noop: false,
+          message: `Applied edit to scene '${scene_id}'${snapshot.commit_hash ? ` (snapshot: ${snapshot.commit_hash.substring(0, 7)})` : " (no pre-edit snapshot needed)"}`,
         });
       } catch (err) {
         if (err.code === "ENOENT") {

--- a/tools/editing.js
+++ b/tools/editing.js
@@ -79,7 +79,7 @@ export function registerEditingTools(s, {
           ? "(no changes)"
           : diffLines.length > 0
             ? diffLines.join("\n")
-            : "(changes occur after the previewed lines)";
+            : "(file changes are not visible in the prose preview; they may be due to frontmatter or whitespace/newline formatting)";
 
         return jsonResponse({
           proposal_id: proposalId,

--- a/tools/editing.js
+++ b/tools/editing.js
@@ -7,9 +7,10 @@ import { getFileWriteDiagnostics, readMeta, indexSceneFile } from "../sync.js";
 
 function renderSceneContent(metadata, revisedProse) {
   const hasFrontmatter = metadata && Object.keys(metadata).length > 0;
+  const normalizedProse = revisedProse.replace(/\r?\n$/, "");
   return hasFrontmatter
-    ? `---\n${yaml.dump(metadata)}---\n\n${revisedProse}\n`
-    : `${revisedProse}\n`;
+    ? `---\n${yaml.dump(metadata)}---\n\n${normalizedProse}\n`
+    : `${normalizedProse}\n`;
 }
 
 export function registerEditingTools(s, {

--- a/tools/editing.js
+++ b/tools/editing.js
@@ -175,6 +175,9 @@ export function registerEditingTools(s, {
         const currentRaw = fs.readFileSync(proposal.scene_file_path, "utf8");
 
         if (currentRaw === content) {
+          const { meta: canonicalMeta } = readMeta(proposal.scene_file_path, SYNC_DIR, { writable: false });
+          const { content: currentProse } = matter(currentRaw);
+          indexSceneFile(db, SYNC_DIR, proposal.scene_file_path, canonicalMeta, currentProse);
           pendingProposals.delete(proposal_id);
 
           return jsonResponse({


### PR DESCRIPTION
## Summary

- add explicit no-op detection for `propose_edit` and `commit_edit` when a proposal would leave the scene file unchanged
- return clearer editing responses with a `noop` flag and less misleading commit/snapshot messaging
- cover both the applied-edit path and the no-op path with integration tests

## Motivation

`commit_edit` could report success even when the resulting scene file did not actually change. That made it hard to distinguish a real applied edit from a no-op proposal and led to misleading success messages.

## Implementation

- factor the scene-file rendering logic into a shared helper so proposals and commits compare the exact bytes that would be written
- mark proposals as `noop` when the rendered content already matches the current scene file
- short-circuit `commit_edit` before snapshot/write work when the current file already matches the proposal
- update success messaging to say the edit was applied only when a write happened
- add integration coverage for both a real write and a no-op retry against the normalized scene file

## Testing

- `node --test test/integration/editing.test.mjs`

## Risks and tradeoffs

- the no-op check is intentionally byte-for-byte against the rendered scene file, so formatting differences that would change the file still count as real edits
- this change adds response fields and messaging, so callers that parse the old free-form message text should prefer the structured `noop` flag

## Follow-up

- None.
