### PR TITLE
feat(reference): add reference link query tools

### DIFF
--- a/docs/prd/in-progress/reference-docs.md
+++ b/docs/prd/in-progress/reference-docs.md
@@ -119,8 +119,9 @@ search_reference(query, type?, tag?)
   - returns matching reference docs by title/summary/tags
   - does not load full content
 
-list_scene_references(scene_id)
+list_scene_references(scene_id, project_id?)
   - returns direct scene -> reference links only
+  - if `scene_id` is ambiguous across projects and `project_id` is omitted, returns a conflict with candidate project IDs
 
 get_reference_doc(doc_id, include_related?)
   - returns reference metadata and optionally one hop of related references
@@ -162,7 +163,7 @@ Rules:
 - default tool responses should be shallow
 
 Default behavior:
-- `list_scene_references(scene_id)` returns only direct scene links
+- `list_scene_references(scene_id, project_id?)` returns only direct scene links
 - `get_reference_doc(doc_id, include_related=true)` returns the doc plus one hop of related references
 - no tool should recursively walk the full graph by default
 
@@ -173,7 +174,7 @@ Default behavior:
 3. Add folder-based type inference (`/world/reference/` -> type 'world', `/Notes/continuity/` -> type 'continuity')
 4. Implement lightweight FTS indexing on title, summary, and tags
 5. Implement `search_reference(query, type?, tag?)`
-6. Implement `list_scene_references(scene_id)`
+6. Implement `list_scene_references(scene_id, project_id?)`
 7. Implement `get_reference_doc(doc_id, include_related?)`
 8. Add `sync()` support for detecting and indexing reference docs and their links
 9. Optionally add authoring helpers for writing/updating links later
@@ -218,7 +219,7 @@ Unit tests:
 Integration tests:
 - `sync()` indexes reference docs and links correctly
 - `search_reference()` returns lightweight results without loading full content
-- `list_scene_references(scene_id)` returns only direct scene links
+- `list_scene_references(scene_id, project_id?)` returns only direct scene links
 - `get_reference_doc(doc_id, include_related=true)` returns one-hop related references without looping
 
 Behavioral guardrails:

--- a/docs/prd/in-progress/reference-docs.md
+++ b/docs/prd/in-progress/reference-docs.md
@@ -201,10 +201,10 @@ Completed (Phase 4A):
 In progress (Phase 4B):
 - explicit `reference_links` schema is implemented
 - `sync()` now indexes direct scene-to-reference (`informs`) and reference-to-reference (`related`) links from metadata
+- `list_scene_references(scene_id, project_id?)` is implemented with project-aware disambiguation
+- `get_reference_doc(doc_id, include_related?)` is implemented with one-hop related expansion
 
 Not started:
-- `list_scene_references(scene_id)`
-- `get_reference_doc(doc_id, include_related?)`
 - `upsert_reference_link(source_kind, source_id, target_doc_id, relation)`
 
 ## Validation and Test Strategy

--- a/docs/release-log.md
+++ b/docs/release-log.md
@@ -14,7 +14,7 @@ This complements `CHANGELOG.md`:
 - Why it matters: Agents can now move from scene context into relevant lore/continuity notes without broad keyword-only search or unbounded graph traversal.
 - Who is affected: Anyone using Writing MCP for continuity and world-reference reasoning.
 - Action needed: Optional but recommended: keep `reference_ids` on scenes and `related_reference_ids` on reference docs up to date for best results.
-- PR: #TBD
+- PR: https://github.com/hannasdev/mcp-writing/compare/main...feat/reference-links-query-tools?expand=1
 
 ### 2026-04-30 — Add persisted scene and reference document links
 

--- a/docs/release-log.md
+++ b/docs/release-log.md
@@ -8,6 +8,14 @@ This complements `CHANGELOG.md`:
 
 ## Unreleased
 
+### 2026-04-30 — Add reference link query tools for scenes and docs
+
+- What changed: Added `list_scene_references` (direct scene → reference links) and `get_reference_doc` (reference metadata with optional one-hop related docs).
+- Why it matters: Agents can now move from scene context into relevant lore/continuity notes without broad keyword-only search or unbounded graph traversal.
+- Who is affected: Anyone using Writing MCP for continuity and world-reference reasoning.
+- Action needed: Optional but recommended: keep `reference_ids` on scenes and `related_reference_ids` on reference docs up to date for best results.
+- PR: #TBD
+
 ### 2026-04-30 — Add persisted scene and reference document links
 
 - What changed: `sync()` now stores explicit links from scenes to reference docs (`reference_ids`) and between reference docs (`related_reference_ids`), and keeps those links pruned as files are removed.

--- a/docs/release-log.md
+++ b/docs/release-log.md
@@ -14,7 +14,7 @@ This complements `CHANGELOG.md`:
 - Why it matters: Agents can now move from scene context into relevant lore/continuity notes without broad keyword-only search or unbounded graph traversal.
 - Who is affected: Anyone using Writing MCP for continuity and world-reference reasoning.
 - Action needed: Optional but recommended: keep `reference_ids` on scenes and `related_reference_ids` on reference docs up to date for best results.
-- PR: https://github.com/hannasdev/mcp-writing/compare/main...feat/reference-links-query-tools?expand=1
+- PR: #148
 
 ### 2026-04-30 — Add persisted scene and reference document links
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -25,6 +25,8 @@
 - [`get_place_sheet`](#get_place_sheet)
 - [`search_metadata`](#search_metadata)
 - [`search_reference`](#search_reference)
+- [`list_scene_references`](#list_scene_references)
+- [`get_reference_doc`](#get_reference_doc)
 - [`list_threads`](#list_threads)
 - [`get_thread_arc`](#get_thread_arc)
 - [`get_relationship_arc`](#get_relationship_arc)
@@ -293,6 +295,28 @@ Full-text search across indexed reference document titles, summaries, and tags. 
 | `query` | `string` | Yes | Search terms (e.g. 'vampirism' or 'blood replacement'). FTS5 syntax supported. |
 | `type` | `string` | No | Optional reference type filter (for example: 'world', 'continuity', 'research', 'style'). |
 | `tag` | `string` | No | Optional exact tag filter. |
+
+---
+
+## list_scene_references
+
+List direct reference documents linked from a scene via metadata (for example, reference_ids). Returns only one-hop scene -> reference links and does not recursively traverse related references.
+
+| Parameter | Type | Required | Description |
+| --- | --- | :---: | --- |
+| `scene_id` | `string` | Yes | Scene ID to inspect. |
+| `project_id` | `string` | No | Optional project ID to disambiguate duplicate scene IDs across projects. |
+
+---
+
+## get_reference_doc
+
+Get metadata for a reference document by doc_id. Optionally includes exactly one hop of related reference docs.
+
+| Parameter | Type | Required | Description |
+| --- | --- | :---: | --- |
+| `doc_id` | `string` | Yes | Reference document ID. |
+| `include_related` | `boolean` | No | If true, include one-hop related reference docs. |
 
 ---
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -300,7 +300,7 @@ Full-text search across indexed reference document titles, summaries, and tags. 
 
 ## list_scene_references
 
-List direct reference documents linked from a scene via metadata (for example, reference_ids). Returns only one-hop scene -> reference links and does not recursively traverse related references.
+List direct reference documents linked from a scene via metadata (for example, reference_ids). Returns only one-hop scene -> reference links and does not recursively traverse related references. If scene IDs are reused across projects, omitting project_id returns CONFLICT with candidate project_ids.
 
 | Parameter | Type | Required | Description |
 | --- | --- | :---: | --- |

--- a/src/test/integration/search.test.mjs
+++ b/src/test/integration/search.test.mjs
@@ -318,6 +318,109 @@ describe("search_reference tool", () => {
   });
 });
 
+describe("reference link tools", () => {
+  test("list_scene_references returns direct scene -> reference links", async () => {
+    const scenePath = path.join(writeSyncDir, "projects", "test-novel", "scenes", "sc-ref-001.md");
+    const worldRefPath = path.join(writeSyncDir, "projects", "test-novel", "world", "reference", "blood-rules.md");
+    const continuityRefPath = path.join(writeSyncDir, "projects", "test-novel", "Notes", "continuity", "sebastian-blood-notes.md");
+
+    fs.mkdirSync(path.dirname(scenePath), { recursive: true });
+    fs.mkdirSync(path.dirname(worldRefPath), { recursive: true });
+    fs.mkdirSync(path.dirname(continuityRefPath), { recursive: true });
+
+    fs.writeFileSync(
+      worldRefPath,
+      "---\ndoc_id: ref-blood-rules\ntitle: Blood Rules\ntags:\n  - vampirism\n---\nReference body."
+    );
+    fs.writeFileSync(
+      continuityRefPath,
+      "---\ndoc_id: ref-sebastian-blood\ntitle: Sebastian Blood Notes\ntags:\n  - continuity\n---\nReference body."
+    );
+    fs.writeFileSync(
+      scenePath,
+      "---\nscene_id: sc-ref-001\ntitle: Reference Scene\nreference_ids:\n  - ref-blood-rules\n  - ref-sebastian-blood\n---\nScene prose."
+    );
+
+    await callWriteTool("sync");
+
+    const text = await callWriteTool("list_scene_references", {
+      scene_id: "sc-ref-001",
+      project_id: "test-novel",
+    });
+    const parsed = JSON.parse(text);
+
+    assert.equal(parsed.scene_id, "sc-ref-001");
+    assert.equal(parsed.project_id, "test-novel");
+    assert.equal(parsed.references.length, 2);
+    assert.ok(parsed.references.some(row => row.doc_id === "ref-blood-rules"));
+    assert.ok(parsed.references.some(row => row.doc_id === "ref-sebastian-blood"));
+  });
+
+  test("list_scene_references returns CONFLICT for ambiguous scene_id without project_id", async () => {
+    const alphaScenePath = path.join(writeSyncDir, "projects", "alpha-novel", "scenes", "shared.md");
+    const betaScenePath = path.join(writeSyncDir, "projects", "beta-novel", "scenes", "shared.md");
+    const alphaRefPath = path.join(writeSyncDir, "projects", "alpha-novel", "world", "reference", "alpha.md");
+    const betaRefPath = path.join(writeSyncDir, "projects", "beta-novel", "world", "reference", "beta.md");
+
+    fs.mkdirSync(path.dirname(alphaScenePath), { recursive: true });
+    fs.mkdirSync(path.dirname(betaScenePath), { recursive: true });
+    fs.mkdirSync(path.dirname(alphaRefPath), { recursive: true });
+    fs.mkdirSync(path.dirname(betaRefPath), { recursive: true });
+
+    fs.writeFileSync(alphaRefPath, "---\ndoc_id: ref-alpha\ntitle: Alpha Ref\n---\nAlpha");
+    fs.writeFileSync(betaRefPath, "---\ndoc_id: ref-beta\ntitle: Beta Ref\n---\nBeta");
+    fs.writeFileSync(
+      alphaScenePath,
+      "---\nscene_id: sc-shared-001\ntitle: Alpha Shared\nreference_ids:\n  - ref-alpha\n---\nAlpha scene prose."
+    );
+    fs.writeFileSync(
+      betaScenePath,
+      "---\nscene_id: sc-shared-001\ntitle: Beta Shared\nreference_ids:\n  - ref-beta\n---\nBeta scene prose."
+    );
+
+    await callWriteTool("sync");
+
+    const text = await callWriteTool("list_scene_references", { scene_id: "sc-shared-001" });
+    const parsed = JSON.parse(text);
+    assert.equal(parsed.ok, false);
+    assert.equal(parsed.error.code, "CONFLICT");
+    assert.ok(Array.isArray(parsed.error.details.project_ids));
+    assert.ok(parsed.error.details.project_ids.includes("alpha-novel"));
+    assert.ok(parsed.error.details.project_ids.includes("beta-novel"));
+  });
+
+  test("get_reference_doc returns metadata plus one-hop related docs", async () => {
+    const sourcePath = path.join(writeSyncDir, "projects", "test-novel", "world", "reference", "vamp-lore.md");
+    const targetPath = path.join(writeSyncDir, "projects", "test-novel", "Notes", "continuity", "vamp-history.md");
+
+    fs.mkdirSync(path.dirname(sourcePath), { recursive: true });
+    fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+
+    fs.writeFileSync(
+      sourcePath,
+      "---\ndoc_id: ref-vamp-lore\ntitle: Vamp Lore\nrelated_reference_ids:\n  - ref-vamp-history\ntags:\n  - lore\n---\nLore body."
+    );
+    fs.writeFileSync(
+      targetPath,
+      "---\ndoc_id: ref-vamp-history\ntitle: Vamp History\ntags:\n  - history\n---\nHistory body."
+    );
+
+    await callWriteTool("sync");
+
+    const text = await callWriteTool("get_reference_doc", {
+      doc_id: "ref-vamp-lore",
+      include_related: true,
+    });
+    const parsed = JSON.parse(text);
+
+    assert.equal(parsed.doc_id, "ref-vamp-lore");
+    assert.ok(parsed.tags.includes("lore"));
+    assert.equal(parsed.related.length, 1);
+    assert.equal(parsed.related[0].doc_id, "ref-vamp-history");
+    assert.ok(parsed.related[0].tags.includes("history"));
+  });
+});
+
 describe("list_threads tool", () => {
   test("returns structured empty result when none created", async () => {
     const text = await callTool("list_threads", { project_id: "test-novel" });

--- a/src/test/integration/search.test.mjs
+++ b/src/test/integration/search.test.mjs
@@ -8,20 +8,22 @@ import { createTestContext } from "../helpers/server.js";
 const ctx = createTestContext(3075, 3074);
 let writeSyncDir, readSyncDir;
 
-before(async () => {
-  await ctx.setup();
-  writeSyncDir = ctx.writeSyncDir;
-  readSyncDir = ctx.readSyncDir;
-});
+describe("search tools integration suite", { concurrency: 1 }, () => {
+  before(async () => {
+    await ctx.setup();
+    writeSyncDir = ctx.writeSyncDir;
+    readSyncDir = ctx.readSyncDir;
+  });
 
-after(async () => {
-  await ctx.teardown();
-});
+  after(async () => {
+    await ctx.teardown();
+  });
 
-const callTool = (n, a) => ctx.callTool(n, a);
-const callWriteTool = (n, a) => ctx.callWriteTool(n, a);
-const waitForAsyncJob = (id, t) => ctx.waitForAsyncJob(id, t);
-describe("find_scenes tool", () => {
+  const callTool = (n, a) => ctx.callTool(n, a);
+  const callWriteTool = (n, a) => ctx.callWriteTool(n, a);
+  const waitForAsyncJob = (id, t) => ctx.waitForAsyncJob(id, t);
+
+  describe("find_scenes tool", () => {
   test("returns all 3 scenes with no filters", async () => {
     const text = await callTool("find_scenes");
     const parsed = JSON.parse(text);
@@ -508,12 +510,13 @@ describe("upsert_thread_link tool", () => {
   });
 });
 
-describe("get_relationship_arc tool", () => {
-  test("returns no data message when no relationships exist", async () => {
-    const text = await callTool("get_relationship_arc", {
-      from_character: "elena",
-      to_character: "marcus",
+  describe("get_relationship_arc tool", () => {
+    test("returns no data message when no relationships exist", async () => {
+      const text = await callTool("get_relationship_arc", {
+        from_character: "elena",
+        to_character: "marcus",
+      });
+      assert.ok(text.toLowerCase().includes("no relationship data"));
     });
-    assert.ok(text.toLowerCase().includes("no relationship data"));
   });
 });

--- a/src/test/unit/reference-tools.test.mjs
+++ b/src/test/unit/reference-tools.test.mjs
@@ -1,0 +1,214 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { openDb } from "../../core/db.js";
+import { registerSearchTools } from "../../tools/search.js";
+
+function makeToolHarness(db) {
+  const handlers = new Map();
+  const server = {
+    tool(name, _description, _schema, handler) {
+      handlers.set(name, handler);
+    },
+  };
+
+  function errorResponse(code, message, details) {
+    return {
+      content: [{
+        type: "text",
+        text: JSON.stringify({
+          ok: false,
+          error: {
+            code,
+            message,
+            ...(details ? { details } : {}),
+          },
+        }),
+      }],
+    };
+  }
+
+  registerSearchTools(server, {
+    db,
+    SYNC_DIR: "",
+    GIT_ENABLED: false,
+    errorResponse,
+    paginateRows: ({ rows }) => ({ paginated: false, rows, meta: {} }),
+    DEFAULT_METADATA_PAGE_SIZE: 20,
+    MAX_CHAPTER_SCENES: 20,
+    getSceneProseAtCommit: () => "",
+    readSupportingNotesForEntity: () => [],
+    readEntityMetadata: () => ({}),
+  });
+
+  return {
+    async call(name, args) {
+      const handler = handlers.get(name);
+      assert.ok(handler, `Expected tool '${name}' to be registered`);
+      const result = await handler(args);
+      return JSON.parse(result.content?.[0]?.text ?? "{}");
+    },
+  };
+}
+
+function seedProject(db, projectId) {
+  db.prepare(`
+    INSERT INTO projects (project_id, universe_id, name)
+    VALUES (?, ?, ?)
+  `).run(projectId, null, projectId);
+}
+
+function seedScene(db, { sceneId, projectId }) {
+  db.prepare(`
+    INSERT INTO scenes (
+      scene_id, project_id, title, file_path, prose_checksum, metadata_stale, updated_at
+    ) VALUES (?, ?, ?, ?, ?, 0, ?)
+  `).run(sceneId, projectId, sceneId, `/tmp/${projectId}-${sceneId}.md`, "deadbeef", new Date().toISOString());
+}
+
+function seedReferenceDoc(db, { docId, projectId, title, type = "reference", summary = null }) {
+  db.prepare(`
+    INSERT INTO reference_docs (
+      doc_id, project_id, universe_id, type, title, summary, file_path
+    ) VALUES (?, ?, ?, ?, ?, ?, ?)
+  `).run(docId, projectId, null, type, title, summary, `/tmp/${projectId}-${docId}.md`);
+}
+
+function seedReferenceTag(db, { docId, tag }) {
+  db.prepare(`
+    INSERT INTO reference_doc_tags (doc_id, tag)
+    VALUES (?, ?)
+  `).run(docId, tag);
+}
+
+function seedReferenceLink(db, {
+  sourceKind,
+  sourceProjectId = "",
+  sourceId,
+  targetDocId,
+  relation,
+}) {
+  db.prepare(`
+    INSERT INTO reference_links (
+      source_kind, source_project_id, source_id, target_doc_id, relation
+    ) VALUES (?, ?, ?, ?, ?)
+  `).run(sourceKind, sourceProjectId, sourceId, targetDocId, relation);
+}
+
+describe("reference link search tools", () => {
+  test("list_scene_references returns conflict when scene_id is ambiguous across projects", async () => {
+    const db = openDb(":memory:");
+    try {
+      seedProject(db, "alpha-novel");
+      seedProject(db, "beta-novel");
+      seedScene(db, { sceneId: "sc-shared", projectId: "alpha-novel" });
+      seedScene(db, { sceneId: "sc-shared", projectId: "beta-novel" });
+
+      const tools = makeToolHarness(db);
+      const parsed = await tools.call("list_scene_references", { scene_id: "sc-shared" });
+
+      assert.equal(parsed.ok, false);
+      assert.equal(parsed.error.code, "CONFLICT");
+      assert.deepEqual(parsed.error.details.project_ids, ["alpha-novel", "beta-novel"]);
+    } finally {
+      db.close();
+    }
+  });
+
+  test("list_scene_references returns direct references with tags for scoped scene", async () => {
+    const db = openDb(":memory:");
+    try {
+      seedProject(db, "test-novel");
+      seedScene(db, { sceneId: "sc-001", projectId: "test-novel" });
+      seedReferenceDoc(db, {
+        docId: "ref-vampirism",
+        projectId: "test-novel",
+        title: "Vampirism in this universe",
+        type: "world",
+      });
+      seedReferenceTag(db, { docId: "ref-vampirism", tag: "vampirism" });
+      seedReferenceTag(db, { docId: "ref-vampirism", tag: "lore" });
+      seedReferenceLink(db, {
+        sourceKind: "scene",
+        sourceProjectId: "test-novel",
+        sourceId: "sc-001",
+        targetDocId: "ref-vampirism",
+        relation: "informs",
+      });
+
+      const tools = makeToolHarness(db);
+      const parsed = await tools.call("list_scene_references", {
+        scene_id: "sc-001",
+        project_id: "test-novel",
+      });
+
+      assert.equal(parsed.scene_id, "sc-001");
+      assert.equal(parsed.project_id, "test-novel");
+      assert.equal(parsed.references.length, 1);
+      assert.equal(parsed.references[0].doc_id, "ref-vampirism");
+      assert.deepEqual(parsed.references[0].tags, ["lore", "vampirism"]);
+    } finally {
+      db.close();
+    }
+  });
+
+  test("get_reference_doc includes one-hop related docs only when requested", async () => {
+    const db = openDb(":memory:");
+    try {
+      seedProject(db, "test-novel");
+      seedReferenceDoc(db, {
+        docId: "ref-root",
+        projectId: "test-novel",
+        title: "Root Doc",
+        type: "world",
+      });
+      seedReferenceTag(db, { docId: "ref-root", tag: "root" });
+      seedReferenceDoc(db, {
+        docId: "ref-related",
+        projectId: "test-novel",
+        title: "Related Doc",
+        type: "continuity",
+      });
+      seedReferenceTag(db, { docId: "ref-related", tag: "related" });
+      seedReferenceDoc(db, {
+        docId: "ref-deep",
+        projectId: "test-novel",
+        title: "Deep Doc",
+        type: "continuity",
+      });
+      seedReferenceTag(db, { docId: "ref-deep", tag: "deep" });
+
+      seedReferenceLink(db, {
+        sourceKind: "reference",
+        sourceProjectId: "test-novel",
+        sourceId: "ref-root",
+        targetDocId: "ref-related",
+        relation: "related",
+      });
+      // Exists in graph but should not be auto-expanded by one-hop response.
+      seedReferenceLink(db, {
+        sourceKind: "reference",
+        sourceProjectId: "test-novel",
+        sourceId: "ref-related",
+        targetDocId: "ref-deep",
+        relation: "related",
+      });
+
+      const tools = makeToolHarness(db);
+      const withoutRelated = await tools.call("get_reference_doc", { doc_id: "ref-root" });
+      assert.equal(withoutRelated.doc_id, "ref-root");
+      assert.equal(withoutRelated.related, undefined);
+
+      const withRelated = await tools.call("get_reference_doc", {
+        doc_id: "ref-root",
+        include_related: true,
+      });
+      assert.equal(withRelated.doc_id, "ref-root");
+      assert.equal(withRelated.related.length, 1);
+      assert.equal(withRelated.related[0].doc_id, "ref-related");
+      assert.deepEqual(withRelated.related[0].tags, ["related"]);
+      assert.ok(!withRelated.related.some(item => item.doc_id === "ref-deep"));
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/src/test/unit/reference-tools.test.mjs
+++ b/src/test/unit/reference-tools.test.mjs
@@ -32,7 +32,7 @@ function makeToolHarness(db) {
     SYNC_DIR: "",
     GIT_ENABLED: false,
     errorResponse,
-    paginateRows: ({ rows }) => ({ paginated: false, rows, meta: {} }),
+    paginateRows: (rows, _opts) => ({ paginated: false, rows, meta: null }),
     DEFAULT_METADATA_PAGE_SIZE: 20,
     MAX_CHAPTER_SCENES: 20,
     getSceneProseAtCommit: () => "",

--- a/src/tools/search.js
+++ b/src/tools/search.js
@@ -485,6 +485,160 @@ export function registerSearchTools(s, {
     }
   );
 
+  // ---- list_scene_references -----------------------------------------------
+  s.tool(
+    "list_scene_references",
+    "List direct reference documents linked from a scene via metadata (for example, reference_ids). Returns only one-hop scene -> reference links and does not recursively traverse related references.",
+    {
+      scene_id: z.string().describe("Scene ID to inspect."),
+      project_id: z.string().optional().describe("Optional project ID to disambiguate duplicate scene IDs across projects."),
+    },
+    async ({ scene_id, project_id }) => {
+      let scene;
+      if (project_id) {
+        scene = db.prepare(`
+          SELECT scene_id, project_id
+          FROM scenes
+          WHERE scene_id = ? AND project_id = ?
+          LIMIT 1
+        `).get(scene_id, project_id);
+        if (!scene) {
+          return errorResponse("NOT_FOUND", `Scene '${scene_id}' not found in project '${project_id}'.`);
+        }
+      } else {
+        const matches = db.prepare(`
+          SELECT scene_id, project_id
+          FROM scenes
+          WHERE scene_id = ?
+          ORDER BY project_id
+        `).all(scene_id);
+        if (matches.length === 0) {
+          return errorResponse("NOT_FOUND", `Scene '${scene_id}' not found.`);
+        }
+        if (matches.length > 1) {
+          return errorResponse(
+            "CONFLICT",
+            `Scene ID '${scene_id}' exists in multiple projects. Provide project_id to disambiguate.`,
+            { scene_id, project_ids: matches.map(row => row.project_id) }
+          );
+        }
+        scene = matches[0];
+      }
+
+      const links = db.prepare(`
+        SELECT
+          rl.target_doc_id,
+          rl.relation,
+          rd.project_id AS target_project_id,
+          rd.universe_id AS target_universe_id,
+          rd.type,
+          rd.title,
+          rd.summary,
+          rd.file_path
+        FROM reference_links rl
+        LEFT JOIN reference_docs rd ON rd.doc_id = rl.target_doc_id
+        WHERE rl.source_kind = 'scene' AND rl.source_project_id = ? AND rl.source_id = ?
+        ORDER BY rl.target_doc_id
+      `).all(scene.project_id ?? "", scene.scene_id);
+
+      if (links.length === 0) {
+        return errorResponse("NO_RESULTS", `No reference links found for scene '${scene.scene_id}' in project '${scene.project_id}'.`);
+      }
+
+      const tagsStmt = db.prepare(`
+        SELECT tag
+        FROM reference_doc_tags
+        WHERE doc_id = ?
+        ORDER BY tag
+      `);
+      const references = links.map((row) => ({
+        doc_id: row.target_doc_id,
+        relation: row.relation,
+        project_id: row.target_project_id,
+        universe_id: row.target_universe_id,
+        type: row.type,
+        title: row.title,
+        summary: row.summary,
+        file_path: row.file_path,
+        tags: tagsStmt.all(row.target_doc_id).map(tagRow => tagRow.tag),
+      }));
+
+      return {
+        content: [{
+          type: "text",
+          text: JSON.stringify({
+            scene_id: scene.scene_id,
+            project_id: scene.project_id,
+            references,
+          }, null, 2),
+        }],
+      };
+    }
+  );
+
+  // ---- get_reference_doc ----------------------------------------------------
+  s.tool(
+    "get_reference_doc",
+    "Get metadata for a reference document by doc_id. Optionally includes exactly one hop of related reference docs.",
+    {
+      doc_id: z.string().describe("Reference document ID."),
+      include_related: z.boolean().optional().describe("If true, include one-hop related reference docs."),
+    },
+    async ({ doc_id, include_related = false }) => {
+      const doc = db.prepare(`
+        SELECT doc_id, project_id, universe_id, type, title, summary, file_path
+        FROM reference_docs
+        WHERE doc_id = ?
+      `).get(doc_id);
+      if (!doc) {
+        return errorResponse("NOT_FOUND", `Reference document '${doc_id}' not found.`);
+      }
+
+      const tagsStmt = db.prepare(`
+        SELECT tag
+        FROM reference_doc_tags
+        WHERE doc_id = ?
+        ORDER BY tag
+      `);
+      const payload = {
+        ...doc,
+        tags: tagsStmt.all(doc.doc_id).map(row => row.tag),
+      };
+
+      if (include_related) {
+        const relatedRows = db.prepare(`
+          SELECT
+            rl.target_doc_id,
+            rl.relation,
+            rd.project_id,
+            rd.universe_id,
+            rd.type,
+            rd.title,
+            rd.summary,
+            rd.file_path
+          FROM reference_links rl
+          LEFT JOIN reference_docs rd ON rd.doc_id = rl.target_doc_id
+          WHERE rl.source_kind = 'reference' AND rl.source_project_id = ? AND rl.source_id = ?
+          ORDER BY rl.target_doc_id
+        `).all(doc.project_id ?? "", doc.doc_id);
+
+        payload.related = relatedRows.map((row) => ({
+          doc_id: row.target_doc_id,
+          relation: row.relation,
+          project_id: row.project_id,
+          universe_id: row.universe_id,
+          type: row.type,
+          title: row.title,
+          summary: row.summary,
+          file_path: row.file_path,
+          tags: tagsStmt.all(row.target_doc_id).map(tagRow => tagRow.tag),
+        }));
+      }
+
+      return { content: [{ type: "text", text: JSON.stringify(payload, null, 2) }] };
+    }
+  );
+
   // ---- list_threads --------------------------------------------------------
   s.tool(
     "list_threads",

--- a/src/tools/search.js
+++ b/src/tools/search.js
@@ -488,7 +488,7 @@ export function registerSearchTools(s, {
   // ---- list_scene_references -----------------------------------------------
   s.tool(
     "list_scene_references",
-    "List direct reference documents linked from a scene via metadata (for example, reference_ids). Returns only one-hop scene -> reference links and does not recursively traverse related references.",
+    "List direct reference documents linked from a scene via metadata (for example, reference_ids). Returns only one-hop scene -> reference links and does not recursively traverse related references. If scene IDs are reused across projects, omitting project_id returns CONFLICT with candidate project_ids.",
     {
       scene_id: z.string().describe("Scene ID to inspect."),
       project_id: z.string().optional().describe("Optional project ID to disambiguate duplicate scene IDs across projects."),


### PR DESCRIPTION
## Summary

- Adds `list_scene_references` for direct scene -> reference link retrieval.
- Adds `get_reference_doc` with optional one-hop related reference expansion.
- Adds integration coverage for both tools and a dedicated unit test file for reference-link tool behavior.
- Updates reference PRD status and generated tool docs.

## Motivation

Phase 4B needed read/query APIs on top of persisted `reference_links` so agents can move from scene context to relevant reference docs without unbounded traversal or keyword-only workflows.

## Implementation

- Implemented `list_scene_references(scene_id, project_id?)` with project-aware disambiguation:
  - returns `CONFLICT` when `scene_id` is ambiguous and `project_id` is omitted.
  - returns only direct scene-linked references (no recursive traversal).
- Implemented `get_reference_doc(doc_id, include_related?)`:
  - always returns doc metadata + tags.
  - when `include_related=true`, returns one-hop `reference -> reference` links only.
- Added tests:
  - integration: happy-path + ambiguity + related expansion.
  - unit: dedicated handler behavior tests for conflict handling, scoped scene links, and one-hop related behavior.
- Updated `docs/prd/in-progress/reference-docs.md` and regenerated `docs/tools.md`.

## Testing

- `npm run lint`
- `npm run test:unit`
- `node --experimental-sqlite --test --test-concurrency=1 src/test/integration/search.test.mjs`
- `npm run docs`

## Risks and tradeoffs

- `list_scene_references` now requires `project_id` when `scene_id` collides across projects; this is intentional to avoid ambiguous results.
- `get_reference_doc(include_related=true)` is intentionally shallow (one hop) to avoid loop/traversal complexity in this slice.

## Follow-up

- Add `upsert_reference_link(source_kind, source_id, target_doc_id, relation)` for authoring/edit workflows.
