### PR TITLE
feat(reference): complete Phase 4D scene reference suggestion flow

### DIFF
--- a/docs/prd/in-progress/reference-docs.md
+++ b/docs/prd/in-progress/reference-docs.md
@@ -222,12 +222,50 @@ Completed (Phase 4C durability & merge rules):
 
 ## Next Implementation Slice (Phase 4D)
 
-Optional enhancement: authoring and auto-suggestion helpers.
+Authoring and auto-suggestion helpers through entity-based reference linking.
 
-- Implement helper flows for suggesting/authoring links based on scene/reference proximity.
-- Consider inferred link suggestions from keyword overlap or character mentions.
-- Define UX/approval flow for bulk link operations (especially cross-project scenarios).
-- Support link batch editing in CLI or tool workflows.
+### Phase 4D Design
+
+**New source kinds:** `character` and `place` for reference links
+
+- Extend `upsert_reference_link` tool to support `character` and `place` as `source_kind` values
+- Links are persisted to character/place `.meta.yaml` sidecars parallel to scene sidecars
+- Write-through helpers: `persistCharacterReferenceLink()`, `persistPlaceReferenceLink()`
+
+**Suggestion mechanism:** `suggest_scene_references(scene_id, project_id?)`
+
+- Query: Find all characters and places in the scene
+- Query: For each character/place, retrieve linked references
+- Score references by link count:
+  - +1 for each character in the scene with a link to that reference
+  - +1 for each place in the scene with a link to that reference
+  - Deduplicate on (doc_id, relation) pair; sum scores
+- Return candidates sorted by score descending
+- Exclude any already-explicit scene → reference links
+- Include source attribution (e.g., "linked via character X" or "linked via place Y" or "linked via both")
+
+**Manual linking:** Users can always call `upsert_reference_link` directly
+
+- `upsert_reference_link('scene', scene_id, project_id, target_doc_id, relation)` creates explicit scene links
+- Explicit scene links take precedence over any suggestion (not overridden by suggestions)
+
+**Sync indexing:** Extend `sync()` to index character/place → reference links
+
+- Index links alongside scene/reference links during sync
+- Preserve `origin` tracking (explicit vs inferred from metadata)
+- Parallel to existing scene/reference indexing
+
+### Example Scoring
+
+Scene "Sebastian's experiment" contains:
+- Character: Sebastian (linked to reference "Vampirism in this universe")
+- Character: Mira (linked to reference "Vampirism in this universe")
+- Place: Laboratory (linked to reference "Alchemy in Sebastian's world")
+- Place: Laboratory (linked to reference "Vampirism in this universe")
+
+Suggestion scores:
+- "Vampirism in this universe": score 3 (Sebastian, Mira, Laboratory all link to it)
+- "Alchemy in Sebastian's world": score 1 (Laboratory links to it)
 
 Phase 4C Completion Notes (v2.17.0):
 ✅ Explicit links survive full DB reset/rebuild from source files via write-through.
@@ -260,7 +298,8 @@ Behavioral guardrails:
 
 - No finalized authoring UX helpers for suggesting links based on scene/reference proximity
 - No auto-suggestion flow for likely scene references based on keyword overlap or character mentions
-- No decision yet on whether summaries are handwritten only or can be inferred from content
+- Deferred feature: reference-document "logline-like" summaries as explicit metadata fields
+- Open design for deferred feature: summaries may be handwritten by users or generated/suggested and then user-edited
 - Bulk link editing workflows (especially cross-project scenarios) not yet scoped
 - Cross-project/shared-universe ownership enforcement may need refinement once used on larger series projects
 

--- a/docs/prd/in-progress/reference-docs.md
+++ b/docs/prd/in-progress/reference-docs.md
@@ -232,7 +232,7 @@ Authoring and auto-suggestion helpers through entity-based reference linking.
 - Links are persisted to character/place `.meta.yaml` sidecars parallel to scene sidecars
 - Write-through helpers: `persistCharacterReferenceLink()`, `persistPlaceReferenceLink()`
 
-**Suggestion mechanism:** `suggest_scene_references(scene_id, project_id?)`
+**Suggestion mechanism:** `suggest_scene_references(scene_id, project_id?, mode?, selected_doc_ids?, max_apply?, min_score?)`
 
 - Query: Find all characters and places in the scene
 - Query: For each character/place, retrieve linked references
@@ -244,10 +244,24 @@ Authoring and auto-suggestion helpers through entity-based reference linking.
 - Exclude any already-explicit scene → reference links
 - Include source attribution (e.g., "linked via character X" or "linked via place Y" or "linked via both")
 
+**Simplified UX modes:**
+
+- `mode: "preview"` (default) returns weighted candidates only
+- `mode: "apply"` persists selected/top suggestions as explicit `scene -> reference` links in one call
+- `selected_doc_ids` optionally limits which suggested doc IDs are applied
+- `max_apply` optionally caps the number of suggestions applied in a single call
+- `min_score` optionally filters low-confidence candidates from preview/apply
+
 **Manual linking:** Users can always call `upsert_reference_link` directly
 
 - `upsert_reference_link('scene', scene_id, project_id, target_doc_id, relation)` creates explicit scene links
 - Explicit scene links take precedence over any suggestion (not overridden by suggestions)
+
+**Order of operations guidance:**
+
+- Common flow can now be single-step with `suggest_scene_references(..., mode="apply")`
+- For manual review/approval, use `suggest_scene_references(..., mode="preview")` then `upsert_reference_link`
+- After external file edits (outside tools), run `sync()` before preview/apply to refresh index state
 
 **Sync indexing:** Extend `sync()` to index character/place → reference links
 

--- a/docs/release-log.md
+++ b/docs/release-log.md
@@ -8,6 +8,14 @@ This complements `CHANGELOG.md`:
 
 ## Unreleased
 
+### 2026-05-01 — Add scene reference suggestion/apply workflow
+
+- What changed: Expanded reference linking to include character/place sources and added `suggest_scene_references` with `preview` and one-call `apply` modes to persist scene links directly from suggestions.
+- Why it matters: Users can now move from discovery to explicit scene linking in a single tool call, reducing multi-step orchestration as the tool surface grows.
+- Who is affected: Anyone using reference docs and continuity workflows through MCP tools.
+- Action needed: Optional: run `sync()` after external file edits before using `suggest_scene_references` to ensure candidates reflect latest metadata.
+- PR: (pending)
+
 ### 2026-04-30 — Add explicit reference link upsert tool
 
 - What changed: Added `upsert_reference_link` so agents can create/update scene → reference and reference → reference links directly, with relation normalization and conflict-safe scene disambiguation.

--- a/docs/release-log.md
+++ b/docs/release-log.md
@@ -14,7 +14,7 @@ This complements `CHANGELOG.md`:
 - Why it matters: Users can now move from discovery to explicit scene linking in a single tool call, reducing multi-step orchestration as the tool surface grows.
 - Who is affected: Anyone using reference docs and continuity workflows through MCP tools.
 - Action needed: Optional: run `sync()` after external file edits before using `suggest_scene_references` to ensure candidates reflect latest metadata.
-- PR: (pending)
+- PR: [#163](https://github.com/hannasdev/mcp-writing/pull/163)
 
 ### 2026-04-30 — Add explicit reference link upsert tool
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -30,6 +30,7 @@
 - [`list_threads`](#list_threads)
 - [`get_thread_arc`](#get_thread_arc)
 - [`get_relationship_arc`](#get_relationship_arc)
+- [`suggest_scene_references`](#suggest_scene_references)
 - [`create_character_sheet`](#create_character_sheet)
 - [`create_place_sheet`](#create_place_sheet)
 - [`upsert_thread_link`](#upsert_thread_link)
@@ -357,6 +358,21 @@ Show how the relationship between two characters evolves across scenes, in order
 
 ---
 
+## suggest_scene_references
+
+Suggest reference documents for a scene by aggregating links from the scene's characters and places. Returns weighted candidates ranked by how many entities in the scene link to each reference. Excludes any explicit scene → reference links already present. In apply mode, can persist selected suggestions as explicit scene links in one call.
+
+| Parameter | Type | Required | Description |
+| --- | --- | :---: | --- |
+| `scene_id` | `string` | Yes | Scene ID (e.g. 'sc-011-sebastian'). |
+| `project_id` | `string` | No | Optional project scope to disambiguate an ambiguous scene_id across projects. |
+| `mode` | `enum("preview","apply")` | No | Use 'preview' (default) to list candidates only, or 'apply' to persist selected suggestions as explicit scene links. |
+| `selected_doc_ids` | `string[]` | No | Optional allowlist of doc_ids to apply when mode='apply'. If omitted, applies top-ranked candidates. |
+| `max_apply` | `integer` | No | Optional cap for how many candidates to apply when mode='apply'. |
+| `min_score` | `integer` | No | Optional minimum candidate score. Candidates below this are excluded from preview/apply. Defaults to 1. |
+
+---
+
 ## create_character_sheet
 
 Create or reuse a canonical character sheet folder with sheet.md and sheet.meta.yaml so the character can be indexed immediately. If the folder already exists, missing canonical files are backfilled and the existing sheet is preserved.
@@ -402,13 +418,13 @@ Create or update a thread and link it to a scene. Idempotent: if the link alread
 
 ## upsert_reference_link
 
-Create or update an explicit reference link from a scene or reference doc to a target reference doc. If a link already exists between the same source and target, this updates the relation. Only available when the sync dir is writable.
+Create or update an explicit reference link from a scene, character, place, or reference doc to a target reference doc. If a link already exists between the same source and target, this updates the relation. Only available when the sync dir is writable.
 
 | Parameter | Type | Required | Description |
 | --- | --- | :---: | --- |
-| `source_kind` | `enum("scene","reference")` | Yes | Link source kind. |
-| `source_id` | `string` | Yes | Source scene_id or reference doc_id. |
-| `source_project_id` | `string` | No | Optional project scope for the source. For scene sources, use this to disambiguate an ambiguous scene_id across projects. For reference sources, when provided, it is treated as an ownership check and must match the source reference doc's project. |
+| `source_kind` | `enum("scene","character","place","reference")` | Yes | Link source kind. |
+| `source_id` | `string` | Yes | Source scene_id, character_id, place_id, or reference doc_id. |
+| `source_project_id` | `string` | No | Optional project scope for the source. For scene/character/place sources, use this to disambiguate an ambiguous source_id across projects. For reference sources, when provided, it is treated as an ownership check and must match the source reference doc's project. |
 | `target_doc_id` | `string` | Yes | Target reference doc_id. |
 | `relation` | `string` | Yes | Relationship label (for example: 'informs', 'related', 'history_of'). The value is trimmed and lowercased before validation. |
 

--- a/src/sync/sync.js
+++ b/src/sync/sync.js
@@ -698,14 +698,26 @@ export function indexWorldFile(db, syncDir, file, meta) {
 
   if (!kind || !isCanonicalWorldEntityFile(syncDir, file, meta)) return;
 
-  if (kind === "character") {
-    if (!meta.character_id) return;
-    
+  const indexWorldEntityReferenceLinks = ({ sourceKind, sourceId }) => {
     const explicitReferenceLinks = collectExplicitReferenceLinks(
       meta,
       ["reference_links", "explicit_reference_links"],
       { defaultRelation: "informs" }
     );
+
+    if (explicitReferenceLinks.hasField) {
+      indexExplicitReferenceLinksForSource(db, {
+        sourceKind,
+        sourceProjectId: project_id ?? "",
+        sourceId,
+        links: explicitReferenceLinks.links,
+        defaultRelation: "informs",
+      });
+    }
+  };
+
+  if (kind === "character") {
+    if (!meta.character_id) return;
 
     db.prepare(`
       INSERT INTO characters (character_id, project_id, universe_id, name, role, arc_summary, first_appearance, file_path)
@@ -724,24 +736,9 @@ export function indexWorldFile(db, syncDir, file, meta) {
         meta.character_id, t
       );
     }
-
-    if (explicitReferenceLinks.hasField) {
-      indexExplicitReferenceLinksForSource(db, {
-        sourceKind: "character",
-        sourceProjectId: project_id ?? "",
-        sourceId: meta.character_id,
-        links: explicitReferenceLinks.links,
-        defaultRelation: "informs",
-      });
-    }
+    indexWorldEntityReferenceLinks({ sourceKind: "character", sourceId: meta.character_id });
   } else if (kind === "place") {
     if (!meta.place_id) return;
-    
-    const explicitReferenceLinks = collectExplicitReferenceLinks(
-      meta,
-      ["reference_links", "explicit_reference_links"],
-      { defaultRelation: "informs" }
-    );
 
     db.prepare(`
       INSERT INTO places (place_id, project_id, universe_id, name, file_path)
@@ -751,16 +748,7 @@ export function indexWorldFile(db, syncDir, file, meta) {
       meta.place_id, project_id ?? null, universe_id ?? null,
       meta.name ?? meta.place_id, file
     );
-
-    if (explicitReferenceLinks.hasField) {
-      indexExplicitReferenceLinksForSource(db, {
-        sourceKind: "place",
-        sourceProjectId: project_id ?? "",
-        sourceId: meta.place_id,
-        links: explicitReferenceLinks.links,
-        defaultRelation: "informs",
-      });
-    }
+    indexWorldEntityReferenceLinks({ sourceKind: "place", sourceId: meta.place_id });
   }
 }
 

--- a/src/sync/sync.js
+++ b/src/sync/sync.js
@@ -700,6 +700,13 @@ export function indexWorldFile(db, syncDir, file, meta) {
 
   if (kind === "character") {
     if (!meta.character_id) return;
+    
+    const explicitReferenceLinks = collectExplicitReferenceLinks(
+      meta,
+      ["reference_links", "explicit_reference_links"],
+      { defaultRelation: "informs" }
+    );
+
     db.prepare(`
       INSERT INTO characters (character_id, project_id, universe_id, name, role, arc_summary, first_appearance, file_path)
       VALUES (?, ?, ?, ?, ?, ?, ?, ?)
@@ -717,8 +724,25 @@ export function indexWorldFile(db, syncDir, file, meta) {
         meta.character_id, t
       );
     }
+
+    if (explicitReferenceLinks.hasField) {
+      indexExplicitReferenceLinksForSource(db, {
+        sourceKind: "character",
+        sourceProjectId: project_id ?? "",
+        sourceId: meta.character_id,
+        links: explicitReferenceLinks.links,
+        defaultRelation: "informs",
+      });
+    }
   } else if (kind === "place") {
     if (!meta.place_id) return;
+    
+    const explicitReferenceLinks = collectExplicitReferenceLinks(
+      meta,
+      ["reference_links", "explicit_reference_links"],
+      { defaultRelation: "informs" }
+    );
+
     db.prepare(`
       INSERT INTO places (place_id, project_id, universe_id, name, file_path)
       VALUES (?, ?, ?, ?, ?)
@@ -727,6 +751,16 @@ export function indexWorldFile(db, syncDir, file, meta) {
       meta.place_id, project_id ?? null, universe_id ?? null,
       meta.name ?? meta.place_id, file
     );
+
+    if (explicitReferenceLinks.hasField) {
+      indexExplicitReferenceLinksForSource(db, {
+        sourceKind: "place",
+        sourceProjectId: project_id ?? "",
+        sourceId: meta.place_id,
+        links: explicitReferenceLinks.links,
+        defaultRelation: "informs",
+      });
+    }
   }
 }
 

--- a/src/test/integration/search.test.mjs
+++ b/src/test/integration/search.test.mjs
@@ -421,6 +421,49 @@ describe("reference link tools", () => {
     assert.equal(parsed.related[0].doc_id, "ref-vamp-history");
     assert.ok(parsed.related[0].tags.includes("history"));
   });
+
+  test("suggest_scene_references apply mode persists explicit scene links on write server", async () => {
+    const refPath = path.join(writeSyncDir, "projects", "test-novel", "world", "reference", "apply-mode-target.md");
+    fs.mkdirSync(path.dirname(refPath), { recursive: true });
+    fs.writeFileSync(
+      refPath,
+      "---\ndoc_id: ref-apply-mode\ntitle: Apply Mode Target\n---\nReference body."
+    );
+
+    await callWriteTool("sync");
+
+    const linkText = await callWriteTool("upsert_reference_link", {
+      source_kind: "character",
+      source_id: "elena",
+      source_project_id: "test-novel",
+      target_doc_id: "ref-apply-mode",
+      relation: "informs",
+    });
+    const linkParsed = JSON.parse(linkText);
+    assert.equal(linkParsed.ok, true);
+
+    const applyText = await callWriteTool("suggest_scene_references", {
+      scene_id: "sc-001",
+      project_id: "test-novel",
+      mode: "apply",
+      selected_doc_ids: ["ref-apply-mode"],
+      max_apply: 1,
+    });
+    const applyParsed = JSON.parse(applyText);
+
+    assert.equal(applyParsed.mode, "apply");
+    assert.equal(applyParsed.applied_count, 1);
+    assert.equal(applyParsed.applied_links[0].target_doc_id, "ref-apply-mode");
+    assert.equal(applyParsed.applied_links[0].origin, "explicit");
+
+    const listedText = await callWriteTool("list_scene_references", {
+      scene_id: "sc-001",
+      project_id: "test-novel",
+    });
+    const listedParsed = JSON.parse(listedText);
+    assert.ok(listedParsed.references.some((row) => row.doc_id === "ref-apply-mode"));
+  });
+
 });
 
 describe("list_threads tool", () => {

--- a/src/test/unit/reference-tools.test.mjs
+++ b/src/test/unit/reference-tools.test.mjs
@@ -336,6 +336,49 @@ describe("reference link search tools", () => {
     }
   });
 
+  test("suggest_scene_references excludes explicit scene links even when relation differs", async () => {
+    const db = openDb(":memory:");
+    try {
+      seedProject(db, "test-novel");
+      seedScene(db, { sceneId: "sc-001", projectId: "test-novel" });
+
+      db.prepare(`
+        INSERT INTO characters (character_id, project_id, name, file_path)
+        VALUES (?, ?, ?, ?)
+      `).run("char-mira", "test-novel", "Mira", "/tmp/mira.md");
+
+      db.prepare(`INSERT INTO scene_characters (scene_id, character_id) VALUES (?, ?)`).run("sc-001", "char-mira");
+
+      seedReferenceDoc(db, { docId: "ref-vampirism", projectId: "test-novel", title: "Vampirism", type: "world" });
+
+      seedReferenceLink(db, {
+        sourceKind: "character",
+        sourceProjectId: "test-novel",
+        sourceId: "char-mira",
+        targetDocId: "ref-vampirism",
+        relation: "informs",
+      });
+
+      // Explicit scene link points to the same doc with a different relation.
+      seedReferenceLink(db, {
+        sourceKind: "scene",
+        sourceProjectId: "test-novel",
+        sourceId: "sc-001",
+        targetDocId: "ref-vampirism",
+        relation: "see_also",
+        origin: "explicit",
+      });
+
+      const tools = makeToolHarness(db);
+      const suggestions = await tools.call("suggest_scene_references", { scene_id: "sc-001", project_id: "test-novel" });
+
+      assert.equal(suggestions.total_candidates, 0);
+      assert.equal(suggestions.candidates.length, 0);
+    } finally {
+      db.close();
+    }
+  });
+
   test("suggest_scene_references ignores links from other projects", async () => {
     const db = openDb(":memory:");
     try {
@@ -399,6 +442,83 @@ describe("reference link search tools", () => {
       assert.equal(suggestions.candidates[0].sources.length, 2);
     } finally {
       db.close();
+    }
+  });
+
+  test("suggest_scene_references uses resolved scene metadata to avoid cross-project scene_id leakage", async () => {
+    const db = openDb(":memory:");
+    const syncDir = fs.mkdtempSync(path.join(os.tmpdir(), "ref-suggest-meta-"));
+    try {
+      seedProject(db, "test-novel");
+      seedProject(db, "other-novel");
+
+      const testSceneDir = path.join(syncDir, "projects", "test-novel", "scenes");
+      fs.mkdirSync(testSceneDir, { recursive: true });
+      const testScenePath = path.join(testSceneDir, "sc-001.md");
+      fs.writeFileSync(
+        testScenePath,
+        "---\nscene_id: sc-001\ncharacters:\n  - char-mira\n---\nScene prose.",
+        "utf8"
+      );
+
+      // Same scene_id in another project to reproduce potential join-table leakage.
+      const otherScenePath = path.join(syncDir, "projects", "other-novel", "scenes", "sc-001.md");
+      fs.mkdirSync(path.dirname(otherScenePath), { recursive: true });
+      fs.writeFileSync(otherScenePath, "---\nscene_id: sc-001\ncharacters:\n  - char-ghost\n---\nOther prose.", "utf8");
+
+      db.prepare(`
+        INSERT INTO scenes (
+          scene_id, project_id, title, file_path, prose_checksum, metadata_stale, updated_at
+        ) VALUES (?, ?, ?, ?, ?, 0, ?)
+      `).run("sc-001", "test-novel", "Scene 1", testScenePath, "deadbeef", new Date().toISOString());
+
+      db.prepare(`
+        INSERT INTO scenes (
+          scene_id, project_id, title, file_path, prose_checksum, metadata_stale, updated_at
+        ) VALUES (?, ?, ?, ?, ?, 0, ?)
+      `).run("sc-001", "other-novel", "Scene 1", otherScenePath, "deadbeef", new Date().toISOString());
+
+      db.prepare(`
+        INSERT INTO characters (character_id, project_id, name, file_path)
+        VALUES (?, ?, ?, ?)
+      `).run("char-mira", "test-novel", "Mira", "/tmp/mira.md");
+
+      db.prepare(`
+        INSERT INTO characters (character_id, project_id, name, file_path)
+        VALUES (?, ?, ?, ?)
+      `).run("char-ghost", "test-novel", "Ghost", "/tmp/ghost.md");
+
+      // Join table contains both rows because it is not project-scoped.
+      db.prepare(`INSERT INTO scene_characters (scene_id, character_id) VALUES (?, ?)`).run("sc-001", "char-mira");
+      db.prepare(`INSERT INTO scene_characters (scene_id, character_id) VALUES (?, ?)`).run("sc-001", "char-ghost");
+
+      seedReferenceDoc(db, { docId: "ref-correct", projectId: "test-novel", title: "Correct Doc", type: "world" });
+      seedReferenceDoc(db, { docId: "ref-leaked", projectId: "test-novel", title: "Leaked Doc", type: "world" });
+
+      seedReferenceLink(db, {
+        sourceKind: "character",
+        sourceProjectId: "test-novel",
+        sourceId: "char-mira",
+        targetDocId: "ref-correct",
+        relation: "informs",
+      });
+      seedReferenceLink(db, {
+        sourceKind: "character",
+        sourceProjectId: "test-novel",
+        sourceId: "char-ghost",
+        targetDocId: "ref-leaked",
+        relation: "informs",
+      });
+
+      const tools = makeToolHarness(db, { syncDir, writable: true });
+      const suggestions = await tools.call("suggest_scene_references", { scene_id: "sc-001", project_id: "test-novel" });
+
+      assert.equal(suggestions.total_candidates, 1);
+      assert.equal(suggestions.candidates[0].doc_id, "ref-correct");
+      assert.equal(suggestions.candidates[0].score, 1);
+    } finally {
+      db.close();
+      fs.rmSync(syncDir, { recursive: true, force: true });
     }
   });
 

--- a/src/test/unit/reference-tools.test.mjs
+++ b/src/test/unit/reference-tools.test.mjs
@@ -332,6 +332,72 @@ describe("reference link search tools", () => {
     }
   });
 
+  test("suggest_scene_references ignores links from other projects", async () => {
+    const db = openDb(":memory:");
+    try {
+      seedProject(db, "test-novel");
+      seedProject(db, "other-novel");
+      seedScene(db, { sceneId: "sc-001", projectId: "test-novel" });
+
+      db.prepare(`
+        INSERT INTO characters (character_id, project_id, name, file_path)
+        VALUES (?, ?, ?, ?)
+      `).run("char-mira", "test-novel", "Mira", "/tmp/mira.md");
+
+      db.prepare(`
+        INSERT INTO places (place_id, project_id, name, file_path)
+        VALUES (?, ?, ?, ?)
+      `).run("place-hospital", "test-novel", "Hospital", "/tmp/hospital.md");
+
+      db.prepare(`INSERT INTO scene_characters (scene_id, character_id) VALUES (?, ?)`).run("sc-001", "char-mira");
+      db.prepare(`INSERT INTO scene_places (scene_id, place_id) VALUES (?, ?)`).run("sc-001", "place-hospital");
+
+      seedReferenceDoc(db, { docId: "ref-correct", projectId: "test-novel", title: "Correct Doc", type: "world" });
+      seedReferenceDoc(db, { docId: "ref-foreign", projectId: "other-novel", title: "Foreign Doc", type: "world" });
+
+      seedReferenceLink(db, {
+        sourceKind: "character",
+        sourceProjectId: "test-novel",
+        sourceId: "char-mira",
+        targetDocId: "ref-correct",
+        relation: "informs",
+      });
+      seedReferenceLink(db, {
+        sourceKind: "place",
+        sourceProjectId: "test-novel",
+        sourceId: "place-hospital",
+        targetDocId: "ref-correct",
+        relation: "informs",
+      });
+
+      // Same source IDs, but links from another project should not affect score or candidates.
+      seedReferenceLink(db, {
+        sourceKind: "character",
+        sourceProjectId: "other-novel",
+        sourceId: "char-mira",
+        targetDocId: "ref-foreign",
+        relation: "informs",
+      });
+      seedReferenceLink(db, {
+        sourceKind: "place",
+        sourceProjectId: "other-novel",
+        sourceId: "place-hospital",
+        targetDocId: "ref-foreign",
+        relation: "informs",
+      });
+
+      const tools = makeToolHarness(db);
+      const suggestions = await tools.call("suggest_scene_references", { scene_id: "sc-001", project_id: "test-novel" });
+
+      assert.equal(suggestions.total_candidates, 1);
+      assert.equal(suggestions.candidates[0].doc_id, "ref-correct");
+      assert.equal(suggestions.candidates[0].score, 2);
+      assert.equal(suggestions.candidates[0].sources.length, 2);
+    } finally {
+      db.close();
+    }
+  });
+
   test("suggest_scene_references returns not-found for non-existent scene", async () => {
     const db = openDb(":memory:");
     try {

--- a/src/test/unit/reference-tools.test.mjs
+++ b/src/test/unit/reference-tools.test.mjs
@@ -496,4 +496,48 @@ describe("reference link search tools", () => {
       fs.rmSync(syncDir, { recursive: true, force: true });
     }
   });
+
+  test("suggest_scene_references apply mode reports failures when scene path is stale", async () => {
+    const db = openDb(":memory:");
+    try {
+      seedProject(db, "test-novel");
+
+      db.prepare(`
+        INSERT INTO scenes (
+          scene_id, project_id, title, file_path, prose_checksum, metadata_stale, updated_at
+        ) VALUES (?, ?, ?, ?, ?, 0, ?)
+      `).run("sc-001", "test-novel", "Scene 1", "/tmp/missing-scene.md", "deadbeef", new Date().toISOString());
+
+      db.prepare(`
+        INSERT INTO characters (character_id, project_id, name, file_path)
+        VALUES (?, ?, ?, ?)
+      `).run("char-mira", "test-novel", "Mira", "/tmp/mira.md");
+      db.prepare(`INSERT INTO scene_characters (scene_id, character_id) VALUES (?, ?)`).run("sc-001", "char-mira");
+
+      seedReferenceDoc(db, { docId: "ref-vampirism", projectId: "test-novel", title: "Vampirism", type: "world" });
+      seedReferenceLink(db, {
+        sourceKind: "character",
+        sourceProjectId: "test-novel",
+        sourceId: "char-mira",
+        targetDocId: "ref-vampirism",
+        relation: "informs",
+      });
+
+      const tools = makeToolHarness(db, { writable: true });
+      const result = await tools.call("suggest_scene_references", {
+        scene_id: "sc-001",
+        project_id: "test-novel",
+        mode: "apply",
+      });
+
+      assert.equal(result.applied_count, 0);
+      assert.equal(result.failed_count, 1);
+      assert.equal(result.failed_links.length, 1);
+      assert.equal(result.failed_links[0].target_doc_id, "ref-vampirism");
+      assert.equal(result.failed_links[0].stage, "metadata");
+      assert.equal(result.failed_links[0].code, "ENOENT");
+    } finally {
+      db.close();
+    }
+  });
 });

--- a/src/test/unit/reference-tools.test.mjs
+++ b/src/test/unit/reference-tools.test.mjs
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { openDb } from "../../core/db.js";
 import { registerSearchTools } from "../../tools/search.js";
+import { upsertExplicitReferenceLinkRow } from "../../tools/reference-link-persistence.js";
 
 function makeToolHarness(db, { syncDir = "", writable = false } = {}) {
   const handlers = new Map();
@@ -100,6 +101,75 @@ function seedReferenceLink(db, {
 }
 
 describe("reference link search tools", () => {
+  test("upsertExplicitReferenceLinkRow is atomic when insert fails", () => {
+    class FakeDb {
+      constructor() {
+        this.rows = [
+          {
+            source_kind: "scene",
+            source_project_id: "test-novel",
+            source_id: "sc-001",
+            target_doc_id: "ref-vampirism",
+            relation: "informs",
+            origin: "explicit",
+          },
+        ];
+      }
+
+      prepare(sql) {
+        if (sql.includes("DELETE FROM reference_links")) {
+          return {
+            run: (sourceKind, sourceProjectId, sourceId, targetDocId) => {
+              this.rows = this.rows.filter((row) => !(
+                row.source_kind === sourceKind
+                && row.source_project_id === sourceProjectId
+                && row.source_id === sourceId
+                && row.target_doc_id === targetDocId
+              ));
+            },
+          };
+        }
+
+        if (sql.includes("INSERT INTO reference_links")) {
+          return {
+            run: () => {
+              throw new Error("simulated insert failure");
+            },
+          };
+        }
+
+        throw new Error(`Unexpected SQL in fake db: ${sql}`);
+      }
+
+      transaction(fn) {
+        return () => {
+          const snapshot = structuredClone(this.rows);
+          try {
+            fn();
+          } catch (err) {
+            this.rows = snapshot;
+            throw err;
+          }
+        };
+      }
+    }
+
+    const db = new FakeDb();
+    assert.throws(
+      () => upsertExplicitReferenceLinkRow(db, {
+        sourceKind: "scene",
+        sourceProjectId: "test-novel",
+        sourceId: "sc-001",
+        targetDocId: "ref-vampirism",
+        relation: "see_also",
+      }),
+      /simulated insert failure/
+    );
+
+    assert.equal(db.rows.length, 1);
+    assert.equal(db.rows[0].relation, "informs");
+  });
+
   test("list_scene_references returns conflict when scene_id is ambiguous across projects", async () => {
     const db = openDb(":memory:");
     try {

--- a/src/test/unit/reference-tools.test.mjs
+++ b/src/test/unit/reference-tools.test.mjs
@@ -63,11 +63,12 @@ function seedProject(db, projectId) {
 }
 
 function seedScene(db, { sceneId, projectId }) {
+  const missingPath = path.join(os.tmpdir(), `mcp-writing-missing-${projectId}-${sceneId}-${Date.now()}-${Math.random().toString(36).slice(2)}.md`);
   db.prepare(`
     INSERT INTO scenes (
       scene_id, project_id, title, file_path, prose_checksum, metadata_stale, updated_at
     ) VALUES (?, ?, ?, ?, ?, 0, ?)
-  `).run(sceneId, projectId, sceneId, `/tmp/${projectId}-${sceneId}.md`, "deadbeef", new Date().toISOString());
+  `).run(sceneId, projectId, sceneId, missingPath, "deadbeef", new Date().toISOString());
 }
 
 function seedReferenceDoc(db, { docId, projectId, title, type = "reference", summary = null }) {
@@ -592,6 +593,158 @@ describe("reference link search tools", () => {
     }
   });
 
+  test("suggest_scene_references treats readable metadata as authoritative even when entity lists are empty", async () => {
+    const db = openDb(":memory:");
+    const syncDir = fs.mkdtempSync(path.join(os.tmpdir(), "ref-suggest-empty-meta-"));
+    try {
+      seedProject(db, "test-novel");
+      seedProject(db, "other-novel");
+
+      const sceneDir = path.join(syncDir, "projects", "test-novel", "scenes");
+      fs.mkdirSync(sceneDir, { recursive: true });
+      const scenePath = path.join(sceneDir, "sc-001.md");
+      fs.writeFileSync(scenePath, "---\nscene_id: sc-001\n---\nScene prose.", "utf8");
+
+      db.prepare(`
+        INSERT INTO scenes (
+          scene_id, project_id, title, file_path, prose_checksum, metadata_stale, updated_at
+        ) VALUES (?, ?, ?, ?, ?, 0, ?)
+      `).run("sc-001", "test-novel", "Scene 1", scenePath, "deadbeef", new Date().toISOString());
+
+      db.prepare(`
+        INSERT INTO characters (character_id, project_id, name, file_path)
+        VALUES (?, ?, ?, ?)
+      `).run("char-leaked", "test-novel", "Leaked", "/tmp/leaked.md");
+
+      // Non-project-scoped join table row that should not be used when metadata read succeeds.
+      db.prepare(`INSERT INTO scene_characters (scene_id, character_id) VALUES (?, ?)`).run("sc-001", "char-leaked");
+
+      seedReferenceDoc(db, { docId: "ref-leaked", projectId: "test-novel", title: "Leaked Doc", type: "world" });
+      seedReferenceLink(db, {
+        sourceKind: "character",
+        sourceProjectId: "test-novel",
+        sourceId: "char-leaked",
+        targetDocId: "ref-leaked",
+        relation: "informs",
+      });
+
+      const tools = makeToolHarness(db, { syncDir, writable: true });
+      const suggestions = await tools.call("suggest_scene_references", { scene_id: "sc-001", project_id: "test-novel" });
+
+      assert.equal(suggestions.total_candidates, 0);
+      assert.equal(suggestions.candidates.length, 0);
+    } finally {
+      db.close();
+      fs.rmSync(syncDir, { recursive: true, force: true });
+    }
+  });
+
+  test("suggest_scene_references filters out links to missing reference docs", async () => {
+    const db = openDb(":memory:");
+    try {
+      seedProject(db, "test-novel");
+      seedScene(db, { sceneId: "sc-001", projectId: "test-novel" });
+
+      db.prepare(`
+        INSERT INTO characters (character_id, project_id, name, file_path)
+        VALUES (?, ?, ?, ?)
+      `).run("char-mira", "test-novel", "Mira", "/tmp/mira.md");
+      db.prepare(`INSERT INTO scene_characters (scene_id, character_id) VALUES (?, ?)`).run("sc-001", "char-mira");
+
+      seedReferenceDoc(db, { docId: "ref-existing", projectId: "test-novel", title: "Existing", type: "world" });
+
+      seedReferenceLink(db, {
+        sourceKind: "character",
+        sourceProjectId: "test-novel",
+        sourceId: "char-mira",
+        targetDocId: "ref-existing",
+        relation: "informs",
+      });
+      seedReferenceLink(db, {
+        sourceKind: "character",
+        sourceProjectId: "test-novel",
+        sourceId: "char-mira",
+        targetDocId: "ref-missing",
+        relation: "informs",
+      });
+
+      const tools = makeToolHarness(db);
+      const suggestions = await tools.call("suggest_scene_references", { scene_id: "sc-001", project_id: "test-novel" });
+
+      assert.equal(suggestions.total_candidates, 1);
+      assert.equal(suggestions.candidates[0].doc_id, "ref-existing");
+      assert.deepEqual(suggestions.skipped_missing_doc_ids, ["ref-missing"]);
+    } finally {
+      db.close();
+    }
+  });
+
+  test("suggest_scene_references apply mode applies at most one relation per doc_id", async () => {
+    const db = openDb(":memory:");
+    const syncDir = fs.mkdtempSync(path.join(os.tmpdir(), "ref-apply-dedupe-"));
+    try {
+      seedProject(db, "test-novel");
+
+      const sceneDir = path.join(syncDir, "projects", "test-novel", "scenes");
+      fs.mkdirSync(sceneDir, { recursive: true });
+      const scenePath = path.join(sceneDir, "sc-001.md");
+      fs.writeFileSync(scenePath, "---\nscene_id: sc-001\ncharacters:\n  - char-mira\nplaces:\n  - place-lab\n---\nScene prose.", "utf8");
+
+      db.prepare(`
+        INSERT INTO scenes (
+          scene_id, project_id, title, file_path, prose_checksum, metadata_stale, updated_at
+        ) VALUES (?, ?, ?, ?, ?, 0, ?)
+      `).run("sc-001", "test-novel", "Scene 1", scenePath, "deadbeef", new Date().toISOString());
+
+      db.prepare(`
+        INSERT INTO characters (character_id, project_id, name, file_path)
+        VALUES (?, ?, ?, ?)
+      `).run("char-mira", "test-novel", "Mira", "/tmp/mira.md");
+      db.prepare(`
+        INSERT INTO places (place_id, project_id, name, file_path)
+        VALUES (?, ?, ?, ?)
+      `).run("place-lab", "test-novel", "Lab", "/tmp/lab.md");
+
+      seedReferenceDoc(db, { docId: "ref-vampirism", projectId: "test-novel", title: "Vampirism", type: "world" });
+      seedReferenceLink(db, {
+        sourceKind: "character",
+        sourceProjectId: "test-novel",
+        sourceId: "char-mira",
+        targetDocId: "ref-vampirism",
+        relation: "see_also",
+      });
+      seedReferenceLink(db, {
+        sourceKind: "place",
+        sourceProjectId: "test-novel",
+        sourceId: "place-lab",
+        targetDocId: "ref-vampirism",
+        relation: "history_of",
+      });
+
+      const tools = makeToolHarness(db, { syncDir, writable: true });
+      const result = await tools.call("suggest_scene_references", {
+        scene_id: "sc-001",
+        project_id: "test-novel",
+        mode: "apply",
+        selected_doc_ids: ["ref-vampirism"],
+      });
+
+      assert.equal(result.applied_count, 1);
+      assert.equal(result.applied_links.length, 1);
+      assert.equal(result.applied_links[0].target_doc_id, "ref-vampirism");
+
+      const rows = db.prepare(`
+        SELECT relation
+        FROM reference_links
+        WHERE source_kind = 'scene' AND source_project_id = 'test-novel' AND source_id = 'sc-001' AND target_doc_id = 'ref-vampirism' AND origin = 'explicit'
+      `).all();
+      assert.equal(rows.length, 1);
+    } finally {
+      db.close();
+      fs.rmSync(syncDir, { recursive: true, force: true });
+    }
+  });
+
   test("suggest_scene_references returns not-found for non-existent scene", async () => {
     const db = openDb(":memory:");
     try {
@@ -636,7 +789,7 @@ describe("reference link search tools", () => {
       const sceneDir = path.join(syncDir, "projects", "test-novel", "scenes");
       fs.mkdirSync(sceneDir, { recursive: true });
       const scenePath = path.join(sceneDir, "sc-001.md");
-      fs.writeFileSync(scenePath, "---\nscene_id: sc-001\ntitle: Scene 1\n---\nScene prose.", "utf8");
+      fs.writeFileSync(scenePath, "---\nscene_id: sc-001\ntitle: Scene 1\ncharacters:\n  - char-mira\n---\nScene prose.", "utf8");
 
       db.prepare(`
         INSERT INTO scenes (

--- a/src/test/unit/reference-tools.test.mjs
+++ b/src/test/unit/reference-tools.test.mjs
@@ -86,12 +86,13 @@ function seedReferenceLink(db, {
   sourceId,
   targetDocId,
   relation,
+  origin = "inferred",
 }) {
   db.prepare(`
     INSERT INTO reference_links (
-      source_kind, source_project_id, source_id, target_doc_id, relation
-    ) VALUES (?, ?, ?, ?, ?)
-  `).run(sourceKind, sourceProjectId, sourceId, targetDocId, relation);
+      source_kind, source_project_id, source_id, target_doc_id, relation, origin
+    ) VALUES (?, ?, ?, ?, ?, ?)
+  `).run(sourceKind, sourceProjectId, sourceId, targetDocId, relation, origin);
 }
 
 describe("reference link search tools", () => {
@@ -207,6 +208,140 @@ describe("reference link search tools", () => {
       assert.equal(withRelated.related[0].doc_id, "ref-related");
       assert.deepEqual(withRelated.related[0].tags, ["related"]);
       assert.ok(!withRelated.related.some(item => item.doc_id === "ref-deep"));
+    } finally {
+      db.close();
+    }
+  });
+
+  test("suggest_scene_references scores references by character/place links", async () => {
+    const db = openDb(":memory:");
+    try {
+      seedProject(db, "test-novel");
+      seedScene(db, { sceneId: "sc-001", projectId: "test-novel" });
+      
+      // Create characters and places
+      db.prepare(`
+        INSERT INTO characters (character_id, project_id, name, file_path)
+        VALUES (?, ?, ?, ?)
+      `).run("char-mira", "test-novel", "Mira", "/tmp/mira.md");
+      
+      db.prepare(`
+        INSERT INTO characters (character_id, project_id, name, file_path)
+        VALUES (?, ?, ?, ?)
+      `).run("char-sebastian", "test-novel", "Sebastian", "/tmp/sebastian.md");
+      
+      db.prepare(`
+        INSERT INTO places (place_id, project_id, name, file_path)
+        VALUES (?, ?, ?, ?)
+      `).run("place-hospital", "test-novel", "Hospital", "/tmp/hospital.md");
+      
+      // Add scene characters and places
+      db.prepare(`INSERT INTO scene_characters (scene_id, character_id) VALUES (?, ?)`).run("sc-001", "char-mira");
+      db.prepare(`INSERT INTO scene_characters (scene_id, character_id) VALUES (?, ?)`).run("sc-001", "char-sebastian");
+      db.prepare(`INSERT INTO scene_places (scene_id, place_id) VALUES (?, ?)`).run("sc-001", "place-hospital");
+      
+      // Create reference docs
+      seedReferenceDoc(db, { docId: "ref-vampirism", projectId: "test-novel", title: "Vampirism in the World", type: "world" });
+      seedReferenceDoc(db, { docId: "ref-hospital-layout", projectId: "test-novel", title: "Hospital Layout", type: "world" });
+      seedReferenceDoc(db, { docId: "ref-unrelated", projectId: "test-novel", title: "Unrelated Doc", type: "world" });
+      
+      // Link references to characters and places
+      seedReferenceLink(db, {
+        sourceKind: "character",
+        sourceProjectId: "test-novel",
+        sourceId: "char-mira",
+        targetDocId: "ref-vampirism",
+        relation: "informs",
+      });
+      seedReferenceLink(db, {
+        sourceKind: "character",
+        sourceProjectId: "test-novel",
+        sourceId: "char-sebastian",
+        targetDocId: "ref-vampirism",
+        relation: "informs",
+      });
+      seedReferenceLink(db, {
+        sourceKind: "place",
+        sourceProjectId: "test-novel",
+        sourceId: "place-hospital",
+        targetDocId: "ref-hospital-layout",
+        relation: "informs",
+      });
+      
+      const tools = makeToolHarness(db);
+      const suggestions = await tools.call("suggest_scene_references", { scene_id: "sc-001", project_id: "test-novel" });
+      
+      assert.equal(suggestions.scene_id, "sc-001");
+      assert.equal(suggestions.total_candidates, 2);
+      
+      // Check scoring: vampirism should be first (score 2: 2 characters link to it)
+      assert.equal(suggestions.candidates[0].doc_id, "ref-vampirism");
+      assert.equal(suggestions.candidates[0].score, 2);
+      assert.equal(suggestions.candidates[0].sources.length, 2);
+      
+      // Hospital layout should be second (score 1: 1 place links to it)
+      assert.equal(suggestions.candidates[1].doc_id, "ref-hospital-layout");
+      assert.equal(suggestions.candidates[1].score, 1);
+      assert.equal(suggestions.candidates[1].sources.length, 1);
+    } finally {
+      db.close();
+    }
+  });
+
+  test("suggest_scene_references excludes already-explicit scene links", async () => {
+    const db = openDb(":memory:");
+    try {
+      seedProject(db, "test-novel");
+      seedScene(db, { sceneId: "sc-001", projectId: "test-novel" });
+      
+      db.prepare(`
+        INSERT INTO characters (character_id, project_id, name, file_path)
+        VALUES (?, ?, ?, ?)
+      `).run("char-mira", "test-novel", "Mira", "/tmp/mira.md");
+      
+      db.prepare(`INSERT INTO scene_characters (scene_id, character_id) VALUES (?, ?)`).run("sc-001", "char-mira");
+      
+      seedReferenceDoc(db, { docId: "ref-vampirism", projectId: "test-novel", title: "Vampirism", type: "world" });
+      
+      seedReferenceLink(db, {
+        sourceKind: "character",
+        sourceProjectId: "test-novel",
+        sourceId: "char-mira",
+        targetDocId: "ref-vampirism",
+        relation: "informs",
+      });
+      
+      // Add an explicit scene link to the same reference
+      seedReferenceLink(db, {
+        sourceKind: "scene",
+        sourceProjectId: "test-novel",
+        sourceId: "sc-001",
+        targetDocId: "ref-vampirism",
+        relation: "informs",
+        origin: "explicit",
+      });
+      
+      const tools = makeToolHarness(db);
+      const suggestions = await tools.call("suggest_scene_references", { scene_id: "sc-001", project_id: "test-novel" });
+      
+      // Should return empty suggestions because the only candidate is already explicitly linked
+      assert.equal(suggestions.total_candidates, 0);
+      assert.equal(suggestions.candidates.length, 0);
+    } finally {
+      db.close();
+    }
+  });
+
+  test("suggest_scene_references returns not-found for non-existent scene", async () => {
+    const db = openDb(":memory:");
+    try {
+      seedProject(db, "test-novel");
+      
+      const tools = makeToolHarness(db);
+      const result = await tools.call("suggest_scene_references", { scene_id: "sc-nonexistent", project_id: "test-novel" });
+      
+      assert.equal(result.ok, false);
+      assert.equal(result.error.code, "NOT_FOUND");
     } finally {
       db.close();
     }

--- a/src/test/unit/reference-tools.test.mjs
+++ b/src/test/unit/reference-tools.test.mjs
@@ -1,9 +1,12 @@
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { openDb } from "../../core/db.js";
 import { registerSearchTools } from "../../tools/search.js";
 
-function makeToolHarness(db) {
+function makeToolHarness(db, { syncDir = "", writable = false } = {}) {
   const handlers = new Map();
   const server = {
     tool(name, _description, _schema, handler) {
@@ -29,7 +32,8 @@ function makeToolHarness(db) {
 
   registerSearchTools(server, {
     db,
-    SYNC_DIR: "",
+    SYNC_DIR: syncDir,
+    SYNC_DIR_WRITABLE: writable,
     GIT_ENABLED: false,
     errorResponse,
     paginateRows: (rows, _opts) => ({ paginated: false, rows, meta: null }),
@@ -410,6 +414,86 @@ describe("reference link search tools", () => {
       assert.equal(result.error.code, "NOT_FOUND");
     } finally {
       db.close();
+    }
+  });
+
+  test("suggest_scene_references apply mode returns READ_ONLY when sync dir is not writable", async () => {
+    const db = openDb(":memory:");
+    try {
+      seedProject(db, "test-novel");
+      seedScene(db, { sceneId: "sc-001", projectId: "test-novel" });
+
+      const tools = makeToolHarness(db, { writable: false });
+      const result = await tools.call("suggest_scene_references", {
+        scene_id: "sc-001",
+        project_id: "test-novel",
+        mode: "apply",
+      });
+
+      assert.equal(result.ok, false);
+      assert.equal(result.error.code, "READ_ONLY");
+    } finally {
+      db.close();
+    }
+  });
+
+  test("suggest_scene_references apply mode persists explicit scene links", async () => {
+    const db = openDb(":memory:");
+    const syncDir = fs.mkdtempSync(path.join(os.tmpdir(), "ref-apply-"));
+    try {
+      seedProject(db, "test-novel");
+
+      const sceneDir = path.join(syncDir, "projects", "test-novel", "scenes");
+      fs.mkdirSync(sceneDir, { recursive: true });
+      const scenePath = path.join(sceneDir, "sc-001.md");
+      fs.writeFileSync(scenePath, "---\nscene_id: sc-001\ntitle: Scene 1\n---\nScene prose.", "utf8");
+
+      db.prepare(`
+        INSERT INTO scenes (
+          scene_id, project_id, title, file_path, prose_checksum, metadata_stale, updated_at
+        ) VALUES (?, ?, ?, ?, ?, 0, ?)
+      `).run("sc-001", "test-novel", "Scene 1", scenePath, "deadbeef", new Date().toISOString());
+
+      db.prepare(`
+        INSERT INTO characters (character_id, project_id, name, file_path)
+        VALUES (?, ?, ?, ?)
+      `).run("char-mira", "test-novel", "Mira", "/tmp/mira.md");
+      db.prepare(`INSERT INTO scene_characters (scene_id, character_id) VALUES (?, ?)`).run("sc-001", "char-mira");
+
+      seedReferenceDoc(db, { docId: "ref-vampirism", projectId: "test-novel", title: "Vampirism", type: "world" });
+      seedReferenceLink(db, {
+        sourceKind: "character",
+        sourceProjectId: "test-novel",
+        sourceId: "char-mira",
+        targetDocId: "ref-vampirism",
+        relation: "informs",
+      });
+
+      const tools = makeToolHarness(db, { syncDir, writable: true });
+      const result = await tools.call("suggest_scene_references", {
+        scene_id: "sc-001",
+        project_id: "test-novel",
+        mode: "apply",
+      });
+
+      assert.equal(result.applied_count, 1);
+      assert.equal(result.applied_links.length, 1);
+      assert.equal(result.applied_links[0].target_doc_id, "ref-vampirism");
+
+      const row = db.prepare(`
+        SELECT relation, origin
+        FROM reference_links
+        WHERE source_kind = 'scene' AND source_project_id = 'test-novel' AND source_id = 'sc-001' AND target_doc_id = 'ref-vampirism'
+      `).get();
+      assert.equal(row.relation, "informs");
+      assert.equal(row.origin, "explicit");
+
+      const sidecar = fs.readFileSync(scenePath.replace(/\.md$/, ".meta.yaml"), "utf8");
+      assert.match(sidecar, /reference_links:/);
+      assert.match(sidecar, /target_doc_id: ref-vampirism/);
+    } finally {
+      db.close();
+      fs.rmSync(syncDir, { recursive: true, force: true });
     }
   });
 });

--- a/src/tools/metadata.js
+++ b/src/tools/metadata.js
@@ -1,46 +1,13 @@
 import { z } from "zod";
 import fs from "node:fs";
 import matter from "gray-matter";
-import { readMeta, writeMeta, indexSceneFile, normalizeSceneMetaForPath, normalizeReferenceLinkList } from "../sync/sync.js";
+import { readMeta, writeMeta, indexSceneFile, normalizeSceneMetaForPath } from "../sync/sync.js";
 import { validateProjectId, validateUniverseId } from "../sync/importer.js";
-
-function upsertSerializedReferenceLinks(existing, targetDocId, relation, { defaultRelation }) {
-  const normalized = normalizeReferenceLinkList(existing ?? [], { defaultRelation });
-  const filtered = normalized.filter((entry) => entry.targetDocId !== targetDocId);
-  filtered.push({ targetDocId, relation });
-  return filtered.map((entry) => ({
-    target_doc_id: entry.targetDocId,
-    relation: entry.relation,
-  }));
-}
-
-function persistSceneReferenceLink({ scenePath, syncDir, targetDocId, relation }) {
-  const { meta } = readMeta(scenePath, syncDir, { writable: true });
-  const existingExplicit = [
-    ...(Array.isArray(meta.reference_links) ? meta.reference_links : meta.reference_links ? [meta.reference_links] : []),
-    ...(Array.isArray(meta.explicit_reference_links) ? meta.explicit_reference_links : meta.explicit_reference_links ? [meta.explicit_reference_links] : []),
-  ];
-  const nextReferenceLinks = upsertSerializedReferenceLinks(existingExplicit, targetDocId, relation, {
-    defaultRelation: "informs",
-  });
-
-  const nextMeta = {
-    ...meta,
-    reference_links: nextReferenceLinks,
-  };
-  delete nextMeta.explicit_reference_links;
-
-  if (relation === "informs") {
-    const existingIds = Array.isArray(meta.reference_ids)
-      ? meta.reference_ids
-      : typeof meta.reference_ids === "string"
-        ? meta.reference_ids.split(",")
-        : [];
-    nextMeta.reference_ids = [...new Set([...existingIds.map((value) => String(value).trim()).filter(Boolean), targetDocId])];
-  }
-
-  writeMeta(scenePath, nextMeta);
-}
+import {
+  persistSceneReferenceLink,
+  upsertExplicitReferenceLinkRow,
+  upsertSerializedReferenceLinks,
+} from "./reference-link-persistence.js";
 
 function persistReferenceDocLink({ filePath, targetDocId, relation }) {
   const raw = fs.readFileSync(filePath, "utf8");
@@ -110,6 +77,129 @@ function persistPlaceReferenceLink({ placePath, syncDir, targetDocId, relation }
   delete nextMeta.explicit_reference_links;
 
   writeMeta(placePath, nextMeta);
+}
+
+function resolveProjectScopedSource({
+  db,
+  errorResponse,
+  sourceKind,
+  sourceId,
+  sourceProjectId,
+  table,
+  idColumn,
+  label,
+}) {
+  if (sourceProjectId) {
+    const scoped = db.prepare(`
+      SELECT ${idColumn} AS source_id, project_id, file_path
+      FROM ${table}
+      WHERE ${idColumn} = ? AND project_id = ?
+      LIMIT 1
+    `).get(sourceId, sourceProjectId);
+    if (!scoped) {
+      return { error: errorResponse("NOT_FOUND", `${label} '${sourceId}' not found in project '${sourceProjectId}'.`) };
+    }
+    return {
+      value: {
+        resolvedSourceProjectId: scoped.project_id ?? "",
+        sourceFilePath: scoped.file_path,
+      },
+    };
+  }
+
+  const matches = db.prepare(`
+    SELECT ${idColumn} AS source_id, project_id, file_path
+    FROM ${table}
+    WHERE ${idColumn} = ?
+    ORDER BY project_id
+  `).all(sourceId);
+
+  if (matches.length === 0) {
+    return { error: errorResponse("NOT_FOUND", `${label} '${sourceId}' not found.`) };
+  }
+  if (matches.length > 1) {
+    return {
+      error: errorResponse(
+        "CONFLICT",
+        `${label} ID '${sourceId}' exists in multiple projects. Provide source_project_id to disambiguate.`,
+        { source_id: sourceId, project_ids: matches.map((row) => row.project_id) }
+      ),
+    };
+  }
+
+  return {
+    value: {
+      resolvedSourceProjectId: matches[0].project_id ?? "",
+      sourceFilePath: matches[0].file_path,
+    },
+  };
+}
+
+function resolveReferenceLinkSource({
+  db,
+  errorResponse,
+  sourceKind,
+  sourceId,
+  sourceProjectId,
+  targetDocId,
+}) {
+  if (sourceKind === "reference") {
+    const sourceDoc = db.prepare(`
+      SELECT doc_id, project_id, file_path
+      FROM reference_docs
+      WHERE doc_id = ?
+      LIMIT 1
+    `).get(sourceId);
+    if (!sourceDoc) {
+      return { error: errorResponse("NOT_FOUND", `Source reference doc '${sourceId}' not found.`) };
+    }
+    if (sourceId === targetDocId) {
+      return { error: errorResponse("VALIDATION_ERROR", "Self-links are not allowed for reference sources.") };
+    }
+    const resolvedSourceProjectId = sourceDoc.project_id ?? "";
+    if ((sourceProjectId ?? "") !== "" && sourceProjectId !== resolvedSourceProjectId) {
+      const resolvedSourceProjectLabel = resolvedSourceProjectId === ""
+        ? "unscoped/no project"
+        : `project '${resolvedSourceProjectId}'`;
+      const requestedSourceProjectLabel = sourceProjectId === ""
+        ? "unscoped/no project"
+        : `project '${sourceProjectId}'`;
+      return {
+        error: errorResponse(
+          "CONFLICT",
+          `Source reference doc '${sourceId}' belongs to ${resolvedSourceProjectLabel}, not ${requestedSourceProjectLabel}.`,
+          {
+            source_id: sourceId,
+            source_project_id: sourceProjectId,
+            resolved_source_project_id: resolvedSourceProjectId,
+          }
+        ),
+      };
+    }
+    return {
+      value: {
+        resolvedSourceProjectId,
+        sourceFilePath: sourceDoc.file_path,
+      },
+    };
+  }
+
+  const sourceConfigByKind = {
+    scene: { table: "scenes", idColumn: "scene_id", label: "Scene" },
+    character: { table: "characters", idColumn: "character_id", label: "Character" },
+    place: { table: "places", idColumn: "place_id", label: "Place" },
+  };
+  const config = sourceConfigByKind[sourceKind];
+  return resolveProjectScopedSource({
+    db,
+    errorResponse,
+    sourceKind,
+    sourceId,
+    sourceProjectId,
+    table: config.table,
+    idColumn: config.idColumn,
+    label: config.label,
+  });
 }
 
 export function registerMetadataTools(s, {
@@ -312,208 +402,77 @@ export function registerMetadataTools(s, {
         return errorResponse("NOT_FOUND", `Target reference doc '${target_doc_id}' not found.`);
       }
 
-      let resolvedSourceProjectId;
-      let sourceScenePath = null;
-      let sourceCharacterPath = null;
-      let sourcePlacePath = null;
-      let sourceReferencePath = null;
-
-      if (source_kind === "scene") {
-        if (source_project_id) {
-          const scene = db.prepare(`
-            SELECT scene_id, project_id, file_path
-            FROM scenes
-            WHERE scene_id = ? AND project_id = ?
-            LIMIT 1
-          `).get(source_id, source_project_id);
-          if (!scene) {
-            return errorResponse("NOT_FOUND", `Scene '${source_id}' not found in project '${source_project_id}'.`);
-          }
-          resolvedSourceProjectId = scene.project_id ?? "";
-          sourceScenePath = scene.file_path;
-        } else {
-          const matches = db.prepare(`
-            SELECT scene_id, project_id, file_path
-            FROM scenes
-            WHERE scene_id = ?
-            ORDER BY project_id
-          `).all(source_id);
-          if (matches.length === 0) {
-            return errorResponse("NOT_FOUND", `Scene '${source_id}' not found.`);
-          }
-          if (matches.length > 1) {
-            return errorResponse(
-              "CONFLICT",
-              `Scene ID '${source_id}' exists in multiple projects. Provide source_project_id to disambiguate.`,
-              { source_id, project_ids: matches.map(row => row.project_id) }
-            );
-          }
-          resolvedSourceProjectId = matches[0].project_id ?? "";
-          sourceScenePath = matches[0].file_path;
-        }
-      } else if (source_kind === "character") {
-        if (source_project_id) {
-          const character = db.prepare(`
-            SELECT character_id, project_id, file_path
-            FROM characters
-            WHERE character_id = ? AND project_id = ?
-            LIMIT 1
-          `).get(source_id, source_project_id);
-          if (!character) {
-            return errorResponse("NOT_FOUND", `Character '${source_id}' not found in project '${source_project_id}'.`);
-          }
-          resolvedSourceProjectId = character.project_id ?? "";
-          sourceCharacterPath = character.file_path;
-        } else {
-          const matches = db.prepare(`
-            SELECT character_id, project_id, file_path
-            FROM characters
-            WHERE character_id = ?
-            ORDER BY project_id
-          `).all(source_id);
-          if (matches.length === 0) {
-            return errorResponse("NOT_FOUND", `Character '${source_id}' not found.`);
-          }
-          if (matches.length > 1) {
-            return errorResponse(
-              "CONFLICT",
-              `Character ID '${source_id}' exists in multiple projects. Provide source_project_id to disambiguate.`,
-              { source_id, project_ids: matches.map(row => row.project_id) }
-            );
-          }
-          resolvedSourceProjectId = matches[0].project_id ?? "";
-          sourceCharacterPath = matches[0].file_path;
-        }
-      } else if (source_kind === "place") {
-        if (source_project_id) {
-          const place = db.prepare(`
-            SELECT place_id, project_id, file_path
-            FROM places
-            WHERE place_id = ? AND project_id = ?
-            LIMIT 1
-          `).get(source_id, source_project_id);
-          if (!place) {
-            return errorResponse("NOT_FOUND", `Place '${source_id}' not found in project '${source_project_id}'.`);
-          }
-          resolvedSourceProjectId = place.project_id ?? "";
-          sourcePlacePath = place.file_path;
-        } else {
-          const matches = db.prepare(`
-            SELECT place_id, project_id, file_path
-            FROM places
-            WHERE place_id = ?
-            ORDER BY project_id
-          `).all(source_id);
-          if (matches.length === 0) {
-            return errorResponse("NOT_FOUND", `Place '${source_id}' not found.`);
-          }
-          if (matches.length > 1) {
-            return errorResponse(
-              "CONFLICT",
-              `Place ID '${source_id}' exists in multiple projects. Provide source_project_id to disambiguate.`,
-              { source_id, project_ids: matches.map(row => row.project_id) }
-            );
-          }
-          resolvedSourceProjectId = matches[0].project_id ?? "";
-          sourcePlacePath = matches[0].file_path;
-        }
-      } else {
-        const sourceDoc = db.prepare(`
-          SELECT doc_id, project_id, file_path
-          FROM reference_docs
-          WHERE doc_id = ?
-          LIMIT 1
-        `).get(source_id);
-        if (!sourceDoc) {
-          return errorResponse("NOT_FOUND", `Source reference doc '${source_id}' not found.`);
-        }
-        if (source_id === target_doc_id) {
-          return errorResponse("VALIDATION_ERROR", "Self-links are not allowed for reference sources.");
-        }
-        resolvedSourceProjectId = sourceDoc.project_id ?? "";
-        if ((source_project_id ?? "") !== "" && source_project_id !== resolvedSourceProjectId) {
-          const resolvedSourceProjectLabel = resolvedSourceProjectId === ""
-            ? "unscoped/no project"
-            : `project '${resolvedSourceProjectId}'`;
-          const requestedSourceProjectLabel = source_project_id === ""
-            ? "unscoped/no project"
-            : `project '${source_project_id}'`;
-          return errorResponse(
-            "CONFLICT",
-            `Source reference doc '${source_id}' belongs to ${resolvedSourceProjectLabel}, not ${requestedSourceProjectLabel}.`,
-            {
-              source_id,
-              source_project_id,
-              resolved_source_project_id: resolvedSourceProjectId,
-            }
-          );
-        }
-        sourceReferencePath = sourceDoc.file_path;
+      const sourceResolution = resolveReferenceLinkSource({
+        db,
+        errorResponse,
+        sourceKind: source_kind,
+        sourceId: source_id,
+        sourceProjectId: source_project_id,
+        targetDocId: target_doc_id,
+      });
+      if (sourceResolution.error) {
+        return sourceResolution.error;
       }
+      const { resolvedSourceProjectId, sourceFilePath } = sourceResolution.value;
 
       try {
         if (source_kind === "scene") {
-          if (!sourceScenePath) {
+          if (!sourceFilePath) {
             return errorResponse("STALE_PATH", `Scene '${source_id}' has no indexed file path. Run sync() to refresh.`, {
               source_id,
               source_project_id: resolvedSourceProjectId,
             });
           }
           persistSceneReferenceLink({
-            scenePath: sourceScenePath,
+            scenePath: sourceFilePath,
             syncDir: SYNC_DIR,
             targetDocId: target_doc_id,
             relation: normalizedRelation,
           });
         } else if (source_kind === "character") {
-          if (!sourceCharacterPath) {
+          if (!sourceFilePath) {
             return errorResponse("STALE_PATH", `Character '${source_id}' has no indexed file path. Run sync() to refresh.`, {
               source_id,
               source_project_id: resolvedSourceProjectId,
             });
           }
           persistCharacterReferenceLink({
-            characterPath: sourceCharacterPath,
+            characterPath: sourceFilePath,
             syncDir: SYNC_DIR,
             targetDocId: target_doc_id,
             relation: normalizedRelation,
           });
         } else if (source_kind === "place") {
-          if (!sourcePlacePath) {
+          if (!sourceFilePath) {
             return errorResponse("STALE_PATH", `Place '${source_id}' has no indexed file path. Run sync() to refresh.`, {
               source_id,
               source_project_id: resolvedSourceProjectId,
             });
           }
           persistPlaceReferenceLink({
-            placePath: sourcePlacePath,
+            placePath: sourceFilePath,
             syncDir: SYNC_DIR,
             targetDocId: target_doc_id,
             relation: normalizedRelation,
           });
         } else {
-          if (!sourceReferencePath) {
+          if (!sourceFilePath) {
             return errorResponse("STALE_PATH", `Reference doc '${source_id}' has no indexed file path. Run sync() to refresh.`, {
               source_id,
             });
           }
           persistReferenceDocLink({
-            filePath: sourceReferencePath,
+            filePath: sourceFilePath,
             targetDocId: target_doc_id,
             relation: normalizedRelation,
           });
         }
       } catch (err) {
         if (err?.code === "ENOENT") {
-          let indexedPath;
-          if (source_kind === "scene") indexedPath = sourceScenePath;
-          else if (source_kind === "character") indexedPath = sourceCharacterPath;
-          else if (source_kind === "place") indexedPath = sourcePlacePath;
-          else indexedPath = sourceReferencePath;
           return errorResponse(
             "STALE_PATH",
             `Source file for ${source_kind} '${source_id}' not found at indexed path — run sync() to refresh.`,
-            { indexed_path: indexedPath }
+            { indexed_path: sourceFilePath }
           );
         }
         return errorResponse("IO_ERROR", `Failed to persist link metadata: ${err.message}`);
@@ -521,16 +480,13 @@ export function registerMetadataTools(s, {
 
       try {
         db.exec("BEGIN");
-        db.prepare(`
-          DELETE FROM reference_links
-          WHERE source_kind = ? AND source_project_id = ? AND source_id = ? AND target_doc_id = ?
-        `).run(source_kind, resolvedSourceProjectId, source_id, target_doc_id);
-
-        db.prepare(`
-          INSERT INTO reference_links (
-            source_kind, source_project_id, source_id, target_doc_id, relation, origin
-          ) VALUES (?, ?, ?, ?, ?, 'explicit')
-        `).run(source_kind, resolvedSourceProjectId, source_id, target_doc_id, normalizedRelation);
+        upsertExplicitReferenceLinkRow(db, {
+          sourceKind: source_kind,
+          sourceProjectId: resolvedSourceProjectId,
+          sourceId: source_id,
+          targetDocId: target_doc_id,
+          relation: normalizedRelation,
+        });
         db.exec("COMMIT");
       } catch (err) {
         try {

--- a/src/tools/metadata.js
+++ b/src/tools/metadata.js
@@ -82,7 +82,6 @@ function persistPlaceReferenceLink({ placePath, syncDir, targetDocId, relation }
 function resolveProjectScopedSource({
   db,
   errorResponse,
-  sourceKind,
   sourceId,
   sourceProjectId,
   table,
@@ -193,7 +192,6 @@ function resolveReferenceLinkSource({
   return resolveProjectScopedSource({
     db,
     errorResponse,
-    sourceKind,
     sourceId,
     sourceProjectId,
     table: config.table,

--- a/src/tools/metadata.js
+++ b/src/tools/metadata.js
@@ -74,6 +74,44 @@ function persistReferenceDocLink({ filePath, targetDocId, relation }) {
   fs.writeFileSync(filePath, matter.stringify(parsed.content, nextData), "utf8");
 }
 
+function persistCharacterReferenceLink({ characterPath, syncDir, targetDocId, relation }) {
+  const { meta } = readMeta(characterPath, syncDir, { writable: true });
+  const existingExplicit = [
+    ...(Array.isArray(meta.reference_links) ? meta.reference_links : meta.reference_links ? [meta.reference_links] : []),
+    ...(Array.isArray(meta.explicit_reference_links) ? meta.explicit_reference_links : meta.explicit_reference_links ? [meta.explicit_reference_links] : []),
+  ];
+  const nextReferenceLinks = upsertSerializedReferenceLinks(existingExplicit, targetDocId, relation, {
+    defaultRelation: "informs",
+  });
+
+  const nextMeta = {
+    ...meta,
+    reference_links: nextReferenceLinks,
+  };
+  delete nextMeta.explicit_reference_links;
+
+  writeMeta(characterPath, nextMeta);
+}
+
+function persistPlaceReferenceLink({ placePath, syncDir, targetDocId, relation }) {
+  const { meta } = readMeta(placePath, syncDir, { writable: true });
+  const existingExplicit = [
+    ...(Array.isArray(meta.reference_links) ? meta.reference_links : meta.reference_links ? [meta.reference_links] : []),
+    ...(Array.isArray(meta.explicit_reference_links) ? meta.explicit_reference_links : meta.explicit_reference_links ? [meta.explicit_reference_links] : []),
+  ];
+  const nextReferenceLinks = upsertSerializedReferenceLinks(existingExplicit, targetDocId, relation, {
+    defaultRelation: "informs",
+  });
+
+  const nextMeta = {
+    ...meta,
+    reference_links: nextReferenceLinks,
+  };
+  delete nextMeta.explicit_reference_links;
+
+  writeMeta(placePath, nextMeta);
+}
+
 export function registerMetadataTools(s, {
   db,
   SYNC_DIR,
@@ -243,11 +281,11 @@ export function registerMetadataTools(s, {
   // ---- upsert_reference_link -----------------------------------------------
   s.tool(
     "upsert_reference_link",
-    "Create or update an explicit reference link from a scene or reference doc to a target reference doc. If a link already exists between the same source and target, this updates the relation. Only available when the sync dir is writable.",
+    "Create or update an explicit reference link from a scene, character, place, or reference doc to a target reference doc. If a link already exists between the same source and target, this updates the relation. Only available when the sync dir is writable.",
     {
-      source_kind: z.enum(["scene", "reference"]).describe("Link source kind."),
-      source_id: z.string().describe("Source scene_id or reference doc_id."),
-      source_project_id: z.string().optional().describe("Optional project scope for the source. For scene sources, use this to disambiguate an ambiguous scene_id across projects. For reference sources, when provided, it is treated as an ownership check and must match the source reference doc's project."),
+      source_kind: z.enum(["scene", "character", "place", "reference"]).describe("Link source kind."),
+      source_id: z.string().describe("Source scene_id, character_id, place_id, or reference doc_id."),
+      source_project_id: z.string().optional().describe("Optional project scope for the source. For scene/character/place sources, use this to disambiguate an ambiguous source_id across projects. For reference sources, when provided, it is treated as an ownership check and must match the source reference doc's project."),
       target_doc_id: z.string().describe("Target reference doc_id."),
       relation: z.string().describe("Relationship label (for example: 'informs', 'related', 'history_of'). The value is trimmed and lowercased before validation."),
     },
@@ -276,7 +314,10 @@ export function registerMetadataTools(s, {
 
       let resolvedSourceProjectId;
       let sourceScenePath = null;
+      let sourceCharacterPath = null;
+      let sourcePlacePath = null;
       let sourceReferencePath = null;
+
       if (source_kind === "scene") {
         if (source_project_id) {
           const scene = db.prepare(`
@@ -309,6 +350,72 @@ export function registerMetadataTools(s, {
           }
           resolvedSourceProjectId = matches[0].project_id ?? "";
           sourceScenePath = matches[0].file_path;
+        }
+      } else if (source_kind === "character") {
+        if (source_project_id) {
+          const character = db.prepare(`
+            SELECT character_id, project_id, file_path
+            FROM characters
+            WHERE character_id = ? AND project_id = ?
+            LIMIT 1
+          `).get(source_id, source_project_id);
+          if (!character) {
+            return errorResponse("NOT_FOUND", `Character '${source_id}' not found in project '${source_project_id}'.`);
+          }
+          resolvedSourceProjectId = character.project_id ?? "";
+          sourceCharacterPath = character.file_path;
+        } else {
+          const matches = db.prepare(`
+            SELECT character_id, project_id, file_path
+            FROM characters
+            WHERE character_id = ?
+            ORDER BY project_id
+          `).all(source_id);
+          if (matches.length === 0) {
+            return errorResponse("NOT_FOUND", `Character '${source_id}' not found.`);
+          }
+          if (matches.length > 1) {
+            return errorResponse(
+              "CONFLICT",
+              `Character ID '${source_id}' exists in multiple projects. Provide source_project_id to disambiguate.`,
+              { source_id, project_ids: matches.map(row => row.project_id) }
+            );
+          }
+          resolvedSourceProjectId = matches[0].project_id ?? "";
+          sourceCharacterPath = matches[0].file_path;
+        }
+      } else if (source_kind === "place") {
+        if (source_project_id) {
+          const place = db.prepare(`
+            SELECT place_id, project_id, file_path
+            FROM places
+            WHERE place_id = ? AND project_id = ?
+            LIMIT 1
+          `).get(source_id, source_project_id);
+          if (!place) {
+            return errorResponse("NOT_FOUND", `Place '${source_id}' not found in project '${source_project_id}'.`);
+          }
+          resolvedSourceProjectId = place.project_id ?? "";
+          sourcePlacePath = place.file_path;
+        } else {
+          const matches = db.prepare(`
+            SELECT place_id, project_id, file_path
+            FROM places
+            WHERE place_id = ?
+            ORDER BY project_id
+          `).all(source_id);
+          if (matches.length === 0) {
+            return errorResponse("NOT_FOUND", `Place '${source_id}' not found.`);
+          }
+          if (matches.length > 1) {
+            return errorResponse(
+              "CONFLICT",
+              `Place ID '${source_id}' exists in multiple projects. Provide source_project_id to disambiguate.`,
+              { source_id, project_ids: matches.map(row => row.project_id) }
+            );
+          }
+          resolvedSourceProjectId = matches[0].project_id ?? "";
+          sourcePlacePath = matches[0].file_path;
         }
       } else {
         const sourceDoc = db.prepare(`
@@ -358,6 +465,32 @@ export function registerMetadataTools(s, {
             targetDocId: target_doc_id,
             relation: normalizedRelation,
           });
+        } else if (source_kind === "character") {
+          if (!sourceCharacterPath) {
+            return errorResponse("STALE_PATH", `Character '${source_id}' has no indexed file path. Run sync() to refresh.`, {
+              source_id,
+              source_project_id: resolvedSourceProjectId,
+            });
+          }
+          persistCharacterReferenceLink({
+            characterPath: sourceCharacterPath,
+            syncDir: SYNC_DIR,
+            targetDocId: target_doc_id,
+            relation: normalizedRelation,
+          });
+        } else if (source_kind === "place") {
+          if (!sourcePlacePath) {
+            return errorResponse("STALE_PATH", `Place '${source_id}' has no indexed file path. Run sync() to refresh.`, {
+              source_id,
+              source_project_id: resolvedSourceProjectId,
+            });
+          }
+          persistPlaceReferenceLink({
+            placePath: sourcePlacePath,
+            syncDir: SYNC_DIR,
+            targetDocId: target_doc_id,
+            relation: normalizedRelation,
+          });
         } else {
           if (!sourceReferencePath) {
             return errorResponse("STALE_PATH", `Reference doc '${source_id}' has no indexed file path. Run sync() to refresh.`, {
@@ -372,7 +505,11 @@ export function registerMetadataTools(s, {
         }
       } catch (err) {
         if (err?.code === "ENOENT") {
-          const indexedPath = source_kind === "scene" ? sourceScenePath : sourceReferencePath;
+          let indexedPath;
+          if (source_kind === "scene") indexedPath = sourceScenePath;
+          else if (source_kind === "character") indexedPath = sourceCharacterPath;
+          else if (source_kind === "place") indexedPath = sourcePlacePath;
+          else indexedPath = sourceReferencePath;
           return errorResponse(
             "STALE_PATH",
             `Source file for ${source_kind} '${source_id}' not found at indexed path — run sync() to refresh.`,

--- a/src/tools/reference-link-persistence.js
+++ b/src/tools/reference-link-persistence.js
@@ -1,0 +1,55 @@
+import { readMeta, writeMeta, normalizeReferenceLinkList } from "../sync/sync.js";
+
+export function upsertSerializedReferenceLinks(existing, targetDocId, relation, { defaultRelation }) {
+  const normalized = normalizeReferenceLinkList(existing ?? [], { defaultRelation });
+  const filtered = normalized.filter((entry) => entry.targetDocId !== targetDocId);
+  filtered.push({ targetDocId, relation });
+  return filtered.map((entry) => ({
+    target_doc_id: entry.targetDocId,
+    relation: entry.relation,
+  }));
+}
+
+export function persistSceneReferenceLink({ scenePath, syncDir, targetDocId, relation }) {
+  const { meta } = readMeta(scenePath, syncDir, { writable: true });
+  const existingExplicit = [
+    ...(Array.isArray(meta.reference_links) ? meta.reference_links : meta.reference_links ? [meta.reference_links] : []),
+    ...(Array.isArray(meta.explicit_reference_links) ? meta.explicit_reference_links : meta.explicit_reference_links ? [meta.explicit_reference_links] : []),
+  ];
+  const nextReferenceLinks = upsertSerializedReferenceLinks(existingExplicit, targetDocId, relation, {
+    defaultRelation: "informs",
+  });
+
+  const nextMeta = {
+    ...meta,
+    reference_links: nextReferenceLinks,
+  };
+  delete nextMeta.explicit_reference_links;
+
+  if (relation === "informs") {
+    const existingIds = Array.isArray(meta.reference_ids)
+      ? meta.reference_ids
+      : typeof meta.reference_ids === "string"
+        ? meta.reference_ids.split(",")
+        : [];
+    nextMeta.reference_ids = [...new Set([...existingIds.map((value) => String(value).trim()).filter(Boolean), targetDocId])];
+  }
+
+  writeMeta(scenePath, nextMeta);
+}
+
+export function upsertExplicitReferenceLinkRow(
+  db,
+  { sourceKind, sourceProjectId, sourceId, targetDocId, relation }
+) {
+  db.prepare(`
+    DELETE FROM reference_links
+    WHERE source_kind = ? AND source_project_id = ? AND source_id = ? AND target_doc_id = ?
+  `).run(sourceKind, sourceProjectId, sourceId, targetDocId);
+
+  db.prepare(`
+    INSERT INTO reference_links (
+      source_kind, source_project_id, source_id, target_doc_id, relation, origin
+    ) VALUES (?, ?, ?, ?, ?, 'explicit')
+  `).run(sourceKind, sourceProjectId, sourceId, targetDocId, relation);
+}

--- a/src/tools/reference-link-persistence.js
+++ b/src/tools/reference-link-persistence.js
@@ -1,5 +1,7 @@
 import { readMeta, writeMeta, normalizeReferenceLinkList } from "../sync/sync.js";
 
+let savepointCounter = 0;
+
 export function upsertSerializedReferenceLinks(existing, targetDocId, relation, { defaultRelation }) {
   const normalized = normalizeReferenceLinkList(existing ?? [], { defaultRelation });
   const filtered = normalized.filter((entry) => entry.targetDocId !== targetDocId);
@@ -42,14 +44,34 @@ export function upsertExplicitReferenceLinkRow(
   db,
   { sourceKind, sourceProjectId, sourceId, targetDocId, relation }
 ) {
-  db.prepare(`
+  const deleteStmt = db.prepare(`
     DELETE FROM reference_links
     WHERE source_kind = ? AND source_project_id = ? AND source_id = ? AND target_doc_id = ?
-  `).run(sourceKind, sourceProjectId, sourceId, targetDocId);
-
-  db.prepare(`
+  `);
+  const insertStmt = db.prepare(`
     INSERT INTO reference_links (
       source_kind, source_project_id, source_id, target_doc_id, relation, origin
     ) VALUES (?, ?, ?, ?, ?, 'explicit')
-  `).run(sourceKind, sourceProjectId, sourceId, targetDocId, relation);
+  `);
+
+  const runUpsertBody = () => {
+    deleteStmt.run(sourceKind, sourceProjectId, sourceId, targetDocId);
+    insertStmt.run(sourceKind, sourceProjectId, sourceId, targetDocId, relation);
+  };
+
+  if (typeof db.transaction === "function") {
+    db.transaction(runUpsertBody)();
+    return;
+  }
+
+  const savepointName = `reference_link_upsert_${savepointCounter += 1}`;
+  db.exec(`SAVEPOINT ${savepointName};`);
+  try {
+    runUpsertBody();
+    db.exec(`RELEASE SAVEPOINT ${savepointName};`);
+  } catch (err) {
+    db.exec(`ROLLBACK TO SAVEPOINT ${savepointName};`);
+    db.exec(`RELEASE SAVEPOINT ${savepointName};`);
+    throw err;
+  }
 }

--- a/src/tools/search.js
+++ b/src/tools/search.js
@@ -1,44 +1,23 @@
 import { z } from "zod";
 import fs from "node:fs";
 import matter from "gray-matter";
-import { readMeta, writeMeta, normalizeReferenceLinkList } from "../sync/sync.js";
+import { persistSceneReferenceLink, upsertExplicitReferenceLinkRow } from "./reference-link-persistence.js";
 
-function upsertSerializedReferenceLinks(existing, targetDocId, relation, { defaultRelation }) {
-  const normalized = normalizeReferenceLinkList(existing ?? [], { defaultRelation });
-  const filtered = normalized.filter((entry) => entry.targetDocId !== targetDocId);
-  filtered.push({ targetDocId, relation });
-  return filtered.map((entry) => ({
-    target_doc_id: entry.targetDocId,
-    relation: entry.relation,
-  }));
-}
-
-function persistSceneReferenceLink({ scenePath, syncDir, targetDocId, relation }) {
-  const { meta } = readMeta(scenePath, syncDir, { writable: true });
-  const existingExplicit = [
-    ...(Array.isArray(meta.reference_links) ? meta.reference_links : meta.reference_links ? [meta.reference_links] : []),
-    ...(Array.isArray(meta.explicit_reference_links) ? meta.explicit_reference_links : meta.explicit_reference_links ? [meta.explicit_reference_links] : []),
-  ];
-  const nextReferenceLinks = upsertSerializedReferenceLinks(existingExplicit, targetDocId, relation, {
-    defaultRelation: "informs",
-  });
-
-  const nextMeta = {
-    ...meta,
-    reference_links: nextReferenceLinks,
-  };
-  delete nextMeta.explicit_reference_links;
-
-  if (relation === "informs") {
-    const existingIds = Array.isArray(meta.reference_ids)
-      ? meta.reference_ids
-      : typeof meta.reference_ids === "string"
-        ? meta.reference_ids.split(",")
-        : [];
-    nextMeta.reference_ids = [...new Set([...existingIds.map((value) => String(value).trim()).filter(Boolean), targetDocId])];
+function accumulateSuggestionScore(scoreMap, rows, sourceLabel) {
+  for (const row of rows) {
+    const key = `${row.target_doc_id}:${row.relation}`;
+    if (!scoreMap.has(key)) {
+      scoreMap.set(key, {
+        doc_id: row.target_doc_id,
+        relation: row.relation,
+        score: 0,
+        sources: [],
+      });
+    }
+    const entry = scoreMap.get(key);
+    entry.score += 1;
+    entry.sources.push(`${sourceLabel}: ${row.source_name ?? row.source_id}`);
   }
-
-  writeMeta(scenePath, nextMeta);
 }
 
 export function registerSearchTools(s, {
@@ -842,7 +821,7 @@ export function registerSearchTools(s, {
       // Load all character/place source links in project scope and aggregate in memory.
       const characterReferenceLinks = characters.length > 0
         ? db.prepare(`
-            SELECT rl.target_doc_id, rl.relation, rl.source_id AS character_id, c.name AS character_name
+            SELECT rl.target_doc_id, rl.relation, rl.source_id AS source_id, c.name AS source_name
             FROM reference_links rl
             LEFT JOIN characters c
               ON c.character_id = rl.source_id
@@ -855,7 +834,7 @@ export function registerSearchTools(s, {
 
       const placeReferenceLinks = places.length > 0
         ? db.prepare(`
-            SELECT rl.target_doc_id, rl.relation, rl.source_id AS place_id, p.name AS place_name
+            SELECT rl.target_doc_id, rl.relation, rl.source_id AS source_id, p.name AS source_name
             FROM reference_links rl
             LEFT JOIN places p
               ON p.place_id = rl.source_id
@@ -868,36 +847,8 @@ export function registerSearchTools(s, {
 
       // Merge and score
       const scoreMap = new Map(); // key: "doc_id:relation" → { doc_id, relation, score, sources: [...] }
-
-      for (const row of characterReferenceLinks) {
-        const key = `${row.target_doc_id}:${row.relation}`;
-        if (!scoreMap.has(key)) {
-          scoreMap.set(key, {
-            doc_id: row.target_doc_id,
-            relation: row.relation,
-            score: 0,
-            sources: [],
-          });
-        }
-        const entry = scoreMap.get(key);
-        entry.score += 1;
-        entry.sources.push(`character: ${row.character_name ?? row.character_id}`);
-      }
-
-      for (const row of placeReferenceLinks) {
-        const key = `${row.target_doc_id}:${row.relation}`;
-        if (!scoreMap.has(key)) {
-          scoreMap.set(key, {
-            doc_id: row.target_doc_id,
-            relation: row.relation,
-            score: 0,
-            sources: [],
-          });
-        }
-        const entry = scoreMap.get(key);
-        entry.score += 1;
-        entry.sources.push(`place: ${row.place_name ?? row.place_id}`);
-      }
+      accumulateSuggestionScore(scoreMap, characterReferenceLinks, "character");
+      accumulateSuggestionScore(scoreMap, placeReferenceLinks, "place");
 
       // Filter out already explicit scene links and deduplicate sources
       const candidates = Array.from(scoreMap.values())
@@ -963,55 +914,50 @@ export function registerSearchTools(s, {
           .slice(0, max_apply ?? enriched.length);
 
         const appliedLinks = [];
-        for (const candidate of toApply) {
-          try {
+        try {
+          db.exec("BEGIN");
+
+          for (const candidate of toApply) {
             persistSceneReferenceLink({
               scenePath: resolvedScene.file_path,
               syncDir: SYNC_DIR,
               targetDocId: candidate.doc_id,
               relation: candidate.relation,
             });
-          } catch (err) {
-            if (err?.code === "ENOENT") {
-              return errorResponse(
-                "STALE_PATH",
-                `Scene file for '${scene_id}' not found at indexed path — run sync() to refresh.`,
-                { indexed_path: resolvedScene.file_path }
-              );
-            }
-            return errorResponse("IO_ERROR", `Failed to persist scene reference link metadata: ${err.message}`);
+
+            upsertExplicitReferenceLinkRow(db, {
+              sourceKind: "scene",
+              sourceProjectId: resolvedProjectId,
+              sourceId: scene_id,
+              targetDocId: candidate.doc_id,
+              relation: candidate.relation,
+            });
+
+            appliedLinks.push({
+              source_kind: "scene",
+              source_project_id: resolvedProjectId,
+              source_id: scene_id,
+              target_doc_id: candidate.doc_id,
+              relation: candidate.relation,
+              origin: "explicit",
+            });
           }
 
+          db.exec("COMMIT");
+        } catch (err) {
           try {
-            db.exec("BEGIN");
-            db.prepare(`
-              DELETE FROM reference_links
-              WHERE source_kind = 'scene' AND source_project_id = ? AND source_id = ? AND target_doc_id = ?
-            `).run(resolvedProjectId, scene_id, candidate.doc_id);
-
-            db.prepare(`
-              INSERT INTO reference_links (
-                source_kind, source_project_id, source_id, target_doc_id, relation, origin
-              ) VALUES ('scene', ?, ?, ?, ?, 'explicit')
-            `).run(resolvedProjectId, scene_id, candidate.doc_id, candidate.relation);
-            db.exec("COMMIT");
-          } catch (err) {
-            try {
-              db.exec("ROLLBACK");
-            } catch (rollbackErr) {
-              void rollbackErr;
-            }
-            return errorResponse("IO_ERROR", `Failed to persist scene reference link index row: ${err.message}`);
+            db.exec("ROLLBACK");
+          } catch (rollbackErr) {
+            void rollbackErr;
           }
-
-          appliedLinks.push({
-            source_kind: "scene",
-            source_project_id: resolvedProjectId,
-            source_id: scene_id,
-            target_doc_id: candidate.doc_id,
-            relation: candidate.relation,
-            origin: "explicit",
-          });
+          if (err?.code === "ENOENT") {
+            return errorResponse(
+              "STALE_PATH",
+              `Scene file for '${scene_id}' not found at indexed path — run sync() to refresh.`,
+              { indexed_path: resolvedScene.file_path }
+            );
+          }
+          return errorResponse("IO_ERROR", `Failed to persist scene reference link index rows: ${err.message}`);
         }
 
         return {

--- a/src/tools/search.js
+++ b/src/tools/search.js
@@ -39,6 +39,21 @@ function readSceneEntityIdsFromMetadata({ scenePath, syncDir }) {
   };
 }
 
+function selectApplyCandidates(enrichedCandidates, selectedDocIds, maxApply) {
+  const selectedSet = selectedDocIds ? new Set(selectedDocIds) : null;
+  const chosenByDocId = new Map();
+
+  for (const candidate of enrichedCandidates) {
+    if (selectedSet && !selectedSet.has(candidate.doc_id)) continue;
+    if (!chosenByDocId.has(candidate.doc_id)) {
+      chosenByDocId.set(candidate.doc_id, candidate);
+    }
+  }
+
+  const uniqueCandidates = Array.from(chosenByDocId.values());
+  return uniqueCandidates.slice(0, maxApply ?? uniqueCandidates.length);
+}
+
 export function registerSearchTools(s, {
   db,
   SYNC_DIR,
@@ -829,11 +844,9 @@ export function registerSearchTools(s, {
             scenePath: resolvedScene.file_path,
             syncDir: SYNC_DIR,
           });
-          if (entities.characterIds.length > 0 || entities.placeIds.length > 0) {
             characterIds = entities.characterIds;
             placeIds = entities.placeIds;
             loadedSceneEntitiesFromMetadata = true;
-          }
         } catch (err) {
           void err;
         }
@@ -891,14 +904,14 @@ export function registerSearchTools(s, {
       accumulateSuggestionScore(scoreMap, placeReferenceLinks, "place");
 
       // Filter out already explicit scene links and deduplicate sources
-      const candidates = Array.from(scoreMap.values())
+        const candidates = Array.from(scoreMap.values())
         .filter(entry => !existingSceneDocIds.has(entry.doc_id))
         .filter(entry => entry.score >= min_score)
         .map(entry => ({
           ...entry,
           sources: [...new Set(entry.sources)], // deduplicate
         }))
-        .sort((a, b) => b.score - a.score || a.doc_id.localeCompare(b.doc_id));
+          .sort((a, b) => b.score - a.score || a.doc_id.localeCompare(b.doc_id) || a.relation.localeCompare(b.relation));
 
       const candidateDocIds = [...new Set(candidates.map(candidate => candidate.doc_id))];
       const docsById = candidateDocIds.length > 0
@@ -914,15 +927,19 @@ export function registerSearchTools(s, {
         : new Map();
 
       // Enrich with reference doc metadata
-      const enriched = candidates.map(candidate => {
-        const doc = docsById.get(candidate.doc_id);
-        return {
-          ...candidate,
-          title: doc?.title || candidate.doc_id,
-          type: doc?.type || "unknown",
-          summary: doc?.summary || null,
-        };
-      });
+        const enriched = candidates
+          .filter(candidate => docsById.has(candidate.doc_id))
+          .map(candidate => {
+            const doc = docsById.get(candidate.doc_id);
+            return {
+              ...candidate,
+              title: doc.title,
+              type: doc.type,
+              summary: doc.summary,
+            };
+          });
+
+        const skippedMissingDocIds = candidateDocIds.filter((docId) => !docsById.has(docId));
 
       if (enriched.length === 0) {
         return {
@@ -932,7 +949,8 @@ export function registerSearchTools(s, {
               scene_id,
               project_id: resolvedProjectId,
               total_candidates: 0,
-                message: "No reference suggestions found. Scene characters and places have no linked references.",
+              message: "No reference suggestions found. Scene characters and places have no linked references.",
+              skipped_missing_doc_ids: skippedMissingDocIds,
               candidates: [],
             }, null, 2),
           }],
@@ -948,10 +966,7 @@ export function registerSearchTools(s, {
           });
         }
 
-        const selectedSet = selected_doc_ids ? new Set(selected_doc_ids) : null;
-        const toApply = enriched
-          .filter(candidate => !selectedSet || selectedSet.has(candidate.doc_id))
-          .slice(0, max_apply ?? enriched.length);
+          const toApply = selectApplyCandidates(enriched, selected_doc_ids, max_apply);
 
         const appliedLinks = [];
         const failedLinks = [];
@@ -1014,6 +1029,7 @@ export function registerSearchTools(s, {
               project_id: resolvedProjectId,
               mode,
               total_candidates: enriched.length,
+                skipped_missing_doc_ids: skippedMissingDocIds,
               applied_count: appliedLinks.length,
               applied_links: appliedLinks,
               failed_count: failedLinks.length,
@@ -1030,6 +1046,7 @@ export function registerSearchTools(s, {
             scene_id,
             project_id: resolvedProjectId,
             total_candidates: enriched.length,
+              skipped_missing_doc_ids: skippedMissingDocIds,
             candidates: enriched,
           }, null, 2),
         }],

--- a/src/tools/search.js
+++ b/src/tools/search.js
@@ -791,75 +791,64 @@ export function registerSearchTools(s, {
       `).all(resolvedProjectId, scene_id);
       const existingSceneLinkKeys = new Set(existingSceneLinks.map(link => `${link.target_doc_id}:${link.relation}`));
 
-      // Aggregate reference links from characters
+      // Load all character/place source links in project scope and aggregate in memory.
       const characterReferenceLinks = characters.length > 0
         ? db.prepare(`
-            SELECT target_doc_id, relation, COUNT(*) as source_count
-            FROM reference_links
-            WHERE source_kind = 'character' AND source_project_id = ? AND source_id IN (${characters.map(() => "?").join(",")})
-            GROUP BY target_doc_id, relation
+            SELECT rl.target_doc_id, rl.relation, rl.source_id AS character_id, c.name AS character_name
+            FROM reference_links rl
+            LEFT JOIN characters c
+              ON c.character_id = rl.source_id
+             AND c.project_id = rl.source_project_id
+            WHERE rl.source_kind = 'character'
+              AND rl.source_project_id = ?
+              AND rl.source_id IN (${characters.map(() => "?").join(",")})
           `).all(resolvedProjectId, ...characters.map(c => c.character_id))
         : [];
 
-      // Aggregate reference links from places
       const placeReferenceLinks = places.length > 0
         ? db.prepare(`
-            SELECT target_doc_id, relation, COUNT(*) as source_count
-            FROM reference_links
-            WHERE source_kind = 'place' AND source_project_id = ? AND source_id IN (${places.map(() => "?").join(",")})
-            GROUP BY target_doc_id, relation
+            SELECT rl.target_doc_id, rl.relation, rl.source_id AS place_id, p.name AS place_name
+            FROM reference_links rl
+            LEFT JOIN places p
+              ON p.place_id = rl.source_id
+             AND p.project_id = rl.source_project_id
+            WHERE rl.source_kind = 'place'
+              AND rl.source_project_id = ?
+              AND rl.source_id IN (${places.map(() => "?").join(",")})
           `).all(resolvedProjectId, ...places.map(p => p.place_id))
         : [];
 
       // Merge and score
       const scoreMap = new Map(); // key: "doc_id:relation" → { doc_id, relation, score, sources: [...] }
-      
-      for (const link of characterReferenceLinks) {
-        const key = `${link.target_doc_id}:${link.relation}`;
+
+      for (const row of characterReferenceLinks) {
+        const key = `${row.target_doc_id}:${row.relation}`;
         if (!scoreMap.has(key)) {
           scoreMap.set(key, {
-            doc_id: link.target_doc_id,
-            relation: link.relation,
+            doc_id: row.target_doc_id,
+            relation: row.relation,
             score: 0,
             sources: [],
           });
         }
         const entry = scoreMap.get(key);
-        entry.score += link.source_count;
-        for (const char of characters) {
-          const charLink = db.prepare(`
-            SELECT relation FROM reference_links
-            WHERE source_kind = 'character' AND source_project_id = ? AND source_id = ? AND target_doc_id = ? AND relation = ?
-          `).get(resolvedProjectId, char.character_id, link.target_doc_id, link.relation);
-          if (charLink) {
-            const charName = db.prepare(`SELECT name FROM characters WHERE character_id = ? AND project_id = ?`).get(char.character_id, resolvedProjectId)?.name || char.character_id;
-            entry.sources.push(`character: ${charName}`);
-          }
-        }
+        entry.score += 1;
+        entry.sources.push(`character: ${row.character_name ?? row.character_id}`);
       }
 
-      for (const link of placeReferenceLinks) {
-        const key = `${link.target_doc_id}:${link.relation}`;
+      for (const row of placeReferenceLinks) {
+        const key = `${row.target_doc_id}:${row.relation}`;
         if (!scoreMap.has(key)) {
           scoreMap.set(key, {
-            doc_id: link.target_doc_id,
-            relation: link.relation,
+            doc_id: row.target_doc_id,
+            relation: row.relation,
             score: 0,
             sources: [],
           });
         }
         const entry = scoreMap.get(key);
-        entry.score += link.source_count;
-        for (const place of places) {
-          const placeLink = db.prepare(`
-            SELECT relation FROM reference_links
-            WHERE source_kind = 'place' AND source_project_id = ? AND source_id = ? AND target_doc_id = ? AND relation = ?
-          `).get(resolvedProjectId, place.place_id, link.target_doc_id, link.relation);
-          if (placeLink) {
-            const placeName = db.prepare(`SELECT name FROM places WHERE place_id = ? AND project_id = ?`).get(place.place_id, resolvedProjectId)?.name || place.place_id;
-            entry.sources.push(`place: ${placeName}`);
-          }
-        }
+        entry.score += 1;
+        entry.sources.push(`place: ${row.place_name ?? row.place_id}`);
       }
 
       // Filter out already explicit scene links and deduplicate sources
@@ -871,13 +860,22 @@ export function registerSearchTools(s, {
         }))
         .sort((a, b) => b.score - a.score || a.doc_id.localeCompare(b.doc_id));
 
+      const candidateDocIds = [...new Set(candidates.map(candidate => candidate.doc_id))];
+      const docsById = candidateDocIds.length > 0
+        ? new Map(
+            db.prepare(`
+              SELECT doc_id, type, title, summary, project_id, universe_id
+              FROM reference_docs
+              WHERE doc_id IN (${candidateDocIds.map(() => "?").join(",")})
+            `)
+              .all(...candidateDocIds)
+              .map(row => [row.doc_id, row])
+          )
+        : new Map();
+
       // Enrich with reference doc metadata
       const enriched = candidates.map(candidate => {
-        const doc = db.prepare(`
-          SELECT doc_id, type, title, summary, project_id, universe_id
-          FROM reference_docs
-          WHERE doc_id = ?
-        `).get(candidate.doc_id);
+        const doc = docsById.get(candidate.doc_id);
         return {
           ...candidate,
           title: doc?.title || candidate.doc_id,

--- a/src/tools/search.js
+++ b/src/tools/search.js
@@ -740,4 +740,178 @@ export function registerSearchTools(s, {
       return { content: [{ type: "text", text: JSON.stringify(rows, null, 2) }] };
     }
   );
+
+  // ---- suggest_scene_references --------------------------------------------
+  s.tool(
+    "suggest_scene_references",
+    "Suggest reference documents for a scene by aggregating links from the scene's characters and places. Returns weighted candidates ranked by how many entities in the scene link to each reference. Excludes any explicit scene → reference links already present. Helpful for discovering relevant conceptual documents during scene review.",
+    {
+      scene_id: z.string().describe("Scene ID (e.g. 'sc-011-sebastian')."),
+      project_id: z.string().optional().describe("Optional project scope to disambiguate an ambiguous scene_id across projects."),
+    },
+    async ({ scene_id, project_id }) => {
+      // Resolve scene
+      let sceneQuery = `SELECT scene_id, project_id FROM scenes WHERE scene_id = ?`;
+      const sceneParams = [scene_id];
+      if (project_id) {
+        sceneQuery += ` AND project_id = ?`;
+        sceneParams.push(project_id);
+      }
+      
+      const scenes = db.prepare(sceneQuery).all(...sceneParams);
+      if (scenes.length === 0) {
+        return errorResponse("NOT_FOUND", `Scene '${scene_id}' not found${project_id ? ` in project '${project_id}'` : ""}.`);
+      }
+      if (scenes.length > 1) {
+        return errorResponse(
+          "CONFLICT",
+          `Scene ID '${scene_id}' exists in multiple projects. Provide project_id to disambiguate.`,
+          { scene_id, project_ids: scenes.map(s => s.project_id) }
+        );
+      }
+
+      const resolvedScene = scenes[0];
+      const resolvedProjectId = resolvedScene.project_id ?? "";
+
+      // Get characters in the scene
+      const characters = db.prepare(`
+        SELECT character_id FROM scene_characters WHERE scene_id = ?
+      `).all(scene_id);
+
+      // Get places in the scene
+      const places = db.prepare(`
+        SELECT place_id FROM scene_places WHERE scene_id = ?
+      `).all(scene_id);
+
+      // Get explicit scene → reference links already present
+      const existingSceneLinks = db.prepare(`
+        SELECT target_doc_id, relation
+        FROM reference_links
+        WHERE source_kind = 'scene' AND source_project_id = ? AND source_id = ? AND origin = 'explicit'
+      `).all(resolvedProjectId, scene_id);
+      const existingSceneLinkKeys = new Set(existingSceneLinks.map(link => `${link.target_doc_id}:${link.relation}`));
+
+      // Aggregate reference links from characters
+      const characterReferenceLinks = characters.length > 0
+        ? db.prepare(`
+            SELECT target_doc_id, relation, COUNT(*) as source_count
+            FROM reference_links
+            WHERE source_kind = 'character' AND source_id IN (${characters.map(() => "?").join(",")})
+            GROUP BY target_doc_id, relation
+          `).all(...characters.map(c => c.character_id))
+        : [];
+
+      // Aggregate reference links from places
+      const placeReferenceLinks = places.length > 0
+        ? db.prepare(`
+            SELECT target_doc_id, relation, COUNT(*) as source_count
+            FROM reference_links
+            WHERE source_kind = 'place' AND source_id IN (${places.map(() => "?").join(",")})
+            GROUP BY target_doc_id, relation
+          `).all(...places.map(p => p.place_id))
+        : [];
+
+      // Merge and score
+      const scoreMap = new Map(); // key: "doc_id:relation" → { doc_id, relation, score, sources: [...] }
+      
+      for (const link of characterReferenceLinks) {
+        const key = `${link.target_doc_id}:${link.relation}`;
+        if (!scoreMap.has(key)) {
+          scoreMap.set(key, {
+            doc_id: link.target_doc_id,
+            relation: link.relation,
+            score: 0,
+            sources: [],
+          });
+        }
+        const entry = scoreMap.get(key);
+        entry.score += link.source_count;
+        for (const char of characters) {
+          const charLink = db.prepare(`
+            SELECT relation FROM reference_links
+            WHERE source_kind = 'character' AND source_project_id = ? AND source_id = ? AND target_doc_id = ? AND relation = ?
+          `).get(resolvedProjectId, char.character_id, link.target_doc_id, link.relation);
+          if (charLink) {
+            const charName = db.prepare(`SELECT name FROM characters WHERE character_id = ?`).get(char.character_id)?.name || char.character_id;
+            entry.sources.push(`character: ${charName}`);
+          }
+        }
+      }
+
+      for (const link of placeReferenceLinks) {
+        const key = `${link.target_doc_id}:${link.relation}`;
+        if (!scoreMap.has(key)) {
+          scoreMap.set(key, {
+            doc_id: link.target_doc_id,
+            relation: link.relation,
+            score: 0,
+            sources: [],
+          });
+        }
+        const entry = scoreMap.get(key);
+        entry.score += link.source_count;
+        for (const place of places) {
+          const placeLink = db.prepare(`
+            SELECT relation FROM reference_links
+            WHERE source_kind = 'place' AND source_project_id = ? AND source_id = ? AND target_doc_id = ? AND relation = ?
+          `).get(resolvedProjectId, place.place_id, link.target_doc_id, link.relation);
+          if (placeLink) {
+            const placeName = db.prepare(`SELECT name FROM places WHERE place_id = ?`).get(place.place_id)?.name || place.place_id;
+            entry.sources.push(`place: ${placeName}`);
+          }
+        }
+      }
+
+      // Filter out already explicit scene links and deduplicate sources
+      const candidates = Array.from(scoreMap.values())
+        .filter(entry => !existingSceneLinkKeys.has(`${entry.doc_id}:${entry.relation}`))
+        .map(entry => ({
+          ...entry,
+          sources: [...new Set(entry.sources)], // deduplicate
+        }))
+        .sort((a, b) => b.score - a.score || a.doc_id.localeCompare(b.doc_id));
+
+      // Enrich with reference doc metadata
+      const enriched = candidates.map(candidate => {
+        const doc = db.prepare(`
+          SELECT doc_id, type, title, summary, project_id, universe_id
+          FROM reference_docs
+          WHERE doc_id = ?
+        `).get(candidate.doc_id);
+        return {
+          ...candidate,
+          title: doc?.title || candidate.doc_id,
+          type: doc?.type || "unknown",
+          summary: doc?.summary || null,
+        };
+      });
+
+      if (enriched.length === 0) {
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({
+              scene_id,
+              project_id: resolvedProjectId,
+              total_candidates: 0,
+              message: "No reference suggestions found. Scene characters and places have no linked references.",
+              candidates: [],
+            }, null, 2),
+          }],
+        };
+      }
+
+      return {
+        content: [{
+          type: "text",
+          text: JSON.stringify({
+            scene_id,
+            project_id: resolvedProjectId,
+            total_candidates: enriched.length,
+            candidates: enriched,
+          }, null, 2),
+        }],
+      };
+    }
+  );
 }

--- a/src/tools/search.js
+++ b/src/tools/search.js
@@ -796,9 +796,9 @@ export function registerSearchTools(s, {
         ? db.prepare(`
             SELECT target_doc_id, relation, COUNT(*) as source_count
             FROM reference_links
-            WHERE source_kind = 'character' AND source_id IN (${characters.map(() => "?").join(",")})
+            WHERE source_kind = 'character' AND source_project_id = ? AND source_id IN (${characters.map(() => "?").join(",")})
             GROUP BY target_doc_id, relation
-          `).all(...characters.map(c => c.character_id))
+          `).all(resolvedProjectId, ...characters.map(c => c.character_id))
         : [];
 
       // Aggregate reference links from places
@@ -806,9 +806,9 @@ export function registerSearchTools(s, {
         ? db.prepare(`
             SELECT target_doc_id, relation, COUNT(*) as source_count
             FROM reference_links
-            WHERE source_kind = 'place' AND source_id IN (${places.map(() => "?").join(",")})
+            WHERE source_kind = 'place' AND source_project_id = ? AND source_id IN (${places.map(() => "?").join(",")})
             GROUP BY target_doc_id, relation
-          `).all(...places.map(p => p.place_id))
+          `).all(resolvedProjectId, ...places.map(p => p.place_id))
         : [];
 
       // Merge and score
@@ -832,7 +832,7 @@ export function registerSearchTools(s, {
             WHERE source_kind = 'character' AND source_project_id = ? AND source_id = ? AND target_doc_id = ? AND relation = ?
           `).get(resolvedProjectId, char.character_id, link.target_doc_id, link.relation);
           if (charLink) {
-            const charName = db.prepare(`SELECT name FROM characters WHERE character_id = ?`).get(char.character_id)?.name || char.character_id;
+            const charName = db.prepare(`SELECT name FROM characters WHERE character_id = ? AND project_id = ?`).get(char.character_id, resolvedProjectId)?.name || char.character_id;
             entry.sources.push(`character: ${charName}`);
           }
         }
@@ -856,7 +856,7 @@ export function registerSearchTools(s, {
             WHERE source_kind = 'place' AND source_project_id = ? AND source_id = ? AND target_doc_id = ? AND relation = ?
           `).get(resolvedProjectId, place.place_id, link.target_doc_id, link.relation);
           if (placeLink) {
-            const placeName = db.prepare(`SELECT name FROM places WHERE place_id = ?`).get(place.place_id)?.name || place.place_id;
+            const placeName = db.prepare(`SELECT name FROM places WHERE place_id = ? AND project_id = ?`).get(place.place_id, resolvedProjectId)?.name || place.place_id;
             entry.sources.push(`place: ${placeName}`);
           }
         }

--- a/src/tools/search.js
+++ b/src/tools/search.js
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import fs from "node:fs";
 import matter from "gray-matter";
+import { readMeta } from "../sync/sync.js";
 import { persistSceneReferenceLink, upsertExplicitReferenceLinkRow } from "./reference-link-persistence.js";
 
 function accumulateSuggestionScore(scoreMap, rows, sourceLabel) {
@@ -18,6 +19,24 @@ function accumulateSuggestionScore(scoreMap, rows, sourceLabel) {
     entry.score += 1;
     entry.sources.push(`${sourceLabel}: ${row.source_name ?? row.source_id}`);
   }
+}
+
+function normalizeEntityIdList(value) {
+  if (Array.isArray(value)) {
+    return value.map((entry) => String(entry).trim()).filter(Boolean);
+  }
+  if (typeof value === "string") {
+    return value.split(",").map((entry) => entry.trim()).filter(Boolean);
+  }
+  return [];
+}
+
+function readSceneEntityIdsFromMetadata({ scenePath, syncDir }) {
+  const { meta } = readMeta(scenePath, syncDir, { writable: false });
+  return {
+    characterIds: normalizeEntityIdList(meta.characters),
+    placeIds: normalizeEntityIdList(meta.places),
+  };
 }
 
 export function registerSearchTools(s, {
@@ -800,26 +819,47 @@ export function registerSearchTools(s, {
         return errorResponse("READ_ONLY", "Cannot apply suggestions: sync dir is read-only.");
       }
 
-      // Get characters in the scene
-      const characters = db.prepare(`
-        SELECT character_id FROM scene_characters WHERE scene_id = ?
-      `).all(scene_id);
+      let characterIds = [];
+      let placeIds = [];
+      let loadedSceneEntitiesFromMetadata = false;
 
-      // Get places in the scene
-      const places = db.prepare(`
-        SELECT place_id FROM scene_places WHERE scene_id = ?
-      `).all(scene_id);
+      if (resolvedScene.file_path) {
+        try {
+          const entities = readSceneEntityIdsFromMetadata({
+            scenePath: resolvedScene.file_path,
+            syncDir: SYNC_DIR,
+          });
+          if (entities.characterIds.length > 0 || entities.placeIds.length > 0) {
+            characterIds = entities.characterIds;
+            placeIds = entities.placeIds;
+            loadedSceneEntitiesFromMetadata = true;
+          }
+        } catch (err) {
+          void err;
+        }
+      }
+
+      if (!loadedSceneEntitiesFromMetadata) {
+        // Fallback for scenes without readable indexed file paths.
+        characterIds = db.prepare(`
+          SELECT character_id FROM scene_characters WHERE scene_id = ?
+        `).all(scene_id).map((row) => row.character_id);
+
+        placeIds = db.prepare(`
+          SELECT place_id FROM scene_places WHERE scene_id = ?
+        `).all(scene_id).map((row) => row.place_id);
+      }
 
       // Get explicit scene → reference links already present
       const existingSceneLinks = db.prepare(`
-        SELECT target_doc_id, relation
+        SELECT target_doc_id
         FROM reference_links
         WHERE source_kind = 'scene' AND source_project_id = ? AND source_id = ? AND origin = 'explicit'
       `).all(resolvedProjectId, scene_id);
-      const existingSceneLinkKeys = new Set(existingSceneLinks.map(link => `${link.target_doc_id}:${link.relation}`));
+      const existingSceneDocIds = new Set(existingSceneLinks.map((link) => link.target_doc_id));
 
       // Load all character/place source links in project scope and aggregate in memory.
-      const characterReferenceLinks = characters.length > 0
+      const characterReferenceLinks = characterIds.length > 0
         ? db.prepare(`
             SELECT rl.target_doc_id, rl.relation, rl.source_id AS source_id, c.name AS source_name
             FROM reference_links rl
@@ -828,11 +868,11 @@ export function registerSearchTools(s, {
              AND c.project_id = rl.source_project_id
             WHERE rl.source_kind = 'character'
               AND rl.source_project_id = ?
-              AND rl.source_id IN (${characters.map(() => "?").join(",")})
-          `).all(resolvedProjectId, ...characters.map(c => c.character_id))
+              AND rl.source_id IN (${characterIds.map(() => "?").join(",")})
+          `).all(resolvedProjectId, ...characterIds)
         : [];
 
-      const placeReferenceLinks = places.length > 0
+      const placeReferenceLinks = placeIds.length > 0
         ? db.prepare(`
             SELECT rl.target_doc_id, rl.relation, rl.source_id AS source_id, p.name AS source_name
             FROM reference_links rl
@@ -841,8 +881,8 @@ export function registerSearchTools(s, {
              AND p.project_id = rl.source_project_id
             WHERE rl.source_kind = 'place'
               AND rl.source_project_id = ?
-              AND rl.source_id IN (${places.map(() => "?").join(",")})
-          `).all(resolvedProjectId, ...places.map(p => p.place_id))
+              AND rl.source_id IN (${placeIds.map(() => "?").join(",")})
+          `).all(resolvedProjectId, ...placeIds)
         : [];
 
       // Merge and score
@@ -852,7 +892,7 @@ export function registerSearchTools(s, {
 
       // Filter out already explicit scene links and deduplicate sources
       const candidates = Array.from(scoreMap.values())
-        .filter(entry => !existingSceneLinkKeys.has(`${entry.doc_id}:${entry.relation}`))
+        .filter(entry => !existingSceneDocIds.has(entry.doc_id))
         .filter(entry => entry.score >= min_score)
         .map(entry => ({
           ...entry,

--- a/src/tools/search.js
+++ b/src/tools/search.js
@@ -1,10 +1,50 @@
 import { z } from "zod";
 import fs from "node:fs";
 import matter from "gray-matter";
+import { readMeta, writeMeta, normalizeReferenceLinkList } from "../sync/sync.js";
+
+function upsertSerializedReferenceLinks(existing, targetDocId, relation, { defaultRelation }) {
+  const normalized = normalizeReferenceLinkList(existing ?? [], { defaultRelation });
+  const filtered = normalized.filter((entry) => entry.targetDocId !== targetDocId);
+  filtered.push({ targetDocId, relation });
+  return filtered.map((entry) => ({
+    target_doc_id: entry.targetDocId,
+    relation: entry.relation,
+  }));
+}
+
+function persistSceneReferenceLink({ scenePath, syncDir, targetDocId, relation }) {
+  const { meta } = readMeta(scenePath, syncDir, { writable: true });
+  const existingExplicit = [
+    ...(Array.isArray(meta.reference_links) ? meta.reference_links : meta.reference_links ? [meta.reference_links] : []),
+    ...(Array.isArray(meta.explicit_reference_links) ? meta.explicit_reference_links : meta.explicit_reference_links ? [meta.explicit_reference_links] : []),
+  ];
+  const nextReferenceLinks = upsertSerializedReferenceLinks(existingExplicit, targetDocId, relation, {
+    defaultRelation: "informs",
+  });
+
+  const nextMeta = {
+    ...meta,
+    reference_links: nextReferenceLinks,
+  };
+  delete nextMeta.explicit_reference_links;
+
+  if (relation === "informs") {
+    const existingIds = Array.isArray(meta.reference_ids)
+      ? meta.reference_ids
+      : typeof meta.reference_ids === "string"
+        ? meta.reference_ids.split(",")
+        : [];
+    nextMeta.reference_ids = [...new Set([...existingIds.map((value) => String(value).trim()).filter(Boolean), targetDocId])];
+  }
+
+  writeMeta(scenePath, nextMeta);
+}
 
 export function registerSearchTools(s, {
   db,
   SYNC_DIR,
+  SYNC_DIR_WRITABLE,
   GIT_ENABLED,
   errorResponse,
   paginateRows,
@@ -744,14 +784,18 @@ export function registerSearchTools(s, {
   // ---- suggest_scene_references --------------------------------------------
   s.tool(
     "suggest_scene_references",
-    "Suggest reference documents for a scene by aggregating links from the scene's characters and places. Returns weighted candidates ranked by how many entities in the scene link to each reference. Excludes any explicit scene → reference links already present. Helpful for discovering relevant conceptual documents during scene review.",
+    "Suggest reference documents for a scene by aggregating links from the scene's characters and places. Returns weighted candidates ranked by how many entities in the scene link to each reference. Excludes any explicit scene → reference links already present. In apply mode, can persist selected suggestions as explicit scene links in one call.",
     {
       scene_id: z.string().describe("Scene ID (e.g. 'sc-011-sebastian')."),
       project_id: z.string().optional().describe("Optional project scope to disambiguate an ambiguous scene_id across projects."),
+      mode: z.enum(["preview", "apply"]).optional().describe("Use 'preview' (default) to list candidates only, or 'apply' to persist selected suggestions as explicit scene links."),
+      selected_doc_ids: z.array(z.string()).optional().describe("Optional allowlist of doc_ids to apply when mode='apply'. If omitted, applies top-ranked candidates."),
+      max_apply: z.number().int().min(1).optional().describe("Optional cap for how many candidates to apply when mode='apply'."),
+      min_score: z.number().int().min(1).optional().describe("Optional minimum candidate score. Candidates below this are excluded from preview/apply. Defaults to 1."),
     },
-    async ({ scene_id, project_id }) => {
+    async ({ scene_id, project_id, mode = "preview", selected_doc_ids, max_apply, min_score = 1 }) => {
       // Resolve scene
-      let sceneQuery = `SELECT scene_id, project_id FROM scenes WHERE scene_id = ?`;
+      let sceneQuery = `SELECT scene_id, project_id, file_path FROM scenes WHERE scene_id = ?`;
       const sceneParams = [scene_id];
       if (project_id) {
         sceneQuery += ` AND project_id = ?`;
@@ -772,6 +816,10 @@ export function registerSearchTools(s, {
 
       const resolvedScene = scenes[0];
       const resolvedProjectId = resolvedScene.project_id ?? "";
+
+      if (mode === "apply" && !SYNC_DIR_WRITABLE) {
+        return errorResponse("READ_ONLY", "Cannot apply suggestions: sync dir is read-only.");
+      }
 
       // Get characters in the scene
       const characters = db.prepare(`
@@ -854,6 +902,7 @@ export function registerSearchTools(s, {
       // Filter out already explicit scene links and deduplicate sources
       const candidates = Array.from(scoreMap.values())
         .filter(entry => !existingSceneLinkKeys.has(`${entry.doc_id}:${entry.relation}`))
+        .filter(entry => entry.score >= min_score)
         .map(entry => ({
           ...entry,
           sources: [...new Set(entry.sources)], // deduplicate
@@ -892,13 +941,94 @@ export function registerSearchTools(s, {
               scene_id,
               project_id: resolvedProjectId,
               total_candidates: 0,
-              message: "No reference suggestions found. Scene characters and places have no linked references.",
+                message: "No reference suggestions found. Scene characters and places have no linked references.",
               candidates: [],
             }, null, 2),
           }],
         };
       }
 
+
+      if (mode === "apply") {
+        if (!resolvedScene.file_path) {
+          return errorResponse("STALE_PATH", `Scene '${scene_id}' has no indexed file path. Run sync() to refresh.`, {
+            scene_id,
+            project_id: resolvedProjectId,
+          });
+        }
+
+        const selectedSet = selected_doc_ids ? new Set(selected_doc_ids) : null;
+        const toApply = enriched
+          .filter(candidate => !selectedSet || selectedSet.has(candidate.doc_id))
+          .slice(0, max_apply ?? enriched.length);
+
+        const appliedLinks = [];
+        for (const candidate of toApply) {
+          try {
+            persistSceneReferenceLink({
+              scenePath: resolvedScene.file_path,
+              syncDir: SYNC_DIR,
+              targetDocId: candidate.doc_id,
+              relation: candidate.relation,
+            });
+          } catch (err) {
+            if (err?.code === "ENOENT") {
+              return errorResponse(
+                "STALE_PATH",
+                `Scene file for '${scene_id}' not found at indexed path — run sync() to refresh.`,
+                { indexed_path: resolvedScene.file_path }
+              );
+            }
+            return errorResponse("IO_ERROR", `Failed to persist scene reference link metadata: ${err.message}`);
+          }
+
+          try {
+            db.exec("BEGIN");
+            db.prepare(`
+              DELETE FROM reference_links
+              WHERE source_kind = 'scene' AND source_project_id = ? AND source_id = ? AND target_doc_id = ?
+            `).run(resolvedProjectId, scene_id, candidate.doc_id);
+
+            db.prepare(`
+              INSERT INTO reference_links (
+                source_kind, source_project_id, source_id, target_doc_id, relation, origin
+              ) VALUES ('scene', ?, ?, ?, ?, 'explicit')
+            `).run(resolvedProjectId, scene_id, candidate.doc_id, candidate.relation);
+            db.exec("COMMIT");
+          } catch (err) {
+            try {
+              db.exec("ROLLBACK");
+            } catch (rollbackErr) {
+              void rollbackErr;
+            }
+            return errorResponse("IO_ERROR", `Failed to persist scene reference link index row: ${err.message}`);
+          }
+
+          appliedLinks.push({
+            source_kind: "scene",
+            source_project_id: resolvedProjectId,
+            source_id: scene_id,
+            target_doc_id: candidate.doc_id,
+            relation: candidate.relation,
+            origin: "explicit",
+          });
+        }
+
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({
+              scene_id,
+              project_id: resolvedProjectId,
+              mode,
+              total_candidates: enriched.length,
+              applied_count: appliedLinks.length,
+              applied_links: appliedLinks,
+              candidates: enriched,
+            }, null, 2),
+          }],
+        };
+      }
       return {
         content: [{
           type: "text",

--- a/src/tools/search.js
+++ b/src/tools/search.js
@@ -914,17 +914,30 @@ export function registerSearchTools(s, {
           .slice(0, max_apply ?? enriched.length);
 
         const appliedLinks = [];
-        try {
-          db.exec("BEGIN");
+        const failedLinks = [];
 
-          for (const candidate of toApply) {
+        for (const candidate of toApply) {
+          try {
             persistSceneReferenceLink({
               scenePath: resolvedScene.file_path,
               syncDir: SYNC_DIR,
               targetDocId: candidate.doc_id,
               relation: candidate.relation,
             });
+          } catch (err) {
+            failedLinks.push({
+              target_doc_id: candidate.doc_id,
+              relation: candidate.relation,
+              stage: "metadata",
+              code: err?.code ?? "IO_ERROR",
+              message: err?.code === "ENOENT"
+                ? `Scene file for '${scene_id}' not found at indexed path — run sync() to refresh.`
+                : `Failed to persist scene reference link metadata: ${err.message}`,
+            });
+            continue;
+          }
 
+          try {
             upsertExplicitReferenceLinkRow(db, {
               sourceKind: "scene",
               sourceProjectId: resolvedProjectId,
@@ -932,32 +945,25 @@ export function registerSearchTools(s, {
               targetDocId: candidate.doc_id,
               relation: candidate.relation,
             });
-
-            appliedLinks.push({
-              source_kind: "scene",
-              source_project_id: resolvedProjectId,
-              source_id: scene_id,
+          } catch (err) {
+            failedLinks.push({
               target_doc_id: candidate.doc_id,
               relation: candidate.relation,
-              origin: "explicit",
+              stage: "index",
+              code: err?.code ?? "IO_ERROR",
+              message: `Failed to persist scene reference link index row: ${err.message}`,
             });
+            continue;
           }
 
-          db.exec("COMMIT");
-        } catch (err) {
-          try {
-            db.exec("ROLLBACK");
-          } catch (rollbackErr) {
-            void rollbackErr;
-          }
-          if (err?.code === "ENOENT") {
-            return errorResponse(
-              "STALE_PATH",
-              `Scene file for '${scene_id}' not found at indexed path — run sync() to refresh.`,
-              { indexed_path: resolvedScene.file_path }
-            );
-          }
-          return errorResponse("IO_ERROR", `Failed to persist scene reference link index rows: ${err.message}`);
+          appliedLinks.push({
+            source_kind: "scene",
+            source_project_id: resolvedProjectId,
+            source_id: scene_id,
+            target_doc_id: candidate.doc_id,
+            relation: candidate.relation,
+            origin: "explicit",
+          });
         }
 
         return {
@@ -970,6 +976,8 @@ export function registerSearchTools(s, {
               total_candidates: enriched.length,
               applied_count: appliedLinks.length,
               applied_links: appliedLinks,
+              failed_count: failedLinks.length,
+              failed_links: failedLinks,
               candidates: enriched,
             }, null, 2),
           }],


### PR DESCRIPTION
## Summary

- Extends reference-link authoring to support `character` and `place` sources in `upsert_reference_link` with write-through persistence.
- Adds `suggest_scene_references` with weighted scoring from scene characters/places and project-scoped isolation.
- Adds one-call UX with `suggest_scene_references(..., mode="apply")` to persist explicit scene links directly from suggestions.
- Reduces suggestion query fanout by replacing per-entity lookups with set-based queries.
- Adds unit + integration coverage for scoring, project isolation, apply-mode persistence, and read-only behavior in unit harness.
- Updates Phase 4D PRD notes and adds an Unreleased `docs/release-log.md` entry.

## Motivation

Phase 4D aimed to make reference-link authoring more practical as tool count grows. The core need was to move from discovery to explicit scene linking with less orchestration, while preserving deterministic/project-safe behavior.

## Implementation

- `upsert_reference_link` now accepts `source_kind` values: `scene|character|place|reference` and persists character/place links to sidecars.
- `sync()` indexing now includes character/place explicit reference links.
- `suggest_scene_references` now:
  - aggregates links from scene characters and places,
  - excludes already-explicit scene links,
  - enforces project-scoped link isolation,
  - supports `mode=preview|apply`, `selected_doc_ids`, `max_apply`, and `min_score`.
- Apply mode writes through to scene sidecar metadata and upserts explicit `reference_links` rows.
- Query fanout reduced via set-based SQL and batched doc enrichment.

## Testing

- `npm run test:unit`
- `npm run test:integration -- src/test/integration/search.test.mjs`

## Risks and tradeoffs

- `mode=apply` increases behavior surface in a read-oriented tool; mitigated via explicit mode flag and READ_ONLY/STALE_PATH guards.
- PR scope is broad (feature + follow-up fixes + perf refactor + tests/docs) but remains within one concern: Phase 4D reference suggestion/authoring workflow.

## Follow-up

- Regenerate `docs/tools.md` so documented tool signatures/params reflect current implementations (`suggest_scene_references` apply params, expanded `upsert_reference_link` source kinds).
