### PR TITLE
feat: add reference document search

### DIFF
--- a/docs/data-ownership.md
+++ b/docs/data-ownership.md
@@ -42,7 +42,7 @@ The importer never reads or writes anything under `world/`. These files are full
 | `world/characters/<slug>/sheet.meta.yaml` | **AI agent** | Character metadata (`name`, `role`, `arc_summary`, `first_appearance`, `traits`). Written by `create_character_sheet`, `update_character_sheet`. |
 | `world/places/<slug>/sheet.md` | **Human** (after creation) | Canonical place sheet prose. `create_place_sheet` writes this file once on first setup; after that it is human-owned and no tool modifies it. |
 | `world/places/<slug>/sheet.meta.yaml` | **AI agent** | Place metadata (`name`, `associated_characters`, `tags`). Written by `create_place_sheet`, `update_place_sheet`. |
-| `world/reference/**/*.md` | **Human** | Free-form reference notes (world rules, timelines, etc.). Never indexed as entities. |
+| `world/reference/**/*.md` | **Human** | Free-form reference notes (world rules, timelines, etc.). Content remains human-owned; metadata may be indexed as lightweight reference-doc entities for discovery/search. |
 
 **Rule:** all character and place changes that should survive forever — backstory, relationships, traits, arc notes — belong in `world/`. This content is never at risk from a Scrivener re-import.
 

--- a/docs/release-log.md
+++ b/docs/release-log.md
@@ -8,6 +8,14 @@ This complements `CHANGELOG.md`:
 
 ## Unreleased
 
+### 2026-04-30 — Add reference document search
+
+- What changed: `sync()` now indexes lightweight metadata for reference docs, and a new `search_reference` tool can discover world/reference and Notes documents by title, summary, and tags.
+- Why it matters: Writers and agents can find relevant setting, continuity, research, and style notes without loading whole reference files or relying only on scene metadata.
+- Who is affected: Anyone using Writing MCP to navigate project reference material.
+- Action needed: Add optional frontmatter like `title`, `summary`, `tags`, or `doc_id` to reference docs if you want better search quality and stable identifiers.
+- PR: (pending)
+
 ### 2026-04-30 — Keep published package focused after test move
 
 - What changed: Tightened `package.json` publish allowlist so the npm package includes production `src/*` modules without unintentionally shipping `src/test`.

--- a/docs/release-log.md
+++ b/docs/release-log.md
@@ -14,7 +14,7 @@ This complements `CHANGELOG.md`:
 - Why it matters: Writers and agents can find relevant setting, continuity, research, and style notes without loading whole reference files or relying only on scene metadata.
 - Who is affected: Anyone using Writing MCP to navigate project reference material.
 - Action needed: Add optional frontmatter like `title`, `summary`, `tags`, or `doc_id` to reference docs if you want better search quality and stable identifiers.
-- PR: (pending)
+- PR: #146
 
 ### 2026-04-30 — Keep published package focused after test move
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -24,6 +24,7 @@
 - [`list_places`](#list_places)
 - [`get_place_sheet`](#get_place_sheet)
 - [`search_metadata`](#search_metadata)
+- [`search_reference`](#search_reference)
 - [`list_threads`](#list_threads)
 - [`get_thread_arc`](#get_thread_arc)
 - [`get_relationship_arc`](#get_relationship_arc)
@@ -280,6 +281,18 @@ Full-text search across scene titles, loglines (synopsis/logline text fields), a
 | `query` | `string` | Yes | Search terms (e.g. 'hospital' or 'Sebastian feeding'). FTS5 syntax supported. |
 | `page` | `integer` | No | Optional page number for paginated responses (1-based). |
 | `page_size` | `integer` | No | Optional page size for paginated responses (default: 20, max: 200). |
+
+---
+
+## search_reference
+
+Full-text search across indexed reference document titles, summaries, and tags. Use this to discover world-building notes, continuity references, research docs, and other reference material without loading full file contents.
+
+| Parameter | Type | Required | Description |
+| --- | --- | :---: | --- |
+| `query` | `string` | Yes | Search terms (e.g. 'vampirism' or 'blood replacement'). FTS5 syntax supported. |
+| `type` | `string` | No | Optional reference type filter (for example: 'world', 'continuity', 'research', 'style'). |
+| `tag` | `string` | No | Optional exact tag filter. |
 
 ---
 

--- a/src/core/db.js
+++ b/src/core/db.js
@@ -106,7 +106,9 @@ export const SCHEMA = `
     doc_id      TEXT NOT NULL PRIMARY KEY,
     project_id  TEXT,
     universe_id TEXT,
+    type        TEXT,
     title       TEXT NOT NULL,
+    summary     TEXT,
     file_path   TEXT NOT NULL
   );
 
@@ -118,6 +120,10 @@ export const SCHEMA = `
 
   CREATE VIRTUAL TABLE IF NOT EXISTS scenes_fts USING fts5(
     scene_id, project_id, logline, title, keywords
+  );
+
+  CREATE VIRTUAL TABLE IF NOT EXISTS reference_docs_fts USING fts5(
+    doc_id, project_id, title, summary, tags
   );
 
   CREATE TABLE IF NOT EXISTS schema_version (
@@ -167,6 +173,27 @@ const MIGRATIONS = [
       `);
       db.exec(`DROP TABLE scenes_fts;`);
       db.exec(`ALTER TABLE scenes_fts_migrating RENAME TO scenes_fts;`);
+    }
+  },
+  // 3: add lightweight reference-doc metadata columns and FTS table
+  (db) => {
+    const referenceDocColumns = db.prepare(`PRAGMA table_info(reference_docs)`).all();
+    if (!referenceDocColumns.some(c => c.name === "type")) {
+      db.exec(`ALTER TABLE reference_docs ADD COLUMN type TEXT;`);
+    }
+    if (!referenceDocColumns.some(c => c.name === "summary")) {
+      db.exec(`ALTER TABLE reference_docs ADD COLUMN summary TEXT;`);
+    }
+
+    const ftsSql = db.prepare(`
+      SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'reference_docs_fts'
+    `).get()?.sql;
+    if (typeof ftsSql !== "string") {
+      db.exec(`
+        CREATE VIRTUAL TABLE reference_docs_fts USING fts5(
+          doc_id, project_id, title, summary, tags
+        );
+      `);
     }
   },
 ];

--- a/src/sync/sync.js
+++ b/src/sync/sync.js
@@ -172,16 +172,48 @@ export function isWorldFile(syncDir, filePath) {
 
 export function isReferenceFile(syncDir, filePath) {
   const rel = path.relative(syncDir, filePath).split(path.sep).join("/").toLowerCase();
-  return rel.includes("/world/reference/") || rel.startsWith("notes/") || rel.includes("/notes/");
+  return rel.startsWith("world/reference/") || rel.includes("/world/reference/") || rel.startsWith("notes/") || rel.includes("/notes/");
 }
 
 export function inferReferenceDocType(syncDir, filePath) {
   const rel = path.relative(syncDir, filePath).split(path.sep).join("/").toLowerCase();
-  if (rel.includes("/world/reference/")) return "world";
-  if (rel.includes("/notes/continuity/")) return "continuity";
-  if (rel.includes("/notes/research/")) return "research";
-  if (rel.includes("/notes/style/")) return "style";
+  if (rel.startsWith("world/reference/") || rel.includes("/world/reference/")) return "world";
+  if (rel.startsWith("notes/continuity/") || rel.includes("/notes/continuity/")) return "continuity";
+  if (rel.startsWith("notes/research/") || rel.includes("/notes/research/")) return "research";
+  if (rel.startsWith("notes/style/") || rel.includes("/notes/style/")) return "style";
   return "reference";
+}
+
+function inferReferenceScopeFromSyncDir(syncDir) {
+  const parts = path.resolve(syncDir).split(path.sep).filter(Boolean);
+  const projectSlug = parts.at(-1);
+  const parent = parts.at(-2);
+  const universeId = parts.at(-2);
+  const universeProjectSlug = parts.at(-1);
+  const universeMarker = parts.at(-3);
+
+  if (parent === "projects" && projectSlug) {
+    return { universe_id: null, project_id: projectSlug };
+  }
+
+  if (universeMarker === "universes" && universeId && universeProjectSlug) {
+    return { universe_id: universeId, project_id: `${universeId}/${universeProjectSlug}` };
+  }
+
+  return null;
+}
+
+function inferReferenceProjectAndUniverse(syncDir, filePath) {
+  const rel = path.relative(syncDir, filePath).split(path.sep).join("/").toLowerCase();
+  const scoped = inferReferenceScopeFromSyncDir(syncDir);
+  if (
+    scoped
+    && (rel.startsWith("world/reference/") || rel.startsWith("notes/"))
+  ) {
+    return scoped;
+  }
+
+  return inferProjectAndUniverse(syncDir, filePath);
 }
 
 function slugifyReferencePart(value) {
@@ -540,7 +572,7 @@ export function indexWorldFile(db, syncDir, file, meta) {
 }
 
 export function indexReferenceFile(db, syncDir, file, meta = {}, content = "") {
-  const { universe_id, project_id } = inferProjectAndUniverse(syncDir, file);
+  const { universe_id, project_id } = inferReferenceProjectAndUniverse(syncDir, file);
   const docId = deriveReferenceDocId(syncDir, file, meta);
   const type = inferReferenceDocType(syncDir, file);
   const title = deriveReferenceTitle(file, meta, content);

--- a/src/sync/sync.js
+++ b/src/sync/sync.js
@@ -196,6 +196,10 @@ function inferReferenceScopeFromSyncDir(syncDir) {
     return { universe_id: null, project_id: projectSlug };
   }
 
+  if (parent === "universes" && projectSlug) {
+    return { universe_id: projectSlug, project_id: null };
+  }
+
   if (universeMarker === "universes" && universeId && universeProjectSlug) {
     return { universe_id: universeId, project_id: `${universeId}/${universeProjectSlug}` };
   }

--- a/src/sync/sync.js
+++ b/src/sync/sync.js
@@ -596,6 +596,12 @@ function pruneMissingReferenceDocs(db, seenDocIds) {
   }
 }
 
+function canPruneReferenceDocs(syncDir) {
+  // A sync root that points directly at a scenes/ subtree cannot observe the
+  // project's reference docs, so pruning there would wipe valid indexed rows.
+  return path.basename(path.resolve(syncDir)).toLowerCase() !== "scenes";
+}
+
 export function indexSceneFile(db, syncDir, file, meta, prose) {
   const { universe_id, project_id } = inferProjectAndUniverse(syncDir, file);
 
@@ -812,7 +818,9 @@ export function syncAll(db, syncDir, { quiet = false, writable = false } = {}) {
     }
   }
 
-  pruneMissingReferenceDocs(db, indexedReferenceDocIds);
+  if (canPruneReferenceDocs(syncDir)) {
+    pruneMissingReferenceDocs(db, indexedReferenceDocIds);
+  }
 
   // --- Pass 2: scene files ---
   for (const file of scanFiles) {

--- a/src/sync/sync.js
+++ b/src/sync/sync.js
@@ -608,8 +608,9 @@ export function indexReferenceFile(db, syncDir, file, meta = {}, content = "") {
     db.prepare(`INSERT OR IGNORE INTO reference_doc_tags (doc_id, tag) VALUES (?, ?)`).run(docId, tag);
   }
 
+  db.prepare(`DELETE FROM reference_docs_fts WHERE doc_id = ?`).run(docId);
   db.prepare(`
-    INSERT OR REPLACE INTO reference_docs_fts (doc_id, project_id, title, summary, tags)
+    INSERT INTO reference_docs_fts (doc_id, project_id, title, summary, tags)
     VALUES (?, ?, ?, ?, ?)
   `).run(
     docId,
@@ -633,9 +634,21 @@ function pruneMissingReferenceDocs(db, seenDocIds) {
 }
 
 function canPruneReferenceDocs(syncDir) {
-  // A sync root that points directly at a scenes/ subtree cannot observe the
-  // project's reference docs, so pruning there would wipe valid indexed rows.
-  return path.basename(path.resolve(syncDir)).toLowerCase() !== "scenes";
+  const resolvedSyncDir = path.resolve(syncDir);
+  const scopedRoot = inferReferenceScopeFromSyncDir(resolvedSyncDir);
+  if (scopedRoot) return true;
+
+  // Flat project roots and broad workspace roots can safely prune because
+  // they can observe the full set of reference docs in their scope.
+  const hasBroadRootChild = ["projects", "universes", "scenes"].some((name) => {
+    try {
+      return fs.statSync(path.join(resolvedSyncDir, name)).isDirectory();
+    } catch {
+      return false;
+    }
+  });
+
+  return hasBroadRootChild;
 }
 
 export function indexSceneFile(db, syncDir, file, meta, prose) {

--- a/src/sync/sync.js
+++ b/src/sync/sync.js
@@ -170,6 +170,82 @@ export function isWorldFile(syncDir, filePath) {
   return rel.includes(`${path.sep}world${path.sep}`) || rel.includes("/world/");
 }
 
+export function isReferenceFile(syncDir, filePath) {
+  const rel = path.relative(syncDir, filePath).split(path.sep).join("/").toLowerCase();
+  return rel.includes("/world/reference/") || rel.startsWith("notes/") || rel.includes("/notes/");
+}
+
+export function inferReferenceDocType(syncDir, filePath) {
+  const rel = path.relative(syncDir, filePath).split(path.sep).join("/").toLowerCase();
+  if (rel.includes("/world/reference/")) return "world";
+  if (rel.includes("/notes/continuity/")) return "continuity";
+  if (rel.includes("/notes/research/")) return "research";
+  if (rel.includes("/notes/style/")) return "style";
+  return "reference";
+}
+
+function slugifyReferencePart(value) {
+  return String(value ?? "")
+    .toLowerCase()
+    .replace(/\.(md|txt)$/i, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+export function deriveReferenceDocId(syncDir, filePath, meta = {}) {
+  if (typeof meta.doc_id === "string" && meta.doc_id.trim()) return meta.doc_id.trim();
+
+  const rel = path.relative(syncDir, filePath).split(path.sep).join("/");
+  const slug = rel
+    .split("/")
+    .map(slugifyReferencePart)
+    .filter(Boolean)
+    .join("-");
+  return `ref-${slug}`;
+}
+
+export function deriveReferenceTitle(filePath, meta = {}, content = "") {
+  if (typeof meta.title === "string" && meta.title.trim()) return meta.title.trim();
+
+  const heading = content.match(/^\s*#\s+(.+?)\s*$/m)?.[1]?.trim();
+  if (heading) return heading;
+
+  const base = path.basename(filePath, path.extname(filePath));
+  return base
+    .replace(/[-_]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function normalizeReferenceTags(tags) {
+  const values = Array.isArray(tags)
+    ? tags
+    : typeof tags === "string"
+      ? tags.split(",")
+      : [];
+
+  return [...new Set(
+    values
+      .map(tag => String(tag).trim())
+      .filter(Boolean)
+  )];
+}
+
+export function deriveReferenceSummary(meta = {}, content = "") {
+  if (typeof meta.summary === "string" && meta.summary.trim()) return meta.summary.trim();
+
+  const body = content
+    .split("\n")
+    .map(line => line.trim())
+    .filter(line => line && !line.startsWith("#"))
+    .join(" ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  if (!body) return null;
+  return body.length <= 240 ? body : `${body.slice(0, 237).trimEnd()}...`;
+}
+
 export function worldEntityKindForPath(syncDir, filePath) {
   const rel = path.relative(syncDir, filePath);
   if (rel.includes(`${path.sep}characters${path.sep}`) || rel.includes("/characters/")) return "character";
@@ -463,6 +539,63 @@ export function indexWorldFile(db, syncDir, file, meta) {
   }
 }
 
+export function indexReferenceFile(db, syncDir, file, meta = {}, content = "") {
+  const { universe_id, project_id } = inferProjectAndUniverse(syncDir, file);
+  const docId = deriveReferenceDocId(syncDir, file, meta);
+  const type = inferReferenceDocType(syncDir, file);
+  const title = deriveReferenceTitle(file, meta, content);
+  const summary = deriveReferenceSummary(meta, content);
+  const tags = normalizeReferenceTags(meta.tags);
+
+  db.prepare(`
+    INSERT INTO reference_docs (doc_id, project_id, universe_id, type, title, summary, file_path)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT (doc_id) DO UPDATE SET
+      project_id = excluded.project_id,
+      universe_id = excluded.universe_id,
+      type = excluded.type,
+      title = excluded.title,
+      summary = excluded.summary,
+      file_path = excluded.file_path
+  `).run(
+    docId,
+    project_id ?? null,
+    universe_id ?? null,
+    type,
+    title,
+    summary ?? null,
+    file
+  );
+
+  db.prepare(`DELETE FROM reference_doc_tags WHERE doc_id = ?`).run(docId);
+  for (const tag of tags) {
+    db.prepare(`INSERT OR IGNORE INTO reference_doc_tags (doc_id, tag) VALUES (?, ?)`).run(docId, tag);
+  }
+
+  db.prepare(`
+    INSERT OR REPLACE INTO reference_docs_fts (doc_id, project_id, title, summary, tags)
+    VALUES (?, ?, ?, ?, ?)
+  `).run(
+    docId,
+    project_id ?? "",
+    title,
+    summary ?? "",
+    tags.join(" ")
+  );
+
+  return docId;
+}
+
+function pruneMissingReferenceDocs(db, seenDocIds) {
+  const rows = db.prepare(`SELECT doc_id FROM reference_docs`).all();
+  for (const row of rows) {
+    if (seenDocIds.has(row.doc_id)) continue;
+    db.prepare(`DELETE FROM reference_doc_tags WHERE doc_id = ?`).run(row.doc_id);
+    db.prepare(`DELETE FROM reference_docs_fts WHERE doc_id = ?`).run(row.doc_id);
+    db.prepare(`DELETE FROM reference_docs WHERE doc_id = ?`).run(row.doc_id);
+  }
+}
+
 export function indexSceneFile(db, syncDir, file, meta, prose) {
   const { universe_id, project_id } = inferProjectAndUniverse(syncDir, file);
 
@@ -639,6 +772,7 @@ export function syncAll(db, syncDir, { quiet = false, writable = false } = {}) {
   let sidecarsMigrated = 0;
   const seenSceneIds = new Map(); // scene_id+project_id → file path, for duplicate detection
   const indexedSceneIds = new Set(); // scene_id only — for orphaned sidecar move detection
+  const indexedReferenceDocIds = new Set();
   const warnings = [];
 
   const scanFiles = [];
@@ -650,9 +784,20 @@ export function syncAll(db, syncDir, { quiet = false, writable = false } = {}) {
     scanFiles.push(file);
   }
 
-  // --- Pass 1: world files (characters/places must be indexed before scenes
-  // so that character name → ID resolution in scene_characters works) ---
+  // --- Pass 1: world files and reference docs (characters/places must be indexed
+  // before scenes so that character name -> ID resolution in scene_characters works) ---
   for (const file of scanFiles) {
+    if (isReferenceFile(syncDir, file)) {
+      try {
+        const { data, content } = parseFile(file);
+        const docId = indexReferenceFile(db, syncDir, file, data, content);
+        indexedReferenceDocIds.add(docId);
+      } catch (err) {
+        process.stderr.write(`[mcp-writing] Failed to index ${file}: ${err.message}\n`);
+      }
+      continue;
+    }
+
     if (!isWorldFile(syncDir, file)) continue;
     try {
       const { meta } = readMeta(file, syncDir, { writable });
@@ -667,9 +812,11 @@ export function syncAll(db, syncDir, { quiet = false, writable = false } = {}) {
     }
   }
 
+  pruneMissingReferenceDocs(db, indexedReferenceDocIds);
+
   // --- Pass 2: scene files ---
   for (const file of scanFiles) {
-    if (isWorldFile(syncDir, file)) continue;
+    if (isWorldFile(syncDir, file) || isReferenceFile(syncDir, file)) continue;
     try {
       const { meta, sourceMeta, sidecarGenerated, derived, mismatches } = readMeta(file, syncDir, { writable });
       if (sidecarGenerated) sidecarsMigrated++;

--- a/src/test/helpers/fixtures.js
+++ b/src/test/helpers/fixtures.js
@@ -283,6 +283,37 @@ tags:
   - recurring
 `
   );
+
+  writeFileSyncWithDirs(
+    path.join(syncDir, "projects", "test-novel", "world", "reference", "vampirism.md"),
+    `---
+title: Vampirism in this universe
+summary: Defines how vampirism works in the setting, including blood need, feeding limits, and inherited traits.
+tags:
+  - vampirism
+  - blood
+  - lore
+---
+
+# Vampirism in this universe
+
+Vampirism in this setting is an inherited condition with strict feeding constraints, ritual taboos, and physiological limits.
+`
+  );
+
+  writeFileSyncWithDirs(
+    path.join(syncDir, "projects", "test-novel", "Notes", "continuity", "blood-replacement.md"),
+    `---
+title: Sebastian's struggle for blood replacement
+tags:
+  - continuity
+  - blood
+  - sebastian
+---
+
+Sebastian has spent years cataloguing failed inventions meant to reduce or replace his dependence on fresh blood.
+`
+  );
 }
 
 export function createScrivenerDraftFixture(baseDir) {

--- a/src/test/integration/search.test.mjs
+++ b/src/test/integration/search.test.mjs
@@ -285,6 +285,39 @@ describe("search_metadata tool", () => {
   });
 });
 
+describe("search_reference tool", () => {
+  test("finds reference docs by title and summary text", async () => {
+    const text = await callTool("search_reference", { query: "vampirism" });
+    const parsed = JSON.parse(text);
+    assert.equal(parsed.length, 1);
+    assert.equal(parsed[0].type, "world");
+    assert.equal(parsed[0].title, "Vampirism in this universe");
+    assert.ok(parsed[0].tags.includes("vampirism"));
+  });
+
+  test("supports exact tag filtering", async () => {
+    const text = await callTool("search_reference", { query: "blood", tag: "continuity" });
+    const parsed = JSON.parse(text);
+    assert.equal(parsed.length, 1);
+    assert.equal(parsed[0].type, "continuity");
+    assert.equal(parsed[0].title, "Sebastian's struggle for blood replacement");
+  });
+
+  test("supports type filtering", async () => {
+    const text = await callTool("search_reference", { query: "blood", type: "world" });
+    const parsed = JSON.parse(text);
+    assert.equal(parsed.length, 1);
+    assert.equal(parsed[0].type, "world");
+  });
+
+  test("returns INVALID_QUERY on malformed FTS syntax", async () => {
+    const text = await callTool("search_reference", { query: '"unmatched' });
+    const parsed = JSON.parse(text);
+    assert.equal(parsed.ok, false);
+    assert.equal(parsed.error.code, "INVALID_QUERY");
+  });
+});
+
 describe("list_threads tool", () => {
   test("returns structured empty result when none created", async () => {
     const text = await callTool("list_threads", { project_id: "test-novel" });

--- a/src/test/unit/db.test.mjs
+++ b/src/test/unit/db.test.mjs
@@ -94,6 +94,46 @@ describe("openDb", () => {
       fs.rmSync(dbPath, { force: true });
     }
   });
+
+  test("migrates legacy reference_docs schema and creates reference_docs_fts", () => {
+    const dbPath = makeTempPath();
+    try {
+      const legacyDb = new DatabaseSync(dbPath);
+      legacyDb.exec(`
+        CREATE TABLE reference_docs (
+          doc_id TEXT NOT NULL PRIMARY KEY,
+          project_id TEXT,
+          universe_id TEXT,
+          title TEXT NOT NULL,
+          file_path TEXT NOT NULL
+        );
+      `);
+      legacyDb.exec(`
+        CREATE TABLE reference_doc_tags (
+          doc_id TEXT NOT NULL,
+          tag TEXT NOT NULL,
+          PRIMARY KEY (doc_id, tag)
+        );
+      `);
+      legacyDb.close();
+
+      const db = openDb(dbPath);
+      const columns = db.prepare(`PRAGMA table_info(reference_docs)`).all();
+      assert.ok(columns.some(column => column.name === "type"));
+      assert.ok(columns.some(column => column.name === "summary"));
+
+      const ftsSql = db.prepare(`
+        SELECT sql
+        FROM sqlite_master
+        WHERE type = 'table' AND name = 'reference_docs_fts'
+      `).get()?.sql;
+      assert.ok(typeof ftsSql === "string" && ftsSql.toLowerCase().includes("summary"));
+
+      db.close();
+    } finally {
+      fs.rmSync(dbPath, { force: true });
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/test/unit/sync.test.mjs
+++ b/src/test/unit/sync.test.mjs
@@ -5,6 +5,8 @@ import fs from "node:fs";
 import path from "node:path";
 import {
   checksumProse, inferProjectAndUniverse, inferScenePositionFromPath,
+  inferReferenceDocType, isReferenceFile, deriveReferenceDocId,
+  deriveReferenceSummary, deriveReferenceTitle, normalizeReferenceTags,
   isCanonicalWorldEntityFile, getSyncOwnershipDiagnostics, getFileWriteDiagnostics,
   isWorldFile, readMeta, isSyncDirWritable, sidecarPath, syncAll,
   walkFiles, walkSidecars, worldEntityFolderKey, worldEntityKindForPath,
@@ -372,6 +374,49 @@ describe("isWorldFile", () => {
   });
 });
 
+describe("reference docs", () => {
+  const syncDir = "/sync";
+
+  test("detects reference files in world/reference paths", () => {
+    assert.equal(isReferenceFile(syncDir, "/sync/projects/novel/world/reference/vampirism.md"), true);
+  });
+
+  test("detects reference files in Notes paths", () => {
+    assert.equal(isReferenceFile(syncDir, "/sync/projects/novel/Notes/continuity/blood.md"), true);
+  });
+
+  test("infers reference doc types from path", () => {
+    assert.equal(inferReferenceDocType(syncDir, "/sync/projects/novel/world/reference/vampirism.md"), "world");
+    assert.equal(inferReferenceDocType(syncDir, "/sync/projects/novel/Notes/continuity/blood.md"), "continuity");
+    assert.equal(inferReferenceDocType(syncDir, "/sync/projects/novel/Notes/research/boats.md"), "research");
+  });
+
+  test("derives stable doc ids from relative path when doc_id is missing", () => {
+    assert.equal(
+      deriveReferenceDocId(syncDir, "/sync/projects/novel/world/reference/vampirism.md", {}),
+      "ref-projects-novel-world-reference-vampirism"
+    );
+  });
+
+  test("prefers explicit title and summary when provided", () => {
+    assert.equal(
+      deriveReferenceTitle("/sync/projects/novel/world/reference/vampirism.md", { title: "Custom Title" }, "# Ignored"),
+      "Custom Title"
+    );
+    assert.equal(
+      deriveReferenceSummary({ summary: "Custom summary" }, "Ignored body"),
+      "Custom summary"
+    );
+  });
+
+  test("normalizes tags from strings and removes duplicates", () => {
+    assert.deepEqual(
+      normalizeReferenceTags(["blood", " blood ", "lore"]),
+      ["blood", "lore"]
+    );
+  });
+});
+
 describe("world entity canonical detection", () => {
   const syncDir = "/sync";
 
@@ -478,6 +523,75 @@ describe("syncAll", () => {
     const places = db.prepare("SELECT * FROM places").all();
     assert.equal(places.length, 1);
     assert.equal(places[0].place_id, "harbor");
+
+    db.close();
+    fs.rmSync(dir, { recursive: true });
+  });
+
+  test("indexes reference docs with inferred type, summary, and tags", () => {
+    const dir = makeTempSync();
+    const db = openDb(":memory:");
+    fs.mkdirSync(path.join(dir, "projects", "test-novel", "world", "reference"), { recursive: true });
+    fs.mkdirSync(path.join(dir, "projects", "test-novel", "Notes", "continuity"), { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, "projects", "test-novel", "world", "reference", "vampirism.md"),
+      "---\ntitle: Vampirism in this universe\nsummary: Rules of vampirism.\ntags:\n  - vampirism\n  - lore\n---\nReference body."
+    );
+    fs.writeFileSync(
+      path.join(dir, "projects", "test-novel", "Notes", "continuity", "blood-replacement.md"),
+      "---\ntitle: Sebastian's struggle for blood replacement\ntags:\n  - continuity\n  - blood\n---\nSebastian catalogues failed inventions."
+    );
+
+    syncAll(db, dir, { quiet: true });
+
+    const docs = db.prepare(`
+      SELECT doc_id, type, title, summary
+      FROM reference_docs
+      ORDER BY doc_id
+    `).all();
+    assert.equal(docs.length, 2);
+    assert.equal(docs[0].type, "continuity");
+    assert.equal(docs[1].type, "world");
+    assert.equal(docs[1].summary, "Rules of vampirism.");
+
+    const tags = db.prepare(`
+      SELECT tag
+      FROM reference_doc_tags
+      WHERE doc_id = ?
+      ORDER BY tag
+    `).all("ref-projects-test-novel-world-reference-vampirism").map(row => row.tag);
+    assert.deepEqual(tags, ["lore", "vampirism"]);
+
+    const matches = db.prepare(`
+      SELECT doc_id
+      FROM reference_docs_fts
+      WHERE reference_docs_fts MATCH 'vampirism'
+    `).all();
+    assert.equal(matches.length, 1);
+
+    db.close();
+    fs.rmSync(dir, { recursive: true });
+  });
+
+  test("prunes deleted reference docs from search tables on re-sync", () => {
+    const dir = makeTempSync();
+    const db = openDb(":memory:");
+    const refPath = path.join(dir, "projects", "test-novel", "world", "reference", "vampirism.md");
+    fs.mkdirSync(path.dirname(refPath), { recursive: true });
+    fs.writeFileSync(
+      refPath,
+      "---\ntitle: Vampirism in this universe\ntags:\n  - vampirism\n---\nReference body."
+    );
+
+    syncAll(db, dir, { quiet: true });
+    assert.equal(db.prepare(`SELECT COUNT(*) AS count FROM reference_docs`).get().count, 1);
+
+    fs.rmSync(refPath);
+    syncAll(db, dir, { quiet: true });
+
+    assert.equal(db.prepare(`SELECT COUNT(*) AS count FROM reference_docs`).get().count, 0);
+    assert.equal(db.prepare(`SELECT COUNT(*) AS count FROM reference_doc_tags`).get().count, 0);
+    assert.equal(db.prepare(`SELECT COUNT(*) AS count FROM reference_docs_fts`).get().count, 0);
 
     db.close();
     fs.rmSync(dir, { recursive: true });

--- a/src/test/unit/sync.test.mjs
+++ b/src/test/unit/sync.test.mjs
@@ -606,6 +606,28 @@ describe("syncAll", () => {
     fs.rmSync(dir, { recursive: true });
   });
 
+  test("keeps one FTS row per reference doc across repeated sync runs", () => {
+    const dir = makeTempSync();
+    const db = openDb(":memory:");
+    const refPath = path.join(dir, "projects", "test-novel", "world", "reference", "vampirism.md");
+    fs.mkdirSync(path.dirname(refPath), { recursive: true });
+    fs.writeFileSync(
+      refPath,
+      "---\ntitle: Vampirism in this universe\ntags:\n  - vampirism\n---\nReference body."
+    );
+
+    syncAll(db, dir, { quiet: true });
+    syncAll(db, dir, { quiet: true });
+
+    assert.equal(
+      db.prepare(`SELECT COUNT(*) AS count FROM reference_docs_fts WHERE doc_id = ?`).get("ref-projects-test-novel-world-reference-vampirism").count,
+      1
+    );
+
+    db.close();
+    fs.rmSync(dir, { recursive: true });
+  });
+
   test("indexes reference docs with correct project metadata from a project-root sync dir", () => {
     const syncRoot = fs.mkdtempSync(path.join(os.tmpdir(), "sync-project-root-"));
     const projectRoot = path.join(syncRoot, "projects", "project-root-novel");
@@ -691,6 +713,35 @@ describe("syncAll", () => {
 
     const scenesRoot = path.join(dir, "projects", "test-novel", "scenes");
     syncAll(db, scenesRoot, { quiet: true });
+
+    assert.equal(db.prepare(`SELECT COUNT(*) AS count FROM reference_docs`).get().count, 1);
+    assert.equal(
+      db.prepare(`SELECT COUNT(*) AS count FROM reference_docs_fts WHERE reference_docs_fts MATCH 'vampirism'`).get().count,
+      1
+    );
+
+    db.close();
+    fs.rmSync(dir, { recursive: true });
+  });
+
+  test("does not prune reference docs when sync root is a deeper scenes subtree", () => {
+    const dir = makeTempSync();
+    const db = openDb(":memory:");
+    const refPath = path.join(dir, "projects", "test-novel", "world", "reference", "vampirism.md");
+    fs.mkdirSync(path.dirname(refPath), { recursive: true });
+    fs.writeFileSync(
+      refPath,
+      "---\ntitle: Vampirism in this universe\ntags:\n  - vampirism\n---\nReference body."
+    );
+    const chapterDir = path.join(dir, "projects", "test-novel", "scenes", "chapter-1");
+    fs.mkdirSync(chapterDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(chapterDir, "sc-001.md"),
+      "---\nscene_id: sc-001\ntitle: Scene sc-001\npart: 1\nchapter: 1\npov: elena\n---\nProse content for scene sc-001."
+    );
+
+    syncAll(db, dir, { quiet: true });
+    syncAll(db, chapterDir, { quiet: true });
 
     assert.equal(db.prepare(`SELECT COUNT(*) AS count FROM reference_docs`).get().count, 1);
     assert.equal(

--- a/src/test/unit/sync.test.mjs
+++ b/src/test/unit/sync.test.mjs
@@ -597,6 +597,33 @@ describe("syncAll", () => {
     fs.rmSync(dir, { recursive: true });
   });
 
+  test("does not prune reference docs when sync root is narrowed to scenes", () => {
+    const dir = makeTempSync();
+    const db = openDb(":memory:");
+    const refPath = path.join(dir, "projects", "test-novel", "world", "reference", "vampirism.md");
+    fs.mkdirSync(path.dirname(refPath), { recursive: true });
+    fs.writeFileSync(
+      refPath,
+      "---\ntitle: Vampirism in this universe\ntags:\n  - vampirism\n---\nReference body."
+    );
+    writeScene(dir, "sc-001");
+
+    syncAll(db, dir, { quiet: true });
+    assert.equal(db.prepare(`SELECT COUNT(*) AS count FROM reference_docs`).get().count, 1);
+
+    const scenesRoot = path.join(dir, "projects", "test-novel", "scenes");
+    syncAll(db, scenesRoot, { quiet: true });
+
+    assert.equal(db.prepare(`SELECT COUNT(*) AS count FROM reference_docs`).get().count, 1);
+    assert.equal(
+      db.prepare(`SELECT COUNT(*) AS count FROM reference_docs_fts WHERE reference_docs_fts MATCH 'vampirism'`).get().count,
+      1
+    );
+
+    db.close();
+    fs.rmSync(dir, { recursive: true });
+  });
+
   test("indexes only canonical files in nested character folders", () => {
     const dir = makeTempSync();
     const db = openDb(":memory:");

--- a/src/test/unit/sync.test.mjs
+++ b/src/test/unit/sync.test.mjs
@@ -381,6 +381,10 @@ describe("reference docs", () => {
     assert.equal(isReferenceFile(syncDir, "/sync/projects/novel/world/reference/vampirism.md"), true);
   });
 
+  test("detects reference files in project-root world/reference paths", () => {
+    assert.equal(isReferenceFile("/sync/projects/novel", "/sync/projects/novel/world/reference/vampirism.md"), true);
+  });
+
   test("detects reference files in Notes paths", () => {
     assert.equal(isReferenceFile(syncDir, "/sync/projects/novel/Notes/continuity/blood.md"), true);
   });
@@ -389,6 +393,11 @@ describe("reference docs", () => {
     assert.equal(inferReferenceDocType(syncDir, "/sync/projects/novel/world/reference/vampirism.md"), "world");
     assert.equal(inferReferenceDocType(syncDir, "/sync/projects/novel/Notes/continuity/blood.md"), "continuity");
     assert.equal(inferReferenceDocType(syncDir, "/sync/projects/novel/Notes/research/boats.md"), "research");
+  });
+
+  test("infers reference doc types for project-root sync layouts", () => {
+    assert.equal(inferReferenceDocType("/sync/projects/novel", "/sync/projects/novel/world/reference/vampirism.md"), "world");
+    assert.equal(inferReferenceDocType("/sync/projects/novel", "/sync/projects/novel/Notes/continuity/blood.md"), "continuity");
   });
 
   test("derives stable doc ids from relative path when doc_id is missing", () => {
@@ -595,6 +604,45 @@ describe("syncAll", () => {
 
     db.close();
     fs.rmSync(dir, { recursive: true });
+  });
+
+  test("indexes reference docs with correct project metadata from a project-root sync dir", () => {
+    const syncRoot = fs.mkdtempSync(path.join(os.tmpdir(), "sync-project-root-"));
+    const projectRoot = path.join(syncRoot, "projects", "project-root-novel");
+    const db = openDb(":memory:");
+    fs.mkdirSync(path.join(projectRoot, "world", "reference"), { recursive: true });
+    fs.mkdirSync(path.join(projectRoot, "Notes", "continuity"), { recursive: true });
+    fs.writeFileSync(
+      path.join(projectRoot, "world", "reference", "vampirism.md"),
+      "---\ntitle: Vampirism in this universe\n---\nReference body."
+    );
+    fs.writeFileSync(
+      path.join(projectRoot, "Notes", "continuity", "blood-replacement.md"),
+      "---\ntitle: Sebastian's struggle for blood replacement\n---\nReference body."
+    );
+
+    syncAll(db, projectRoot, { quiet: true });
+
+    const docs = db.prepare(`
+      SELECT doc_id, project_id, type
+      FROM reference_docs
+      ORDER BY doc_id
+    `).all().map(row => ({ ...row }));
+    assert.deepEqual(docs, [
+      {
+        doc_id: "ref-notes-continuity-blood-replacement",
+        project_id: "project-root-novel",
+        type: "continuity",
+      },
+      {
+        doc_id: "ref-world-reference-vampirism",
+        project_id: "project-root-novel",
+        type: "world",
+      },
+    ]);
+
+    db.close();
+    fs.rmSync(syncRoot, { recursive: true });
   });
 
   test("does not prune reference docs when sync root is narrowed to scenes", () => {

--- a/src/test/unit/sync.test.mjs
+++ b/src/test/unit/sync.test.mjs
@@ -645,6 +645,36 @@ describe("syncAll", () => {
     fs.rmSync(syncRoot, { recursive: true });
   });
 
+  test("indexes universe-root reference docs with correct universe metadata", () => {
+    const syncRoot = fs.mkdtempSync(path.join(os.tmpdir(), "sync-universe-root-"));
+    const universeRoot = path.join(syncRoot, "universes", "aether");
+    const db = openDb(":memory:");
+    fs.mkdirSync(path.join(universeRoot, "world", "reference"), { recursive: true });
+    fs.writeFileSync(
+      path.join(universeRoot, "world", "reference", "vampirism.md"),
+      "---\ntitle: Vampirism in this universe\n---\nReference body."
+    );
+
+    syncAll(db, universeRoot, { quiet: true });
+
+    const docs = db.prepare(`
+      SELECT doc_id, project_id, universe_id, type
+      FROM reference_docs
+      ORDER BY doc_id
+    `).all().map(row => ({ ...row }));
+    assert.deepEqual(docs, [
+      {
+        doc_id: "ref-world-reference-vampirism",
+        project_id: null,
+        universe_id: "aether",
+        type: "world",
+      },
+    ]);
+
+    db.close();
+    fs.rmSync(syncRoot, { recursive: true });
+  });
+
   test("does not prune reference docs when sync root is narrowed to scenes", () => {
     const dir = makeTempSync();
     const db = openDb(":memory:");

--- a/src/tools/search.js
+++ b/src/tools/search.js
@@ -424,6 +424,67 @@ export function registerSearchTools(s, {
     }
   );
 
+  // ---- search_reference ----------------------------------------------------
+  s.tool(
+    "search_reference",
+    "Full-text search across indexed reference document titles, summaries, and tags. Use this to discover world-building notes, continuity references, research docs, and other reference material without loading full file contents.",
+    {
+      query: z.string().describe("Search terms (e.g. 'vampirism' or 'blood replacement'). FTS5 syntax supported."),
+      type: z.string().optional().describe("Optional reference type filter (for example: 'world', 'continuity', 'research', 'style')."),
+      tag: z.string().optional().describe("Optional exact tag filter."),
+    },
+    async ({ query, type, tag }) => {
+      let matchRows;
+      try {
+        matchRows = db.prepare(`
+          SELECT doc_id, rank
+          FROM reference_docs_fts
+          WHERE reference_docs_fts MATCH ?
+          ORDER BY rank
+        `).all(query);
+      } catch (err) {
+        return errorResponse("INVALID_QUERY", "Invalid reference search query syntax. Use plain keywords or quoted phrases.", { detail: err.message });
+      }
+
+      if (matchRows.length === 0) {
+        return errorResponse("NO_RESULTS", "No reference documents matched the search query.");
+      }
+
+      const rows = [];
+      const docStmt = db.prepare(`
+        SELECT doc_id, project_id, universe_id, type, title, summary, file_path
+        FROM reference_docs
+        WHERE doc_id = ?
+      `);
+      const tagsStmt = db.prepare(`
+        SELECT tag
+        FROM reference_doc_tags
+        WHERE doc_id = ?
+        ORDER BY tag
+      `);
+
+      for (const match of matchRows) {
+        const doc = docStmt.get(match.doc_id);
+        if (!doc) continue;
+
+        const tags = tagsStmt.all(match.doc_id).map(row => row.tag);
+        if (type && doc.type !== type) continue;
+        if (tag && !tags.includes(tag)) continue;
+
+        rows.push({
+          ...doc,
+          tags,
+        });
+      }
+
+      if (rows.length === 0) {
+        return errorResponse("NO_RESULTS", "No reference documents matched the provided filters.");
+      }
+
+      return { content: [{ type: "text", text: JSON.stringify(rows, null, 2) }] };
+    }
+  );
+
   // ---- list_threads --------------------------------------------------------
   s.tool(
     "list_threads",


### PR DESCRIPTION
## Summary

- Adds lightweight reference document indexing during `sync()` for `world/reference` and `Notes` content.
- Introduces a new `search_reference` tool for title/summary/tag discovery without loading full reference prose.
- Documents the new search surface and records the user-facing change in the release log.

## Motivation

Reference material is currently file-first and difficult to discover reliably from MCP tools. This change makes reference docs first-class searchable entities so agents can find relevant world, continuity, research, and style notes before we add explicit scene/reference linking.

## Implementation

- Extends the `reference_docs` schema with `type` and `summary`, plus a dedicated FTS table for reference search.
- Indexes reference docs in `syncAll()` from both `world/reference/**` and `Notes/**`, including inferred type, derived or explicit title, summary, tags, and stable `doc_id` fallback.
- Prunes deleted reference docs from the DB and FTS tables on re-sync so search results do not go stale.
- Adds `search_reference(query, type?, tag?)` and covers schema migration, indexing, filtering, invalid-query handling, and pruning with unit and integration tests.

## Testing

- `npm run test:unit`
- `npm run test:integration`
- `npm run lint`
- `npm run docs`

## Risks and tradeoffs

- This slice intentionally stops at indexing and search; it does not yet add scene -> reference or reference -> reference links.
- Reference type inference is path-based for now, which keeps metadata simple but may need refinement if projects adopt additional Notes subfolders.

## Follow-up

- Add explicit scene -> reference links and a `list_scene_references` tool.
- Closes #136
