### PR TITLE
feat(reference): persist explicit links to source metadata

### DIFF
--- a/src/sync/sync.js
+++ b/src/sync/sync.js
@@ -281,6 +281,49 @@ export function normalizeReferenceIdList(values) {
   )];
 }
 
+function normalizeReferenceRelation(value, fallbackRelation) {
+  const normalized = String(value ?? fallbackRelation ?? "").trim().toLowerCase();
+  if (/^[a-z][a-z0-9_-]*$/.test(normalized)) return normalized;
+  return String(fallbackRelation ?? "related").trim().toLowerCase();
+}
+
+export function normalizeReferenceLinkList(values, { defaultRelation = "related" } = {}) {
+  const rawValues = Array.isArray(values)
+    ? values
+    : typeof values === "string"
+      ? values.split(",")
+      : [];
+
+  const links = [];
+  for (const value of rawValues) {
+    if (typeof value === "string") {
+      const targetDocId = value.trim();
+      if (!targetDocId) continue;
+      links.push({ targetDocId, relation: normalizeReferenceRelation(defaultRelation, defaultRelation) });
+      continue;
+    }
+
+    if (!value || typeof value !== "object") continue;
+    const targetDocId = String(value.target_doc_id ?? value.doc_id ?? value.id ?? "").trim();
+    if (!targetDocId) continue;
+    links.push({
+      targetDocId,
+      relation: normalizeReferenceRelation(value.relation, defaultRelation),
+    });
+  }
+
+  const deduped = [];
+  const seen = new Set();
+  for (const link of links) {
+    const key = `${link.targetDocId}::${link.relation}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(link);
+  }
+
+  return deduped;
+}
+
 export function deriveReferenceSummary(meta = {}, content = "") {
   if (typeof meta.summary === "string" && meta.summary.trim()) return meta.summary.trim();
 
@@ -338,6 +381,59 @@ function indexReferenceLinksForSource(db, {
       targetDocId
     );
   }
+}
+
+function indexExplicitReferenceLinksForSource(db, {
+  sourceKind,
+  sourceProjectId = "",
+  sourceId,
+  links,
+  defaultRelation,
+}) {
+  db.prepare(`
+    DELETE FROM reference_links
+    WHERE source_kind = ? AND source_project_id = ? AND source_id = ? AND origin = 'explicit'
+  `).run(sourceKind, sourceProjectId, sourceId);
+
+  const insertReferenceLink = db.prepare(`
+    INSERT OR IGNORE INTO reference_links (
+      source_kind, source_project_id, source_id, target_doc_id, relation, origin
+    ) VALUES (?, ?, ?, ?, ?, 'explicit')
+  `);
+
+  for (const link of links) {
+    if (sourceKind === "reference" && sourceId === link.targetDocId) continue;
+    insertReferenceLink.run(
+      sourceKind,
+      sourceProjectId,
+      sourceId,
+      link.targetDocId,
+      normalizeReferenceRelation(link.relation, defaultRelation)
+    );
+  }
+}
+
+function collectExplicitReferenceLinks(meta, fields, { defaultRelation }) {
+  const hasField = fields.some((field) => Object.prototype.hasOwnProperty.call(meta, field));
+  if (!hasField) {
+    return { hasField: false, links: [] };
+  }
+
+  const rawValues = [];
+  for (const field of fields) {
+    if (!Object.prototype.hasOwnProperty.call(meta, field)) continue;
+    const value = meta[field];
+    if (Array.isArray(value)) {
+      rawValues.push(...value);
+    } else if (value !== undefined && value !== null) {
+      rawValues.push(value);
+    }
+  }
+
+  return {
+    hasField: true,
+    links: normalizeReferenceLinkList(rawValues, { defaultRelation }),
+  };
 }
 
 export function worldEntityKindForPath(syncDir, filePath) {
@@ -643,6 +739,11 @@ export function indexReferenceFile(db, syncDir, file, meta = {}, content = "") {
   const relatedReferenceIds = normalizeReferenceIdList(
     meta.related_reference_ids ?? meta.related_references ?? meta.related_docs ?? meta.related
   );
+  const explicitReferenceLinks = collectExplicitReferenceLinks(
+    meta,
+    ["reference_links", "related_reference_links", "explicit_reference_links"],
+    { defaultRelation: "related" }
+  );
 
   db.prepare(`
     INSERT INTO reference_docs (doc_id, project_id, universe_id, type, title, summary, file_path)
@@ -688,6 +789,16 @@ export function indexReferenceFile(db, syncDir, file, meta = {}, content = "") {
     targetDocIds: relatedReferenceIds,
     relation: "related",
   });
+
+  if (explicitReferenceLinks.hasField) {
+    indexExplicitReferenceLinksForSource(db, {
+      sourceKind: "reference",
+      sourceProjectId: project_id ?? "",
+      sourceId: docId,
+      links: explicitReferenceLinks.links,
+      defaultRelation: "related",
+    });
+  }
 
   return docId;
 }
@@ -798,6 +909,11 @@ function pruneMissingScenes(db, seenSceneKeys, syncDir) {
 export function indexSceneFile(db, syncDir, file, meta, prose) {
   const { universe_id, project_id } = inferProjectAndUniverse(syncDir, file);
   const referenceIds = normalizeReferenceIdList(meta.reference_ids ?? meta.references);
+  const explicitSceneLinks = collectExplicitReferenceLinks(
+    meta,
+    ["reference_links", "explicit_reference_links"],
+    { defaultRelation: "informs" }
+  );
 
   if (universe_id) {
     db.prepare(`INSERT OR IGNORE INTO universes (universe_id, name) VALUES (?, ?)`).run(
@@ -929,6 +1045,16 @@ export function indexSceneFile(db, syncDir, file, meta, prose) {
     targetDocIds: referenceIds,
     relation: "informs",
   });
+
+  if (explicitSceneLinks.hasField) {
+    indexExplicitReferenceLinksForSource(db, {
+      sourceKind: "scene",
+      sourceProjectId: project_id ?? "",
+      sourceId: meta.scene_id,
+      links: explicitSceneLinks.links,
+      defaultRelation: "informs",
+    });
+  }
 
   return { isStale };
 }

--- a/src/sync/sync.js
+++ b/src/sync/sync.js
@@ -297,9 +297,10 @@ export function normalizeReferenceLinkList(values, { defaultRelation = "related"
   const links = [];
   for (const value of rawValues) {
     if (typeof value === "string") {
-      const targetDocId = value.trim();
-      if (!targetDocId) continue;
-      links.push({ targetDocId, relation: normalizeReferenceRelation(defaultRelation, defaultRelation) });
+      const parts = value.split(",").map((part) => part.trim()).filter(Boolean);
+      for (const targetDocId of parts) {
+        links.push({ targetDocId, relation: normalizeReferenceRelation(defaultRelation, defaultRelation) });
+      }
       continue;
     }
 
@@ -782,14 +783,6 @@ export function indexReferenceFile(db, syncDir, file, meta = {}, content = "") {
     tags.join(" ")
   );
 
-  indexReferenceLinksForSource(db, {
-    sourceKind: "reference",
-    sourceProjectId: project_id ?? "",
-    sourceId: docId,
-    targetDocIds: relatedReferenceIds,
-    relation: "related",
-  });
-
   if (explicitReferenceLinks.hasField) {
     indexExplicitReferenceLinksForSource(db, {
       sourceKind: "reference",
@@ -799,6 +792,14 @@ export function indexReferenceFile(db, syncDir, file, meta = {}, content = "") {
       defaultRelation: "related",
     });
   }
+
+  indexReferenceLinksForSource(db, {
+    sourceKind: "reference",
+    sourceProjectId: project_id ?? "",
+    sourceId: docId,
+    targetDocIds: relatedReferenceIds,
+    relation: "related",
+  });
 
   return docId;
 }
@@ -1038,14 +1039,6 @@ export function indexSceneFile(db, syncDir, file, meta, prose) {
     keywordTokens,
   );
 
-  indexReferenceLinksForSource(db, {
-    sourceKind: "scene",
-    sourceProjectId: project_id ?? "",
-    sourceId: meta.scene_id,
-    targetDocIds: referenceIds,
-    relation: "informs",
-  });
-
   if (explicitSceneLinks.hasField) {
     indexExplicitReferenceLinksForSource(db, {
       sourceKind: "scene",
@@ -1055,6 +1048,14 @@ export function indexSceneFile(db, syncDir, file, meta, prose) {
       defaultRelation: "informs",
     });
   }
+
+  indexReferenceLinksForSource(db, {
+    sourceKind: "scene",
+    sourceProjectId: project_id ?? "",
+    sourceId: meta.scene_id,
+    targetDocIds: referenceIds,
+    relation: "informs",
+  });
 
   return { isStale };
 }

--- a/src/test/integration/search.test.mjs
+++ b/src/test/integration/search.test.mjs
@@ -544,6 +544,11 @@ describe("upsert_reference_link tool", () => {
     assert.equal(parsed.link.source_id, "sc-upsert-ref-001");
     assert.equal(parsed.link.target_doc_id, "ref-upsert-target");
     assert.equal(parsed.link.relation, "informs");
+
+    const sidecarText = fs.readFileSync(scenePath.replace(/\.md$/, ".meta.yaml"), "utf8");
+    assert.ok(sidecarText.includes("reference_links:"));
+    assert.ok(sidecarText.includes("target_doc_id: ref-upsert-target"));
+    assert.ok(sidecarText.includes("relation: informs"));
   });
 
   test("updates existing relation for same source and target", async () => {
@@ -649,6 +654,11 @@ describe("upsert_reference_link tool", () => {
     assert.equal(referenceDoc.related.length, 1);
     assert.equal(referenceDoc.related[0].doc_id, "ref-upsert-target-2");
     assert.equal(referenceDoc.related[0].relation, "history_of");
+
+    const sourceRefFrontmatter = fs.readFileSync(sourceRefPath, "utf8");
+    assert.ok(sourceRefFrontmatter.includes("reference_links:"));
+    assert.ok(sourceRefFrontmatter.includes("target_doc_id: ref-upsert-target-2"));
+    assert.ok(sourceRefFrontmatter.includes("relation: history_of"));
   });
 
   test("returns conflict for reference source with mismatched source_project_id", async () => {

--- a/src/test/integration/search.test.mjs
+++ b/src/test/integration/search.test.mjs
@@ -661,6 +661,39 @@ describe("upsert_reference_link tool", () => {
     assert.ok(sourceRefFrontmatter.includes("relation: history_of"));
   });
 
+  test("canonicalizes legacy explicit link fields on reference upsert", async () => {
+    const sourceRefPath = path.join(writeSyncDir, "projects", "test-novel", "world", "reference", "ref-upsert-source.md");
+    fs.writeFileSync(
+      sourceRefPath,
+      "---\ndoc_id: ref-upsert-source\ntitle: Upsert Source\nrelated_reference_links:\n  - target_doc_id: ref-upsert-target-2\n    relation: see_also\nexplicit_reference_links:\n  - target_doc_id: ref-upsert-target-2\n    relation: depends_on\n---\nSource body."
+    );
+    await callWriteTool("sync");
+
+    const updatedText = await callWriteTool("upsert_reference_link", {
+      source_kind: "reference",
+      source_id: "ref-upsert-source",
+      source_project_id: "test-novel",
+      target_doc_id: "ref-upsert-target-2",
+      relation: "related",
+    });
+    const updated = JSON.parse(updatedText);
+    assert.equal(updated.ok, true);
+
+    const canonicalFrontmatter = fs.readFileSync(sourceRefPath, "utf8");
+    assert.ok(canonicalFrontmatter.includes("reference_links:"));
+    assert.ok(!canonicalFrontmatter.includes("related_reference_links:"));
+    assert.ok(!canonicalFrontmatter.includes("explicit_reference_links:"));
+
+    const referenceDocText = await callWriteTool("get_reference_doc", {
+      doc_id: "ref-upsert-source",
+      include_related: true,
+    });
+    const referenceDoc = JSON.parse(referenceDocText);
+    const targetRows = referenceDoc.related.filter((row) => row.doc_id === "ref-upsert-target-2");
+    assert.equal(targetRows.length, 1);
+    assert.equal(targetRows[0].relation, "related");
+  });
+
   test("returns conflict for reference source with mismatched source_project_id", async () => {
     const text = await callWriteTool("upsert_reference_link", {
       source_kind: "reference",

--- a/src/test/unit/metadata-tools.test.mjs
+++ b/src/test/unit/metadata-tools.test.mjs
@@ -1,5 +1,6 @@
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs";
 import { openDb } from "../../core/db.js";
 import { registerMetadataTools } from "../../tools/metadata.js";
 
@@ -55,19 +56,31 @@ function seedProject(db, projectId) {
 }
 
 function seedScene(db, { sceneId, projectId }) {
+  const scenePath = `/tmp/${projectId}-${sceneId}.md`;
+  fs.writeFileSync(
+    scenePath,
+    `---\nscene_id: ${sceneId}\ntitle: ${sceneId}\n---\nScene prose.`,
+    "utf8"
+  );
   db.prepare(`
     INSERT INTO scenes (
       scene_id, project_id, title, file_path, prose_checksum, metadata_stale, updated_at
     ) VALUES (?, ?, ?, ?, ?, 0, ?)
-  `).run(sceneId, projectId, sceneId, `/tmp/${projectId}-${sceneId}.md`, "deadbeef", new Date().toISOString());
+  `).run(sceneId, projectId, sceneId, scenePath, "deadbeef", new Date().toISOString());
 }
 
 function seedReferenceDoc(db, { docId, projectId, title }) {
+  const referencePath = `/tmp/${projectId ?? "global"}-${docId}.md`;
+  fs.writeFileSync(
+    referencePath,
+    `---\ndoc_id: ${docId}\ntitle: ${title}\n---\nReference body.`,
+    "utf8"
+  );
   db.prepare(`
     INSERT INTO reference_docs (
       doc_id, project_id, universe_id, type, title, summary, file_path
     ) VALUES (?, ?, ?, ?, ?, ?, ?)
-  `).run(docId, projectId, null, "world", title, null, `/tmp/${projectId}-${docId}.md`);
+  `).run(docId, projectId, null, "world", title, null, referencePath);
 }
 
 describe("metadata upsert_reference_link tool", () => {

--- a/src/test/unit/metadata-tools.test.mjs
+++ b/src/test/unit/metadata-tools.test.mjs
@@ -1,8 +1,17 @@
-import { describe, test } from "node:test";
+import { after, describe, test } from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { openDb } from "../../core/db.js";
 import { registerMetadataTools } from "../../tools/metadata.js";
+
+const SEED_TMP_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "mcp-writing-metadata-tools-"));
+let seedCounter = 0;
+
+after(() => {
+  fs.rmSync(SEED_TMP_DIR, { recursive: true, force: true });
+});
 
 function makeToolHarness(db, { writable = true } = {}) {
   const handlers = new Map();
@@ -56,7 +65,8 @@ function seedProject(db, projectId) {
 }
 
 function seedScene(db, { sceneId, projectId }) {
-  const scenePath = `/tmp/${projectId}-${sceneId}.md`;
+  seedCounter += 1;
+  const scenePath = path.join(SEED_TMP_DIR, `${projectId}-${sceneId}-${seedCounter}.md`);
   fs.writeFileSync(
     scenePath,
     `---\nscene_id: ${sceneId}\ntitle: ${sceneId}\n---\nScene prose.`,
@@ -70,7 +80,8 @@ function seedScene(db, { sceneId, projectId }) {
 }
 
 function seedReferenceDoc(db, { docId, projectId, title }) {
-  const referencePath = `/tmp/${projectId ?? "global"}-${docId}.md`;
+  seedCounter += 1;
+  const referencePath = path.join(SEED_TMP_DIR, `${projectId ?? "global"}-${docId}-${seedCounter}.md`);
   fs.writeFileSync(
     referencePath,
     `---\ndoc_id: ${docId}\ntitle: ${title}\n---\nReference body.`,

--- a/src/test/unit/sync.test.mjs
+++ b/src/test/unit/sync.test.mjs
@@ -735,7 +735,7 @@ describe("syncAll", () => {
     fs.rmSync(dir, { recursive: true });
   });
 
-  test("preserves explicit reference links across sync and skips inferred overwrite for same target", () => {
+  test("indexes explicit links from metadata fields and skips inferred overwrite for the same target", () => {
     const dir = makeTempSync();
     const db = openDb(":memory:");
 
@@ -744,7 +744,7 @@ describe("syncAll", () => {
 
     fs.writeFileSync(
       path.join(dir, "projects", "test-novel", "scenes", "sc-001.md"),
-      "---\nscene_id: sc-001\ntitle: Scene\ntags: [test]\nreference_ids:\n  - ref-vamp\n---\nScene prose."
+      "---\nscene_id: sc-001\ntitle: Scene\ntags: [test]\nreference_ids:\n  - ref-vamp\nreference_links:\n  - target_doc_id: ref-vamp\n    relation: see_also\n---\nScene prose."
     );
     fs.writeFileSync(
       path.join(dir, "projects", "test-novel", "world", "reference", "vamp.md"),
@@ -752,17 +752,6 @@ describe("syncAll", () => {
     );
 
     syncAll(db, dir, { quiet: true });
-
-    db.prepare(`
-      DELETE FROM reference_links
-      WHERE source_kind = 'scene' AND source_project_id = 'test-novel' AND source_id = 'sc-001' AND target_doc_id = 'ref-vamp'
-    `).run();
-    db.prepare(`
-      INSERT INTO reference_links (
-        source_kind, source_project_id, source_id, target_doc_id, relation, origin
-      ) VALUES (?, ?, ?, ?, ?, ?)
-    `).run("scene", "test-novel", "sc-001", "ref-vamp", "see_also", "explicit");
-
     syncAll(db, dir, { quiet: true });
 
     const links = db.prepare(`
@@ -776,6 +765,70 @@ describe("syncAll", () => {
     ]);
 
     db.close();
+    fs.rmSync(dir, { recursive: true });
+  });
+
+  test("rebuilds explicit links from source metadata after DB reset", () => {
+    const dir = makeTempSync();
+    const scenePath = path.join(dir, "projects", "test-novel", "scenes", "sc-001.md");
+    const sourceRefPath = path.join(dir, "projects", "test-novel", "world", "reference", "source.md");
+    const targetRefPath = path.join(dir, "projects", "test-novel", "world", "reference", "target.md");
+
+    fs.mkdirSync(path.dirname(scenePath), { recursive: true });
+    fs.mkdirSync(path.dirname(sourceRefPath), { recursive: true });
+
+    fs.writeFileSync(
+      scenePath,
+      "---\nscene_id: sc-001\ntitle: Scene\nreference_links:\n  - target_doc_id: ref-target\n    relation: history_of\n---\nScene prose."
+    );
+    fs.writeFileSync(
+      sourceRefPath,
+      "---\ndoc_id: ref-source\ntitle: Source\nreference_links:\n  - target_doc_id: ref-target\n    relation: depends_on\n---\nSource body."
+    );
+    fs.writeFileSync(
+      targetRefPath,
+      "---\ndoc_id: ref-target\ntitle: Target\n---\nTarget body."
+    );
+
+    const db1 = openDb(":memory:");
+    syncAll(db1, dir, { quiet: true });
+
+    const linksAfterFirstSync = db1.prepare(`
+      SELECT source_kind, source_project_id, source_id, target_doc_id, relation, origin
+      FROM reference_links
+      ORDER BY source_kind, source_id, relation
+    `).all().map(row => ({ ...row }));
+    assert.deepEqual(linksAfterFirstSync, [
+      {
+        source_kind: "reference",
+        source_project_id: "test-novel",
+        source_id: "ref-source",
+        target_doc_id: "ref-target",
+        relation: "depends_on",
+        origin: "explicit",
+      },
+      {
+        source_kind: "scene",
+        source_project_id: "test-novel",
+        source_id: "sc-001",
+        target_doc_id: "ref-target",
+        relation: "history_of",
+        origin: "explicit",
+      },
+    ]);
+    db1.close();
+
+    const db2 = openDb(":memory:");
+    syncAll(db2, dir, { quiet: true });
+
+    const linksAfterRebuild = db2.prepare(`
+      SELECT source_kind, source_project_id, source_id, target_doc_id, relation, origin
+      FROM reference_links
+      ORDER BY source_kind, source_id, relation
+    `).all().map(row => ({ ...row }));
+    assert.deepEqual(linksAfterRebuild, linksAfterFirstSync);
+
+    db2.close();
     fs.rmSync(dir, { recursive: true });
   });
 

--- a/src/test/unit/sync.test.mjs
+++ b/src/test/unit/sync.test.mjs
@@ -768,6 +768,35 @@ describe("syncAll", () => {
     fs.rmSync(dir, { recursive: true });
   });
 
+  test("single sync pass prefers explicit relation when inferred and explicit target overlap", () => {
+    const dir = makeTempSync();
+    const db = openDb(":memory:");
+
+    fs.mkdirSync(path.join(dir, "projects", "test-novel", "scenes"), { recursive: true });
+    fs.mkdirSync(path.join(dir, "projects", "test-novel", "world", "reference"), { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, "projects", "test-novel", "world", "reference", "vamp.md"),
+      "---\ndoc_id: ref-vamp\ntitle: Vamp\nrelated_reference_ids:\n  - ref-vamp\nreference_links:\n  - target_doc_id: ref-vamp\n    relation: history_of\n---\nReference body."
+    );
+    fs.writeFileSync(
+      path.join(dir, "projects", "test-novel", "scenes", "sc-001.md"),
+      "---\nscene_id: sc-001\ntitle: Scene\nreference_ids:\n  - ref-vamp\nreference_links:\n  - target_doc_id: ref-vamp\n    relation: see_also\n---\nScene prose."
+    );
+
+    syncAll(db, dir, { quiet: true });
+
+    const sceneLinks = db.prepare(`
+      SELECT relation, origin
+      FROM reference_links
+      WHERE source_kind = 'scene' AND source_project_id = 'test-novel' AND source_id = 'sc-001' AND target_doc_id = 'ref-vamp'
+      ORDER BY relation
+    `).all().map((row) => ({ ...row }));
+    assert.deepEqual(sceneLinks, [{ relation: "see_also", origin: "explicit" }]);
+
+    db.close();
+    fs.rmSync(dir, { recursive: true });
+  });
+
   test("rebuilds explicit links from source metadata after DB reset", () => {
     const dir = makeTempSync();
     const scenePath = path.join(dir, "projects", "test-novel", "scenes", "sc-001.md");

--- a/src/tools/metadata.js
+++ b/src/tools/metadata.js
@@ -4,8 +4,8 @@ import matter from "gray-matter";
 import { readMeta, writeMeta, indexSceneFile, normalizeSceneMetaForPath, normalizeReferenceLinkList } from "../sync/sync.js";
 import { validateProjectId, validateUniverseId } from "../sync/importer.js";
 
-function upsertSerializedReferenceLinks(existing, targetDocId, relation) {
-  const normalized = normalizeReferenceLinkList(existing ?? [], { defaultRelation: "related" });
+function upsertSerializedReferenceLinks(existing, targetDocId, relation, { defaultRelation }) {
+  const normalized = normalizeReferenceLinkList(existing ?? [], { defaultRelation });
   const filtered = normalized.filter((entry) => entry.targetDocId !== targetDocId);
   filtered.push({ targetDocId, relation });
   return filtered.map((entry) => ({
@@ -16,13 +16,19 @@ function upsertSerializedReferenceLinks(existing, targetDocId, relation) {
 
 function persistSceneReferenceLink({ scenePath, syncDir, targetDocId, relation }) {
   const { meta } = readMeta(scenePath, syncDir, { writable: true });
-  const existingExplicit = meta.reference_links ?? meta.explicit_reference_links ?? [];
-  const nextReferenceLinks = upsertSerializedReferenceLinks(existingExplicit, targetDocId, relation);
+  const existingExplicit = [
+    ...(Array.isArray(meta.reference_links) ? meta.reference_links : meta.reference_links ? [meta.reference_links] : []),
+    ...(Array.isArray(meta.explicit_reference_links) ? meta.explicit_reference_links : meta.explicit_reference_links ? [meta.explicit_reference_links] : []),
+  ];
+  const nextReferenceLinks = upsertSerializedReferenceLinks(existingExplicit, targetDocId, relation, {
+    defaultRelation: "informs",
+  });
 
   const nextMeta = {
     ...meta,
     reference_links: nextReferenceLinks,
   };
+  delete nextMeta.explicit_reference_links;
 
   if (relation === "informs") {
     const existingIds = Array.isArray(meta.reference_ids)
@@ -40,13 +46,21 @@ function persistReferenceDocLink({ filePath, targetDocId, relation }) {
   const raw = fs.readFileSync(filePath, "utf8");
   const parsed = matter(raw);
   const data = parsed.data ?? {};
-  const existingExplicit = data.reference_links ?? data.related_reference_links ?? data.explicit_reference_links ?? [];
-  const nextReferenceLinks = upsertSerializedReferenceLinks(existingExplicit, targetDocId, relation);
+  const existingExplicit = [
+    ...(Array.isArray(data.reference_links) ? data.reference_links : data.reference_links ? [data.reference_links] : []),
+    ...(Array.isArray(data.related_reference_links) ? data.related_reference_links : data.related_reference_links ? [data.related_reference_links] : []),
+    ...(Array.isArray(data.explicit_reference_links) ? data.explicit_reference_links : data.explicit_reference_links ? [data.explicit_reference_links] : []),
+  ];
+  const nextReferenceLinks = upsertSerializedReferenceLinks(existingExplicit, targetDocId, relation, {
+    defaultRelation: "related",
+  });
 
   const nextData = {
     ...data,
     reference_links: nextReferenceLinks,
   };
+  delete nextData.related_reference_links;
+  delete nextData.explicit_reference_links;
 
   if (relation === "related") {
     const existingIds = Array.isArray(data.related_reference_ids)

--- a/src/tools/metadata.js
+++ b/src/tools/metadata.js
@@ -1,8 +1,64 @@
 import { z } from "zod";
 import fs from "node:fs";
 import matter from "gray-matter";
-import { readMeta, writeMeta, indexSceneFile, normalizeSceneMetaForPath } from "../sync/sync.js";
+import { readMeta, writeMeta, indexSceneFile, normalizeSceneMetaForPath, normalizeReferenceLinkList } from "../sync/sync.js";
 import { validateProjectId, validateUniverseId } from "../sync/importer.js";
+
+function upsertSerializedReferenceLinks(existing, targetDocId, relation) {
+  const normalized = normalizeReferenceLinkList(existing ?? [], { defaultRelation: "related" });
+  const filtered = normalized.filter((entry) => entry.targetDocId !== targetDocId);
+  filtered.push({ targetDocId, relation });
+  return filtered.map((entry) => ({
+    target_doc_id: entry.targetDocId,
+    relation: entry.relation,
+  }));
+}
+
+function persistSceneReferenceLink({ scenePath, syncDir, targetDocId, relation }) {
+  const { meta } = readMeta(scenePath, syncDir, { writable: true });
+  const existingExplicit = meta.reference_links ?? meta.explicit_reference_links ?? [];
+  const nextReferenceLinks = upsertSerializedReferenceLinks(existingExplicit, targetDocId, relation);
+
+  const nextMeta = {
+    ...meta,
+    reference_links: nextReferenceLinks,
+  };
+
+  if (relation === "informs") {
+    const existingIds = Array.isArray(meta.reference_ids)
+      ? meta.reference_ids
+      : typeof meta.reference_ids === "string"
+        ? meta.reference_ids.split(",")
+        : [];
+    nextMeta.reference_ids = [...new Set([...existingIds.map((value) => String(value).trim()).filter(Boolean), targetDocId])];
+  }
+
+  writeMeta(scenePath, nextMeta);
+}
+
+function persistReferenceDocLink({ filePath, targetDocId, relation }) {
+  const raw = fs.readFileSync(filePath, "utf8");
+  const parsed = matter(raw);
+  const data = parsed.data ?? {};
+  const existingExplicit = data.reference_links ?? data.related_reference_links ?? data.explicit_reference_links ?? [];
+  const nextReferenceLinks = upsertSerializedReferenceLinks(existingExplicit, targetDocId, relation);
+
+  const nextData = {
+    ...data,
+    reference_links: nextReferenceLinks,
+  };
+
+  if (relation === "related") {
+    const existingIds = Array.isArray(data.related_reference_ids)
+      ? data.related_reference_ids
+      : typeof data.related_reference_ids === "string"
+        ? data.related_reference_ids.split(",")
+        : [];
+    nextData.related_reference_ids = [...new Set([...existingIds.map((value) => String(value).trim()).filter(Boolean), targetDocId])];
+  }
+
+  fs.writeFileSync(filePath, matter.stringify(parsed.content, nextData), "utf8");
+}
 
 export function registerMetadataTools(s, {
   db,
@@ -205,10 +261,12 @@ export function registerMetadataTools(s, {
       }
 
       let resolvedSourceProjectId;
+      let sourceScenePath = null;
+      let sourceReferencePath = null;
       if (source_kind === "scene") {
         if (source_project_id) {
           const scene = db.prepare(`
-            SELECT scene_id, project_id
+            SELECT scene_id, project_id, file_path
             FROM scenes
             WHERE scene_id = ? AND project_id = ?
             LIMIT 1
@@ -217,9 +275,10 @@ export function registerMetadataTools(s, {
             return errorResponse("NOT_FOUND", `Scene '${source_id}' not found in project '${source_project_id}'.`);
           }
           resolvedSourceProjectId = scene.project_id ?? "";
+          sourceScenePath = scene.file_path;
         } else {
           const matches = db.prepare(`
-            SELECT scene_id, project_id
+            SELECT scene_id, project_id, file_path
             FROM scenes
             WHERE scene_id = ?
             ORDER BY project_id
@@ -235,10 +294,11 @@ export function registerMetadataTools(s, {
             );
           }
           resolvedSourceProjectId = matches[0].project_id ?? "";
+          sourceScenePath = matches[0].file_path;
         }
       } else {
         const sourceDoc = db.prepare(`
-          SELECT doc_id, project_id
+          SELECT doc_id, project_id, file_path
           FROM reference_docs
           WHERE doc_id = ?
           LIMIT 1
@@ -267,6 +327,45 @@ export function registerMetadataTools(s, {
             }
           );
         }
+        sourceReferencePath = sourceDoc.file_path;
+      }
+
+      try {
+        if (source_kind === "scene") {
+          if (!sourceScenePath) {
+            return errorResponse("STALE_PATH", `Scene '${source_id}' has no indexed file path. Run sync() to refresh.`, {
+              source_id,
+              source_project_id: resolvedSourceProjectId,
+            });
+          }
+          persistSceneReferenceLink({
+            scenePath: sourceScenePath,
+            syncDir: SYNC_DIR,
+            targetDocId: target_doc_id,
+            relation: normalizedRelation,
+          });
+        } else {
+          if (!sourceReferencePath) {
+            return errorResponse("STALE_PATH", `Reference doc '${source_id}' has no indexed file path. Run sync() to refresh.`, {
+              source_id,
+            });
+          }
+          persistReferenceDocLink({
+            filePath: sourceReferencePath,
+            targetDocId: target_doc_id,
+            relation: normalizedRelation,
+          });
+        }
+      } catch (err) {
+        if (err?.code === "ENOENT") {
+          const indexedPath = source_kind === "scene" ? sourceScenePath : sourceReferencePath;
+          return errorResponse(
+            "STALE_PATH",
+            `Source file for ${source_kind} '${source_id}' not found at indexed path — run sync() to refresh.`,
+            { indexed_path: indexedPath }
+          );
+        }
+        return errorResponse("IO_ERROR", `Failed to persist link metadata: ${err.message}`);
       }
 
       try {


### PR DESCRIPTION
## Summary

Implements the Phase 4C durability foundation for reference links by persisting explicit `upsert_reference_link` writes to source metadata files and making sync rebuild explicit links from file-backed metadata.

## Motivation

Previously, explicit links authored through `upsert_reference_link` were stored only in the database. This made them survive normal sync runs, but they could be lost after a DB reset/rebuild because source files did not carry equivalent explicit link data.

## Implementation

- Added explicit-link metadata parsing and indexing in sync:
  - `sync` now reads explicit link specs from metadata fields (`reference_links`, `related_reference_links`, `explicit_reference_links`) for both scenes and reference docs.
  - explicit links are indexed with `origin='explicit'` and reconciled per source during sync.
  - inferred links continue to be indexed from legacy ID lists, but inferred inserts are skipped when an explicit link exists for the same source/target.
- Added write-through persistence in `upsert_reference_link`:
  - scene sources: writes explicit entries to scene sidecar metadata (`reference_links`) and keeps `reference_ids` compatible for `informs` links.
  - reference sources: writes explicit entries to reference frontmatter (`reference_links`) and keeps `related_reference_ids` compatible for `related` links.
- Added/updated tests:
  - unit: metadata tool fixtures now create real source files so write-through paths are exercised.
  - unit sync: explicit-link metadata indexing and DB rebuild durability assertions.
  - integration: verifies `upsert_reference_link` writes through to scene sidecar and reference frontmatter.

## Testing

- `node --test src/test/unit/metadata-tools.test.mjs src/test/unit/sync.test.mjs src/test/integration/search.test.mjs`

## Risks and tradeoffs

- Introduces a new explicit metadata surface (`reference_links`) that now participates in sync semantics.
- Write-through keeps backward-compatible ID lists for common relations (`informs`, `related`), but relation-rich explicit links are now the stronger source of truth for rebuild durability.

## Follow-up

- Finalize ownership semantics for cross-project/shared-universe reference docs in tool validation policy.
- Codify any remaining merge rules between legacy inferred fields and explicit link metadata in docs and acceptance tests.
