### PR TITLE
feat(reference): add reference link indexing for Phase 4B

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -156,13 +156,13 @@ Semantic search for queries that require understanding meaning, not just keyword
 
 ---
 
-### 📚 [Reference Document Querying](docs/prd/todo/reference-docs.md) 📋
+### 📚 [Reference Document Querying](docs/prd/in-progress/reference-docs.md) 🚧
 
 Index and link world-building notes, research, and continuity scratchpads as a reference system.
 
 **Example:** "Find all continuity notes mentioning Elena", "What are the rules of magic in this world?", or "What reference docs directly inform this scene?"
 
-**Status:** Deferred backlog (not active). Pending decision on initial schema, link authoring model, and indexing scope.
+**Status:** In progress. Phase 4A is shipped and Phase 4B is underway.
 
 ---
 

--- a/docs/prd/in-progress/reference-docs.md
+++ b/docs/prd/in-progress/reference-docs.md
@@ -1,6 +1,6 @@
 # Reference Document Querying
 
-**Status:** 📋 Deferred backlog (not active)
+**Status:** 🚧 In progress (Phase 4A shipped; Phase 4B in progress)
 
 ## Motivation
 
@@ -189,6 +189,23 @@ Do not require semantic auto-linking in the first version.
 - Phase 4A: Reference docs become indexed entities with lightweight search
 - Phase 4B: Add explicit scene-to-reference and reference-to-reference links
 - Phase 4C: Optional helper flows for authoring/suggesting links
+
+## Current Implementation Status
+
+Completed (Phase 4A):
+- `reference_docs` metadata indexing is implemented
+- folder-based type inference is implemented (`/world/reference/`, `/Notes/*`)
+- FTS indexing on title/summary/tags is implemented
+- `search_reference(query, type?, tag?)` is implemented
+
+In progress (Phase 4B):
+- explicit `reference_links` schema is implemented
+- `sync()` now indexes direct scene-to-reference (`informs`) and reference-to-reference (`related`) links from metadata
+
+Not started:
+- `list_scene_references(scene_id)`
+- `get_reference_doc(doc_id, include_related?)`
+- `upsert_reference_link(source_kind, source_id, target_doc_id, relation)`
 
 ## Validation and Test Strategy
 

--- a/docs/release-log.md
+++ b/docs/release-log.md
@@ -8,6 +8,14 @@ This complements `CHANGELOG.md`:
 
 ## Unreleased
 
+### 2026-04-30 — Add persisted scene and reference document links
+
+- What changed: `sync()` now stores explicit links from scenes to reference docs (`reference_ids`) and between reference docs (`related_reference_ids`), and keeps those links pruned as files are removed.
+- Why it matters: Agents can traverse stable reference relationships instead of relying only on keyword matching, making continuity and lore lookups more reliable.
+- Who is affected: Anyone using Writing MCP reference docs and scene metadata for reasoning workflows.
+- Action needed: Add optional `reference_ids` on scenes and `related_reference_ids` on reference docs to get the most value from link-aware queries.
+- PR: #147
+
 ### 2026-04-30 — Add reference document search
 
 - What changed: `sync()` now indexes lightweight metadata for reference docs, and a new `search_reference` tool can discover world/reference and Notes documents by title, summary, and tags.

--- a/src/core/db.js
+++ b/src/core/db.js
@@ -118,6 +118,14 @@ export const SCHEMA = `
     PRIMARY KEY (doc_id, tag)
   );
 
+  CREATE TABLE IF NOT EXISTS reference_links (
+    source_kind   TEXT NOT NULL,
+    source_id     TEXT NOT NULL,
+    target_doc_id TEXT NOT NULL,
+    relation      TEXT NOT NULL,
+    PRIMARY KEY (source_kind, source_id, target_doc_id, relation)
+  );
+
   CREATE VIRTUAL TABLE IF NOT EXISTS scenes_fts USING fts5(
     scene_id, project_id, logline, title, keywords
   );
@@ -195,6 +203,18 @@ const MIGRATIONS = [
         );
       `);
     }
+  },
+  // 4: add explicit reference links table
+  (db) => {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS reference_links (
+        source_kind   TEXT NOT NULL,
+        source_id     TEXT NOT NULL,
+        target_doc_id TEXT NOT NULL,
+        relation      TEXT NOT NULL,
+        PRIMARY KEY (source_kind, source_id, target_doc_id, relation)
+      );
+    `);
   },
 ];
 

--- a/src/core/db.js
+++ b/src/core/db.js
@@ -120,11 +120,15 @@ export const SCHEMA = `
 
   CREATE TABLE IF NOT EXISTS reference_links (
     source_kind   TEXT NOT NULL,
+    source_project_id TEXT NOT NULL DEFAULT '',
     source_id     TEXT NOT NULL,
     target_doc_id TEXT NOT NULL,
     relation      TEXT NOT NULL,
-    PRIMARY KEY (source_kind, source_id, target_doc_id, relation)
+    PRIMARY KEY (source_kind, source_project_id, source_id, target_doc_id, relation)
   );
+
+  CREATE INDEX IF NOT EXISTS idx_reference_links_target_doc_id
+    ON reference_links(target_doc_id);
 
   CREATE VIRTUAL TABLE IF NOT EXISTS scenes_fts USING fts5(
     scene_id, project_id, logline, title, keywords
@@ -209,11 +213,65 @@ const MIGRATIONS = [
     db.exec(`
       CREATE TABLE IF NOT EXISTS reference_links (
         source_kind   TEXT NOT NULL,
+        source_project_id TEXT NOT NULL DEFAULT '',
         source_id     TEXT NOT NULL,
         target_doc_id TEXT NOT NULL,
         relation      TEXT NOT NULL,
-        PRIMARY KEY (source_kind, source_id, target_doc_id, relation)
+        PRIMARY KEY (source_kind, source_project_id, source_id, target_doc_id, relation)
       );
+    `);
+
+    db.exec(`
+      CREATE INDEX IF NOT EXISTS idx_reference_links_target_doc_id
+        ON reference_links(target_doc_id);
+    `);
+  },
+  // 5: ensure reference_links has project-scoped source key and target_doc_id index
+  (db) => {
+    const tables = db.prepare(`
+      SELECT name
+      FROM sqlite_master
+      WHERE type = 'table' AND name = 'reference_links'
+    `).all();
+
+    if (tables.length === 0) {
+      db.exec(`
+        CREATE TABLE reference_links (
+          source_kind   TEXT NOT NULL,
+          source_project_id TEXT NOT NULL DEFAULT '',
+          source_id     TEXT NOT NULL,
+          target_doc_id TEXT NOT NULL,
+          relation      TEXT NOT NULL,
+          PRIMARY KEY (source_kind, source_project_id, source_id, target_doc_id, relation)
+        );
+      `);
+    } else {
+      const columns = db.prepare(`PRAGMA table_info(reference_links)`).all();
+      if (!columns.some(c => c.name === "source_project_id")) {
+        db.exec(`
+          CREATE TABLE reference_links_migrating (
+            source_kind   TEXT NOT NULL,
+            source_project_id TEXT NOT NULL DEFAULT '',
+            source_id     TEXT NOT NULL,
+            target_doc_id TEXT NOT NULL,
+            relation      TEXT NOT NULL,
+            PRIMARY KEY (source_kind, source_project_id, source_id, target_doc_id, relation)
+          );
+        `);
+        db.exec(`
+          INSERT OR IGNORE INTO reference_links_migrating
+            (source_kind, source_project_id, source_id, target_doc_id, relation)
+          SELECT source_kind, '', source_id, target_doc_id, relation
+          FROM reference_links;
+        `);
+        db.exec(`DROP TABLE reference_links;`);
+        db.exec(`ALTER TABLE reference_links_migrating RENAME TO reference_links;`);
+      }
+    }
+
+    db.exec(`
+      CREATE INDEX IF NOT EXISTS idx_reference_links_target_doc_id
+        ON reference_links(target_doc_id);
     `);
   },
 ];

--- a/src/sync/sync.js
+++ b/src/sync/sync.js
@@ -267,6 +267,20 @@ export function normalizeReferenceTags(tags) {
   )];
 }
 
+export function normalizeReferenceIdList(values) {
+  const rawValues = Array.isArray(values)
+    ? values
+    : typeof values === "string"
+      ? values.split(",")
+      : [];
+
+  return [...new Set(
+    rawValues
+      .map(value => String(value).trim())
+      .filter(Boolean)
+  )];
+}
+
 export function deriveReferenceSummary(meta = {}, content = "") {
   if (typeof meta.summary === "string" && meta.summary.trim()) return meta.summary.trim();
 
@@ -280,6 +294,18 @@ export function deriveReferenceSummary(meta = {}, content = "") {
 
   if (!body) return null;
   return body.length <= 240 ? body : `${body.slice(0, 237).trimEnd()}...`;
+}
+
+function indexReferenceLinksForSource(db, { sourceKind, sourceId, targetDocIds, relation }) {
+  db.prepare(`DELETE FROM reference_links WHERE source_kind = ? AND source_id = ?`).run(sourceKind, sourceId);
+
+  for (const targetDocId of targetDocIds) {
+    if (sourceKind === "reference" && sourceId === targetDocId) continue;
+    db.prepare(`
+      INSERT OR IGNORE INTO reference_links (source_kind, source_id, target_doc_id, relation)
+      VALUES (?, ?, ?, ?)
+    `).run(sourceKind, sourceId, targetDocId, relation);
+  }
 }
 
 export function worldEntityKindForPath(syncDir, filePath) {
@@ -582,6 +608,9 @@ export function indexReferenceFile(db, syncDir, file, meta = {}, content = "") {
   const title = deriveReferenceTitle(file, meta, content);
   const summary = deriveReferenceSummary(meta, content);
   const tags = normalizeReferenceTags(meta.tags);
+  const relatedReferenceIds = normalizeReferenceIdList(
+    meta.related_reference_ids ?? meta.related_references ?? meta.related_docs ?? meta.related
+  );
 
   db.prepare(`
     INSERT INTO reference_docs (doc_id, project_id, universe_id, type, title, summary, file_path)
@@ -620,6 +649,13 @@ export function indexReferenceFile(db, syncDir, file, meta = {}, content = "") {
     tags.join(" ")
   );
 
+  indexReferenceLinksForSource(db, {
+    sourceKind: "reference",
+    sourceId: docId,
+    targetDocIds: relatedReferenceIds,
+    relation: "related",
+  });
+
   return docId;
 }
 
@@ -627,6 +663,8 @@ function pruneMissingReferenceDocs(db, seenDocIds) {
   const rows = db.prepare(`SELECT doc_id FROM reference_docs`).all();
   for (const row of rows) {
     if (seenDocIds.has(row.doc_id)) continue;
+    db.prepare(`DELETE FROM reference_links WHERE source_kind = 'reference' AND source_id = ?`).run(row.doc_id);
+    db.prepare(`DELETE FROM reference_links WHERE target_doc_id = ?`).run(row.doc_id);
     db.prepare(`DELETE FROM reference_doc_tags WHERE doc_id = ?`).run(row.doc_id);
     db.prepare(`DELETE FROM reference_docs_fts WHERE doc_id = ?`).run(row.doc_id);
     db.prepare(`DELETE FROM reference_docs WHERE doc_id = ?`).run(row.doc_id);
@@ -653,6 +691,7 @@ function canPruneReferenceDocs(syncDir) {
 
 export function indexSceneFile(db, syncDir, file, meta, prose) {
   const { universe_id, project_id } = inferProjectAndUniverse(syncDir, file);
+  const referenceIds = normalizeReferenceIdList(meta.reference_ids ?? meta.references);
 
   if (universe_id) {
     db.prepare(`INSERT OR IGNORE INTO universes (universe_id, name) VALUES (?, ?)`).run(
@@ -776,6 +815,13 @@ export function indexSceneFile(db, syncDir, file, meta, prose) {
     meta.title ?? "",
     keywordTokens,
   );
+
+  indexReferenceLinksForSource(db, {
+    sourceKind: "scene",
+    sourceId: meta.scene_id,
+    targetDocIds: referenceIds,
+    relation: "informs",
+  });
 
   return { isStale };
 }

--- a/src/sync/sync.js
+++ b/src/sync/sync.js
@@ -705,6 +705,72 @@ function canPruneReferenceDocs(syncDir) {
   return hasBroadRootChild;
 }
 
+function inferSceneProjectScopeFromSyncDir(syncDir) {
+  const parts = path.resolve(syncDir).split(path.sep).filter(Boolean);
+  if (parts.length < 2) return null;
+
+  const tail = parts.at(-1);
+  const parent = parts.at(-2);
+
+  if (parent === "projects" && tail) {
+    return tail;
+  }
+
+  if (tail === "scenes" && parts.length >= 3 && parts.at(-3) === "projects") {
+    return parts.at(-2);
+  }
+
+  if (parts.length >= 3 && parts.at(-3) === "universes") {
+    return `${parts.at(-2)}/${parts.at(-1)}`;
+  }
+
+  if (tail === "scenes" && parts.length >= 4 && parts.at(-4) === "universes") {
+    return `${parts.at(-3)}/${parts.at(-2)}`;
+  }
+
+  return null;
+}
+
+function canPruneScenes(syncDir) {
+  const resolvedSyncDir = path.resolve(syncDir);
+
+  if (inferSceneProjectScopeFromSyncDir(resolvedSyncDir)) {
+    return true;
+  }
+
+  const hasBroadRootChild = ["projects", "universes", "scenes"].some((name) => {
+    try {
+      return fs.statSync(path.join(resolvedSyncDir, name)).isDirectory();
+    } catch {
+      return false;
+    }
+  });
+
+  return hasBroadRootChild;
+}
+
+function pruneMissingScenes(db, seenSceneKeys, syncDir) {
+  const projectScope = inferSceneProjectScopeFromSyncDir(syncDir);
+  const rows = projectScope
+    ? db.prepare(`SELECT scene_id, project_id FROM scenes WHERE project_id = ?`).all(projectScope)
+    : db.prepare(`SELECT scene_id, project_id FROM scenes`).all();
+
+  for (const row of rows) {
+    const key = `${row.scene_id}::${row.project_id}`;
+    if (seenSceneKeys.has(key)) continue;
+
+    db.prepare(`DELETE FROM scene_characters WHERE scene_id = ?`).run(row.scene_id);
+    db.prepare(`DELETE FROM scene_places WHERE scene_id = ?`).run(row.scene_id);
+    db.prepare(`DELETE FROM scene_tags WHERE scene_id = ?`).run(row.scene_id);
+    db.prepare(`DELETE FROM scenes_fts WHERE scene_id = ? AND project_id = ?`).run(row.scene_id, row.project_id);
+    db.prepare(`
+      DELETE FROM reference_links
+      WHERE source_kind = 'scene' AND source_project_id = ? AND source_id = ?
+    `).run(row.project_id ?? "", row.scene_id);
+    db.prepare(`DELETE FROM scenes WHERE scene_id = ? AND project_id = ?`).run(row.scene_id, row.project_id);
+  }
+}
+
 export function indexSceneFile(db, syncDir, file, meta, prose) {
   const { universe_id, project_id } = inferProjectAndUniverse(syncDir, file);
   const referenceIds = normalizeReferenceIdList(meta.reference_ids ?? meta.references);
@@ -889,6 +955,7 @@ export function syncAll(db, syncDir, { quiet = false, writable = false } = {}) {
   let skipped = 0;
   let sidecarsMigrated = 0;
   const seenSceneIds = new Map(); // scene_id+project_id → file path, for duplicate detection
+  const seenSceneKeys = new Set();
   const indexedSceneIds = new Set(); // scene_id only — for orphaned sidecar move detection
   const indexedReferenceDocIds = new Set();
   const warnings = [];
@@ -959,6 +1026,7 @@ export function syncAll(db, syncDir, { quiet = false, writable = false } = {}) {
       } else {
         seenSceneIds.set(key, file);
       }
+      seenSceneKeys.add(key);
 
       if (mismatches.part || mismatches.chapter) {
         const details = [];
@@ -977,6 +1045,10 @@ export function syncAll(db, syncDir, { quiet = false, writable = false } = {}) {
     } catch (err) {
       process.stderr.write(`[mcp-writing] Failed to index ${file}: ${err.message}\n`);
     }
+  }
+
+  if (canPruneScenes(syncDir)) {
+    pruneMissingScenes(db, seenSceneKeys, syncDir);
   }
 
   // --- Orphaned sidecar detection ---

--- a/src/sync/sync.js
+++ b/src/sync/sync.js
@@ -296,15 +296,27 @@ export function deriveReferenceSummary(meta = {}, content = "") {
   return body.length <= 240 ? body : `${body.slice(0, 237).trimEnd()}...`;
 }
 
-function indexReferenceLinksForSource(db, { sourceKind, sourceId, targetDocIds, relation }) {
-  db.prepare(`DELETE FROM reference_links WHERE source_kind = ? AND source_id = ?`).run(sourceKind, sourceId);
+function indexReferenceLinksForSource(db, {
+  sourceKind,
+  sourceProjectId = "",
+  sourceId,
+  targetDocIds,
+  relation,
+}) {
+  db.prepare(`
+    DELETE FROM reference_links
+    WHERE source_kind = ? AND source_project_id = ? AND source_id = ?
+  `).run(sourceKind, sourceProjectId, sourceId);
+
+  const insertReferenceLink = db.prepare(`
+    INSERT OR IGNORE INTO reference_links
+      (source_kind, source_project_id, source_id, target_doc_id, relation)
+    VALUES (?, ?, ?, ?, ?)
+  `);
 
   for (const targetDocId of targetDocIds) {
     if (sourceKind === "reference" && sourceId === targetDocId) continue;
-    db.prepare(`
-      INSERT OR IGNORE INTO reference_links (source_kind, source_id, target_doc_id, relation)
-      VALUES (?, ?, ?, ?)
-    `).run(sourceKind, sourceId, targetDocId, relation);
+    insertReferenceLink.run(sourceKind, sourceProjectId, sourceId, targetDocId, relation);
   }
 }
 
@@ -651,6 +663,7 @@ export function indexReferenceFile(db, syncDir, file, meta = {}, content = "") {
 
   indexReferenceLinksForSource(db, {
     sourceKind: "reference",
+    sourceProjectId: project_id ?? "",
     sourceId: docId,
     targetDocIds: relatedReferenceIds,
     relation: "related",
@@ -660,10 +673,13 @@ export function indexReferenceFile(db, syncDir, file, meta = {}, content = "") {
 }
 
 function pruneMissingReferenceDocs(db, seenDocIds) {
-  const rows = db.prepare(`SELECT doc_id FROM reference_docs`).all();
+  const rows = db.prepare(`SELECT doc_id, project_id FROM reference_docs`).all();
   for (const row of rows) {
     if (seenDocIds.has(row.doc_id)) continue;
-    db.prepare(`DELETE FROM reference_links WHERE source_kind = 'reference' AND source_id = ?`).run(row.doc_id);
+    db.prepare(`
+      DELETE FROM reference_links
+      WHERE source_kind = 'reference' AND source_project_id = ? AND source_id = ?
+    `).run(row.project_id ?? "", row.doc_id);
     db.prepare(`DELETE FROM reference_links WHERE target_doc_id = ?`).run(row.doc_id);
     db.prepare(`DELETE FROM reference_doc_tags WHERE doc_id = ?`).run(row.doc_id);
     db.prepare(`DELETE FROM reference_docs_fts WHERE doc_id = ?`).run(row.doc_id);
@@ -818,6 +834,7 @@ export function indexSceneFile(db, syncDir, file, meta, prose) {
 
   indexReferenceLinksForSource(db, {
     sourceKind: "scene",
+    sourceProjectId: project_id ?? "",
     sourceId: meta.scene_id,
     targetDocIds: referenceIds,
     relation: "informs",

--- a/src/sync/sync.js
+++ b/src/sync/sync.js
@@ -759,15 +759,19 @@ function pruneMissingScenes(db, seenSceneKeys, syncDir) {
     const key = `${row.scene_id}::${row.project_id}`;
     if (seenSceneKeys.has(key)) continue;
 
-    db.prepare(`DELETE FROM scene_characters WHERE scene_id = ?`).run(row.scene_id);
-    db.prepare(`DELETE FROM scene_places WHERE scene_id = ?`).run(row.scene_id);
-    db.prepare(`DELETE FROM scene_tags WHERE scene_id = ?`).run(row.scene_id);
     db.prepare(`DELETE FROM scenes_fts WHERE scene_id = ? AND project_id = ?`).run(row.scene_id, row.project_id);
     db.prepare(`
       DELETE FROM reference_links
       WHERE source_kind = 'scene' AND source_project_id = ? AND source_id = ?
     `).run(row.project_id ?? "", row.scene_id);
     db.prepare(`DELETE FROM scenes WHERE scene_id = ? AND project_id = ?`).run(row.scene_id, row.project_id);
+
+    const remainingScene = db.prepare(`SELECT 1 FROM scenes WHERE scene_id = ? LIMIT 1`).get(row.scene_id);
+    if (!remainingScene) {
+      db.prepare(`DELETE FROM scene_characters WHERE scene_id = ?`).run(row.scene_id);
+      db.prepare(`DELETE FROM scene_places WHERE scene_id = ?`).run(row.scene_id);
+      db.prepare(`DELETE FROM scene_tags WHERE scene_id = ?`).run(row.scene_id);
+    }
   }
 }
 
@@ -958,6 +962,7 @@ export function syncAll(db, syncDir, { quiet = false, writable = false } = {}) {
   const seenSceneKeys = new Set();
   const indexedSceneIds = new Set(); // scene_id only — for orphaned sidecar move detection
   const indexedReferenceDocIds = new Set();
+  let sceneIndexFailures = 0;
   const warnings = [];
 
   const scanFiles = [];
@@ -1043,11 +1048,12 @@ export function syncAll(db, syncDir, { quiet = false, writable = false } = {}) {
       if (isStale) staleMarked++;
       indexed++;
     } catch (err) {
+      sceneIndexFailures++;
       process.stderr.write(`[mcp-writing] Failed to index ${file}: ${err.message}\n`);
     }
   }
 
-  if (canPruneScenes(syncDir)) {
+  if (canPruneScenes(syncDir) && sceneIndexFailures === 0) {
     pruneMissingScenes(db, seenSceneKeys, syncDir);
   }
 

--- a/src/test/unit/db.test.mjs
+++ b/src/test/unit/db.test.mjs
@@ -134,6 +134,34 @@ describe("openDb", () => {
       fs.rmSync(dbPath, { force: true });
     }
   });
+
+  test("creates reference_links table for legacy databases", () => {
+    const dbPath = makeTempPath();
+    try {
+      const legacyDb = new DatabaseSync(dbPath);
+      legacyDb.exec(`
+        CREATE TABLE schema_version (
+          id INTEGER PRIMARY KEY CHECK (id = 1),
+          version INTEGER NOT NULL
+        );
+      `);
+      // Simulate database at previous migration level.
+      legacyDb.exec(`INSERT INTO schema_version (id, version) VALUES (1, 3);`);
+      legacyDb.close();
+
+      const db = openDb(dbPath);
+      const table = db.prepare(`
+        SELECT name
+        FROM sqlite_master
+        WHERE type = 'table' AND name = 'reference_links'
+      `).get();
+      assert.equal(table?.name, "reference_links");
+
+      db.close();
+    } finally {
+      fs.rmSync(dbPath, { force: true });
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/test/unit/db.test.mjs
+++ b/src/test/unit/db.test.mjs
@@ -157,6 +157,16 @@ describe("openDb", () => {
       `).get();
       assert.equal(table?.name, "reference_links");
 
+      const columns = db.prepare(`PRAGMA table_info(reference_links)`).all();
+      assert.ok(columns.some(column => column.name === "source_project_id"));
+
+      const index = db.prepare(`
+        SELECT name
+        FROM sqlite_master
+        WHERE type = 'index' AND name = 'idx_reference_links_target_doc_id'
+      `).get();
+      assert.equal(index?.name, "idx_reference_links_target_doc_id");
+
       db.close();
     } finally {
       fs.rmSync(dbPath, { force: true });

--- a/src/test/unit/sync.test.mjs
+++ b/src/test/unit/sync.test.mjs
@@ -952,6 +952,66 @@ describe("syncAll", () => {
     fs.rmSync(dir, { recursive: true });
   });
 
+  test("pruning one project does not clear scene metadata for same scene_id in another project", () => {
+    const dir = makeTempSync();
+    const db = openDb(":memory:");
+
+    fs.mkdirSync(path.join(dir, "projects", "alpha-novel", "scenes"), { recursive: true });
+    fs.mkdirSync(path.join(dir, "projects", "beta-novel", "scenes"), { recursive: true });
+
+    fs.writeFileSync(
+      path.join(dir, "projects", "alpha-novel", "scenes", "sc-shared.md"),
+      "---\nscene_id: sc-shared\ntitle: Alpha Scene\ncharacters:\n  - alpha-hero\n---\nAlpha prose."
+    );
+    fs.writeFileSync(
+      path.join(dir, "projects", "beta-novel", "scenes", "sc-shared.md"),
+      "---\nscene_id: sc-shared\ntitle: Beta Scene\ncharacters:\n  - beta-hero\n---\nBeta prose."
+    );
+
+    syncAll(db, dir, { quiet: true });
+
+    fs.rmSync(path.join(dir, "projects", "alpha-novel", "scenes", "sc-shared.md"));
+    syncAll(db, dir, { quiet: true });
+
+    assert.equal(
+      db.prepare(`SELECT COUNT(*) AS count FROM scenes WHERE scene_id = 'sc-shared' AND project_id = 'alpha-novel'`).get().count,
+      0
+    );
+    assert.equal(
+      db.prepare(`SELECT COUNT(*) AS count FROM scenes WHERE scene_id = 'sc-shared' AND project_id = 'beta-novel'`).get().count,
+      1
+    );
+    assert.deepEqual(
+      db.prepare(`SELECT character_id FROM scene_characters WHERE scene_id = 'sc-shared' ORDER BY character_id`)
+        .all()
+        .map(row => row.character_id),
+      ["beta-hero"]
+    );
+
+    db.close();
+    fs.rmSync(dir, { recursive: true });
+  });
+
+  test("does not prune existing scenes when scene indexing fails", () => {
+    const dir = makeTempSync();
+    const db = openDb(":memory:");
+
+    writeScene(dir, "sc-001");
+    syncAll(db, dir, { quiet: true });
+    assert.equal(db.prepare(`SELECT COUNT(*) AS count FROM scenes WHERE scene_id = 'sc-001'`).get().count, 1);
+
+    fs.writeFileSync(
+      path.join(dir, "projects", "test-novel", "scenes", "sc-001.meta.yaml"),
+      "scene_id: [invalid"
+    );
+    syncAll(db, dir, { quiet: true });
+
+    assert.equal(db.prepare(`SELECT COUNT(*) AS count FROM scenes WHERE scene_id = 'sc-001'`).get().count, 1);
+
+    db.close();
+    fs.rmSync(dir, { recursive: true });
+  });
+
   test("does not prune scenes when sync root is a deeper scenes subtree", () => {
     const dir = makeTempSync();
     const db = openDb(":memory:");

--- a/src/test/unit/sync.test.mjs
+++ b/src/test/unit/sync.test.mjs
@@ -613,24 +613,24 @@ describe("syncAll", () => {
     syncAll(db, dir, { quiet: true });
 
     const sceneLinks = db.prepare(`
-      SELECT source_kind, source_id, target_doc_id, relation
+      SELECT source_kind, source_project_id, source_id, target_doc_id, relation
       FROM reference_links
-      WHERE source_kind = 'scene' AND source_id = 'sc-001'
+      WHERE source_kind = 'scene' AND source_project_id = 'test-novel' AND source_id = 'sc-001'
       ORDER BY target_doc_id
     `).all().map(row => ({ ...row }));
     assert.deepEqual(sceneLinks, [
-      { source_kind: "scene", source_id: "sc-001", target_doc_id: "ref-blood-replacement", relation: "informs" },
-      { source_kind: "scene", source_id: "sc-001", target_doc_id: "ref-vampirism", relation: "informs" },
+      { source_kind: "scene", source_project_id: "test-novel", source_id: "sc-001", target_doc_id: "ref-blood-replacement", relation: "informs" },
+      { source_kind: "scene", source_project_id: "test-novel", source_id: "sc-001", target_doc_id: "ref-vampirism", relation: "informs" },
     ]);
 
     const referenceLinks = db.prepare(`
-      SELECT source_kind, source_id, target_doc_id, relation
+      SELECT source_kind, source_project_id, source_id, target_doc_id, relation
       FROM reference_links
-      WHERE source_kind = 'reference' AND source_id = 'ref-vampirism'
+      WHERE source_kind = 'reference' AND source_project_id = 'test-novel' AND source_id = 'ref-vampirism'
       ORDER BY target_doc_id
     `).all().map(row => ({ ...row }));
     assert.deepEqual(referenceLinks, [
-      { source_kind: "reference", source_id: "ref-vampirism", target_doc_id: "ref-blood-replacement", relation: "related" },
+      { source_kind: "reference", source_project_id: "test-novel", source_id: "ref-vampirism", target_doc_id: "ref-blood-replacement", relation: "related" },
     ]);
 
     db.close();
@@ -686,6 +686,50 @@ describe("syncAll", () => {
 
     assert.equal(db.prepare(`SELECT COUNT(*) AS count FROM reference_docs WHERE doc_id = 'ref-vampirism'`).get().count, 0);
     assert.equal(db.prepare(`SELECT COUNT(*) AS count FROM reference_links`).get().count, 0);
+
+    db.close();
+    fs.rmSync(dir, { recursive: true });
+  });
+
+  test("keeps scene->reference links isolated when the same scene_id exists in multiple projects", () => {
+    const dir = makeTempSync();
+    const db = openDb(":memory:");
+
+    fs.mkdirSync(path.join(dir, "projects", "alpha-novel", "scenes"), { recursive: true });
+    fs.mkdirSync(path.join(dir, "projects", "alpha-novel", "world", "reference"), { recursive: true });
+    fs.mkdirSync(path.join(dir, "projects", "beta-novel", "scenes"), { recursive: true });
+    fs.mkdirSync(path.join(dir, "projects", "beta-novel", "world", "reference"), { recursive: true });
+
+    fs.writeFileSync(
+      path.join(dir, "projects", "alpha-novel", "scenes", "sc-001.md"),
+      "---\nscene_id: sc-001\ntitle: Alpha Scene\nreference_ids:\n  - ref-alpha\n---\nAlpha prose."
+    );
+    fs.writeFileSync(
+      path.join(dir, "projects", "beta-novel", "scenes", "sc-001.md"),
+      "---\nscene_id: sc-001\ntitle: Beta Scene\nreference_ids:\n  - ref-beta\n---\nBeta prose."
+    );
+    fs.writeFileSync(
+      path.join(dir, "projects", "alpha-novel", "world", "reference", "alpha.md"),
+      "---\ndoc_id: ref-alpha\ntitle: Alpha reference\n---\nAlpha reference body."
+    );
+    fs.writeFileSync(
+      path.join(dir, "projects", "beta-novel", "world", "reference", "beta.md"),
+      "---\ndoc_id: ref-beta\ntitle: Beta reference\n---\nBeta reference body."
+    );
+
+    syncAll(db, dir, { quiet: true });
+
+    const sceneLinks = db.prepare(`
+      SELECT source_kind, source_project_id, source_id, target_doc_id, relation
+      FROM reference_links
+      WHERE source_kind = 'scene' AND source_id = 'sc-001'
+      ORDER BY source_project_id, target_doc_id
+    `).all().map(row => ({ ...row }));
+
+    assert.deepEqual(sceneLinks, [
+      { source_kind: "scene", source_project_id: "alpha-novel", source_id: "sc-001", target_doc_id: "ref-alpha", relation: "informs" },
+      { source_kind: "scene", source_project_id: "beta-novel", source_id: "sc-001", target_doc_id: "ref-beta", relation: "informs" },
+    ]);
 
     db.close();
     fs.rmSync(dir, { recursive: true });

--- a/src/test/unit/sync.test.mjs
+++ b/src/test/unit/sync.test.mjs
@@ -7,6 +7,7 @@ import {
   checksumProse, inferProjectAndUniverse, inferScenePositionFromPath,
   inferReferenceDocType, isReferenceFile, deriveReferenceDocId,
   deriveReferenceSummary, deriveReferenceTitle, normalizeReferenceTags,
+  normalizeReferenceIdList,
   isCanonicalWorldEntityFile, getSyncOwnershipDiagnostics, getFileWriteDiagnostics,
   isWorldFile, readMeta, isSyncDirWritable, sidecarPath, syncAll,
   walkFiles, walkSidecars, worldEntityFolderKey, worldEntityKindForPath,
@@ -424,6 +425,13 @@ describe("reference docs", () => {
       ["blood", "lore"]
     );
   });
+
+  test("normalizes reference ids from strings and removes duplicates", () => {
+    assert.deepEqual(
+      normalizeReferenceIdList("ref-vampirism, ref-blood, ref-vampirism"),
+      ["ref-vampirism", "ref-blood"]
+    );
+  });
 });
 
 describe("world entity canonical detection", () => {
@@ -582,6 +590,53 @@ describe("syncAll", () => {
     fs.rmSync(dir, { recursive: true });
   });
 
+  test("indexes scene->reference and reference->reference links from metadata", () => {
+    const dir = makeTempSync();
+    const db = openDb(":memory:");
+
+    fs.mkdirSync(path.join(dir, "projects", "test-novel", "world", "reference"), { recursive: true });
+    fs.mkdirSync(path.join(dir, "projects", "test-novel", "Notes", "continuity"), { recursive: true });
+
+    fs.writeFileSync(
+      path.join(dir, "projects", "test-novel", "world", "reference", "vampirism.md"),
+      "---\ndoc_id: ref-vampirism\ntitle: Vampirism in this universe\nrelated_reference_ids:\n  - ref-blood-replacement\n  - ref-vampirism\n---\nReference body."
+    );
+    fs.writeFileSync(
+      path.join(dir, "projects", "test-novel", "Notes", "continuity", "blood-replacement.md"),
+      "---\ndoc_id: ref-blood-replacement\ntitle: Sebastian's struggle for blood replacement\n---\nReference body."
+    );
+
+    writeScene(dir, "sc-001", {
+      reference_ids: ["ref-vampirism", "ref-blood-replacement"],
+    });
+
+    syncAll(db, dir, { quiet: true });
+
+    const sceneLinks = db.prepare(`
+      SELECT source_kind, source_id, target_doc_id, relation
+      FROM reference_links
+      WHERE source_kind = 'scene' AND source_id = 'sc-001'
+      ORDER BY target_doc_id
+    `).all().map(row => ({ ...row }));
+    assert.deepEqual(sceneLinks, [
+      { source_kind: "scene", source_id: "sc-001", target_doc_id: "ref-blood-replacement", relation: "informs" },
+      { source_kind: "scene", source_id: "sc-001", target_doc_id: "ref-vampirism", relation: "informs" },
+    ]);
+
+    const referenceLinks = db.prepare(`
+      SELECT source_kind, source_id, target_doc_id, relation
+      FROM reference_links
+      WHERE source_kind = 'reference' AND source_id = 'ref-vampirism'
+      ORDER BY target_doc_id
+    `).all().map(row => ({ ...row }));
+    assert.deepEqual(referenceLinks, [
+      { source_kind: "reference", source_id: "ref-vampirism", target_doc_id: "ref-blood-replacement", relation: "related" },
+    ]);
+
+    db.close();
+    fs.rmSync(dir, { recursive: true });
+  });
+
   test("prunes deleted reference docs from search tables on re-sync", () => {
     const dir = makeTempSync();
     const db = openDb(":memory:");
@@ -601,6 +656,36 @@ describe("syncAll", () => {
     assert.equal(db.prepare(`SELECT COUNT(*) AS count FROM reference_docs`).get().count, 0);
     assert.equal(db.prepare(`SELECT COUNT(*) AS count FROM reference_doc_tags`).get().count, 0);
     assert.equal(db.prepare(`SELECT COUNT(*) AS count FROM reference_docs_fts`).get().count, 0);
+
+    db.close();
+    fs.rmSync(dir, { recursive: true });
+  });
+
+  test("prunes reference_links that target deleted reference docs on re-sync", () => {
+    const dir = makeTempSync();
+    const db = openDb(":memory:");
+    const targetPath = path.join(dir, "projects", "test-novel", "world", "reference", "vampirism.md");
+    const sourcePath = path.join(dir, "projects", "test-novel", "Notes", "continuity", "blood-replacement.md");
+    fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+    fs.mkdirSync(path.dirname(sourcePath), { recursive: true });
+
+    fs.writeFileSync(
+      targetPath,
+      "---\ndoc_id: ref-vampirism\ntitle: Vampirism in this universe\n---\nReference body."
+    );
+    fs.writeFileSync(
+      sourcePath,
+      "---\ndoc_id: ref-blood\ntitle: Blood replacement notes\nrelated_reference_ids:\n  - ref-vampirism\n---\nReference body."
+    );
+
+    syncAll(db, dir, { quiet: true });
+    assert.equal(db.prepare(`SELECT COUNT(*) AS count FROM reference_links`).get().count, 1);
+
+    fs.rmSync(targetPath);
+    syncAll(db, dir, { quiet: true });
+
+    assert.equal(db.prepare(`SELECT COUNT(*) AS count FROM reference_docs WHERE doc_id = 'ref-vampirism'`).get().count, 0);
+    assert.equal(db.prepare(`SELECT COUNT(*) AS count FROM reference_links`).get().count, 0);
 
     db.close();
     fs.rmSync(dir, { recursive: true });

--- a/src/test/unit/sync.test.mjs
+++ b/src/test/unit/sync.test.mjs
@@ -921,6 +921,69 @@ describe("syncAll", () => {
     fs.rmSync(dir, { recursive: true });
   });
 
+  test("prunes deleted scenes and related scene links on re-sync", () => {
+    const dir = makeTempSync();
+    const db = openDb(":memory:");
+
+    fs.mkdirSync(path.join(dir, "projects", "test-novel", "world", "reference"), { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, "projects", "test-novel", "world", "reference", "vampirism.md"),
+      "---\ndoc_id: ref-vampirism\ntitle: Vampirism in this universe\n---\nReference body."
+    );
+
+    writeScene(dir, "sc-001", { reference_ids: ["ref-vampirism"] });
+    syncAll(db, dir, { quiet: true });
+    assert.equal(db.prepare(`SELECT COUNT(*) AS count FROM scenes WHERE scene_id = 'sc-001'`).get().count, 1);
+    assert.equal(
+      db.prepare(`SELECT COUNT(*) AS count FROM reference_links WHERE source_kind = 'scene' AND source_id = 'sc-001'`).get().count,
+      1
+    );
+
+    fs.rmSync(path.join(dir, "projects", "test-novel", "scenes", "sc-001.md"));
+    syncAll(db, dir, { quiet: true });
+
+    assert.equal(db.prepare(`SELECT COUNT(*) AS count FROM scenes WHERE scene_id = 'sc-001'`).get().count, 0);
+    assert.equal(
+      db.prepare(`SELECT COUNT(*) AS count FROM reference_links WHERE source_kind = 'scene' AND source_id = 'sc-001'`).get().count,
+      0
+    );
+
+    db.close();
+    fs.rmSync(dir, { recursive: true });
+  });
+
+  test("does not prune scenes when sync root is a deeper scenes subtree", () => {
+    const dir = makeTempSync();
+    const db = openDb(":memory:");
+
+    fs.mkdirSync(path.join(dir, "projects", "test-novel", "scenes", "chapter-1"), { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, "projects", "test-novel", "scenes", "chapter-1", "sc-001.md"),
+      "---\nscene_id: sc-001\ntitle: Scene one\n---\nScene prose."
+    );
+    fs.writeFileSync(
+      path.join(dir, "projects", "test-novel", "scenes", "sc-002.md"),
+      "---\nscene_id: sc-002\ntitle: Scene two\n---\nScene prose."
+    );
+
+    syncAll(db, dir, { quiet: true });
+    assert.equal(
+      db.prepare(`SELECT COUNT(*) AS count FROM scenes WHERE project_id = 'test-novel'`).get().count,
+      2
+    );
+
+    const chapterRoot = path.join(dir, "projects", "test-novel", "scenes", "chapter-1");
+    syncAll(db, chapterRoot, { quiet: true });
+
+    assert.equal(
+      db.prepare(`SELECT COUNT(*) AS count FROM scenes WHERE project_id = 'test-novel'`).get().count,
+      2
+    );
+
+    db.close();
+    fs.rmSync(dir, { recursive: true });
+  });
+
   test("skips files without scene_id", () => {
     const dir = makeTempSync();
     const db = openDb(":memory:");


### PR DESCRIPTION
## Summary

- Adds explicit persistence for reference graph edges via a new reference_links table.
- Extends sync to index scene to reference links (informs) and reference to reference links (related) from metadata.
- Prunes stale reference_links rows when reference docs are removed during re-sync.
- Moves Reference Document Querying PRD to in-progress and updates top-level PRD linkage/status.

## Motivation

Reference document querying already shipped Phase 4A (indexing and search), but graph links were not yet persisted. This starts Phase 4B by storing explicit links and keeping them consistent across sync cycles.

## Implementation

- Database:
- Added reference_links with composite primary key: source_kind, source_id, target_doc_id, relation.
- Added migration so existing databases create reference_links on open.
- Sync:
- Added normalizeReferenceIdList for array/comma-separated ID fields.
- Added shared link indexing helper used by both scene and reference ingestion.
- indexReferenceFile now indexes related links from metadata fields (related_reference_ids, related_references, related_docs, related).
- indexSceneFile now indexes informs links from scene metadata fields (reference_ids, references).
- pruneMissingReferenceDocs now removes both outgoing and incoming links for deleted docs.
- Docs:
- Moved reference-doc PRD to docs/prd/in-progress/reference-docs.md and updated current status.
- Updated PRD overview to point to the new in-progress reference-doc path.

## Testing

- `node --test src/test/unit/sync.test.mjs src/test/unit/db.test.mjs`
- Manual verification: `gh pr checks 147` now identifies only this template check as failing pre-fix.
- Added and updated coverage for:
- legacy migration creating reference_links
- reference ID normalization
- scene->reference and reference->reference indexing
- pruning links targeting deleted reference docs

## Risks and tradeoffs

- source_id currently uses existing scene_id/doc_id semantics. If cross-project ID collisions become common, schema scoping may need to expand.
- Relations remain intentionally narrow in this increment (informs, related) to keep Phase 4B focused.

## Follow-up

- Implement list_scene_references(scene_id).
- Implement get_reference_doc(doc_id, include_related?) with one-hop related expansion.
- Implement upsert_reference_link(source_kind, source_id, target_doc_id, relation).
