### PR TITLE
docs(workflow): add human-readable release-log skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,7 @@ All changes MUST follow this sequence:
 
 - ALWAYS open a PR after implementation and commit preparation (no direct merges)
 - MUST use `skills/pr-description/SKILL.md`
+- For user-facing or maintainer-facing behavior changes, use `skills/release-log/SKILL.md`
 - PR must accurately reflect the actual implementation
 
 ### 6. Review handling
@@ -90,6 +91,7 @@ Use these specialized skills:
 
 - `skills/commit-writing/SKILL.md` (used during Commit step)
 - `skills/pr-description/SKILL.md` (used during Pull Request step)
+- `skills/release-log/SKILL.md` (used during Pull Request step for human-readable value notes)
 - `skills/code-review/SKILL.md` (used during Review handling step)
 
 These define execution details. This file defines workflow and constraints.

--- a/docs/release-log.md
+++ b/docs/release-log.md
@@ -1,0 +1,17 @@
+# Release Log
+
+Human-readable release notes focused on user and maintainer value.
+
+This complements `CHANGELOG.md`:
+- `CHANGELOG.md` is technical and release-oriented.
+- This log is plain-language and outcome-oriented.
+
+## Unreleased
+
+### 2026-04-29 — Template initialized
+
+- What changed: Added a human-readable release log format for future PR entries.
+- Why it matters: Important user value will remain visible after PR context is gone.
+- Who is affected: Users and maintainers who follow project updates.
+- Action needed: None.
+- PR: TBD

--- a/docs/release-log.md
+++ b/docs/release-log.md
@@ -13,5 +13,5 @@ This complements `CHANGELOG.md`:
 - What changed: Added a human-readable release log format for future PR entries.
 - Why it matters: Important user value will remain visible after PR context is gone.
 - Who is affected: Users and maintainers who follow project updates.
-- Action needed: None.
-- PR: TBD
+- Action needed: None
+- PR: #129

--- a/skills/pr-description/SKILL.md
+++ b/skills/pr-description/SKILL.md
@@ -19,6 +19,7 @@ Before writing the PR description:
 4. Identify test coverage and validation performed.
 5. Identify risks, tradeoffs, and follow-up work.
 6. Ensure the PR is scoped to one concern.
+7. If user-facing or maintainer-facing behavior changed, update `docs/release-log.md` using `skills/release-log/SKILL.md`.
 
 ## PR title
 

--- a/skills/release-log/SKILL.md
+++ b/skills/release-log/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: release-log
+description: Use when preparing a PR that changes user or maintainer behavior and you want a human-readable release entry focused on value, impact, and action.
+---
+
+# Release Log Skill
+
+## Purpose
+
+Capture user-facing value from each relevant PR in a concise, non-technical release log so merged work stays understandable after review context is gone.
+
+## When to use
+
+Use this skill during PR creation or PR updates when the change affects:
+- user workflows;
+- maintainer workflows;
+- configuration defaults;
+- output shape or behavior;
+- setup, migration, or operational expectations.
+
+Skip for strictly internal refactors with no external impact.
+
+## Required process
+
+Before writing the release log entry:
+
+1. Review the PR diff against `main`.
+2. Review the PR description (`Summary`, `Motivation`, `Implementation`, `Testing`, `Risks and tradeoffs`, `Follow-up`).
+3. Identify concrete user or maintainer value.
+4. Identify who is affected and whether any action is required.
+5. Add/update one entry in `docs/release-log.md` under `## Unreleased`.
+
+## Entry format
+
+Use this structure:
+
+```markdown
+### YYYY-MM-DD — Short title
+
+- What changed: <plain-language change summary>
+- Why it matters: <value/outcome for users or maintainers>
+- Who is affected: <audience>
+- Action needed: <explicit action or `None`>
+- PR: <link or #number>
+```
+
+Rules:
+- Newest entries first under `## Unreleased`.
+- Use plain language; avoid internal implementation detail unless it changes behavior.
+- Keep bullets outcome-focused.
+- If no action is required, write `Action needed: None`.
+- Do not duplicate technical changelog wording.
+
+## Quality bar
+
+Good:
+- Explains the benefit, not only the code movement.
+- Makes impact clear in under 5 bullets.
+- Mentions required user action only when relevant.
+
+Bad:
+- "Refactored module paths and updated exports."
+- Vague statements with no value framing.
+
+## Final response after updating release log
+
+After updating `docs/release-log.md`, summarize:
+- the new release-log entry title/date;
+- intended audience;
+- any required user action (or `None`).


### PR DESCRIPTION
## Summary
- Add a new `skills/release-log/SKILL.md` that defines how to produce human-readable, value-focused release notes from PRs.
- Add `docs/release-log.md` with an `Unreleased` section and a stable entry template.
- Wire the new workflow into existing contributor guidance so PR preparation includes release-log updates when behavior changes are user/maintainer facing.

## Motivation
PR descriptions already capture user value during review, but that context is lost after merge. A dedicated release-log workflow keeps user-facing value visible in a durable place.

## Implementation
- Added a new release-log skill with usage criteria, entry format, and quality bar.
- Added a starter human-readable release log document.
- Updated `AGENTS.md` and `skills/pr-description/SKILL.md` to reference the new skill during PR preparation.

## Testing
- Not run: documentation/workflow change only.

## Risks and tradeoffs
- Adds one more contributor workflow step, so adoption depends on team discipline until/if CI enforcement is added.
- Guidance quality depends on keeping the release-log entries concise and value-focused over time.

## Follow-up
- Consider adding a lightweight CI check later to require release-log updates for PRs with user-facing impact labels.
