### PR TITLE
docs: mark root structure reorganization as complete

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -164,8 +164,8 @@ See [ideas-and-questions.md](docs/prd/inbox/ideas-and-questions.md) for:
 - Feature ideas (tag enhancements, relationship graphs, continuity checker)
 - Operational improvements (first-time setup, permission warnings)
 
-Additional in-progress proposal:
-- [Root Structure Reorganization](docs/prd/in-progress/root-structure-reorganization.md)
+Additional completed structural proposal:
+- [Root Structure Reorganization](docs/prd/done/root-structure-reorganization.md)
 
 ---
 

--- a/docs/prd/done/root-structure-reorganization.md
+++ b/docs/prd/done/root-structure-reorganization.md
@@ -1,6 +1,8 @@
 # Root Structure Reorganization
 
-**Status:** 🚧 In Progress
+**Status:** ✅ Done
+
+Completed and retained as a structural change record for the source-root migration.
 
 ## Motivation
 
@@ -307,6 +309,6 @@ Because phases are incremental and behavior-neutral, rollback should be low-cost
 
 ## Related
 
-- [../done/refactoring.md](../done/refactoring.md)
+- [./refactoring.md](./refactoring.md)
 - [../../development.md](../../development.md)
 - [../../../AGENTS.md](../../../AGENTS.md)


### PR DESCRIPTION
## Summary

- Moves the root structure reorganization document from `docs/prd/in-progress/` to `docs/prd/done/`.
- Marks the document status as complete.
- Updates the top-level PRD link so it points to the `done/` location and no longer labels this work as in-progress.

## Motivation

Refactor status was inconsistent across PRD documents: one file marked the structural work as done while another still tracked it as in-progress.

## Implementation

- Renamed:
  - `docs/prd/in-progress/root-structure-reorganization.md`
  - to `docs/prd/done/root-structure-reorganization.md`
- Updated status line to `✅ Done`.
- Updated `PRD.md` reference text and link target.
- Fixed the related-link path in the moved document.

## Testing

- Not run: documentation-only change.

## Risks and tradeoffs

- Low risk. This is a docs/status synchronization change with no runtime impact.

## Follow-up

- None
