### PR TITLE
docs: finalize reference docs PRD status

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -126,6 +126,16 @@ Direct ingestion from Scrivener project internals (`.scriv`/`.scrivx`) for riche
 
 ---
 
+### 📚 [Reference Document Querying](docs/prd/done/reference-docs.md) ✅
+
+Index and link world-building notes, research, and continuity scratchpads as a reference system.
+
+**Example:** "Find all continuity notes mentioning Elena", "What are the rules of magic in this world?", or "What reference docs directly inform this scene?"
+
+**Status:** Completed. Phase 4A–4D are shipped; follow-up candidates are documented in the PRD.
+
+---
+
 ## Active Development
 
 ### 🚀 [OpenClaw Integration](docs/prd/in-progress/openclaw-integration.md) 🚧
@@ -153,16 +163,6 @@ Semantic search for queries that require understanding meaning, not just keyword
 **Example:** "Find scenes with confrontation near water" (currently impossible with FTS5 alone)
 
 **Status:** Deferred backlog (not active). Pending evaluation of embedding backend (OpenAI vs Ollama vs Hugging Face), cost, and performance.
-
----
-
-### 📚 [Reference Document Querying](docs/prd/done/reference-docs.md) ✅
-
-Index and link world-building notes, research, and continuity scratchpads as a reference system.
-
-**Example:** "Find all continuity notes mentioning Elena", "What are the rules of magic in this world?", or "What reference docs directly inform this scene?"
-
-**Status:** Completed. Phase 4A–4D are shipped; follow-up candidates are documented in the PRD.
 
 ---
 
@@ -234,7 +234,7 @@ Writing MCP is now in continuous development rather than sequential phase delive
 
 - **Core platform complete:** metadata architecture, import/sync, prose editing, search/analysis, review bundles, and Scrivener Direct extraction are all implemented.
 - **Active development:** OpenClaw integration and guideline generation.
-- **Deferred backlog:** embeddings search and the reference document system.
+- **Deferred backlog:** embeddings search.
 - **Ideas and open questions:** tracked separately so future exploration does not distort the active roadmap.
 
 ---

--- a/PRD.md
+++ b/PRD.md
@@ -156,13 +156,13 @@ Semantic search for queries that require understanding meaning, not just keyword
 
 ---
 
-### 📚 [Reference Document Querying](docs/prd/in-progress/reference-docs.md) 🚧
+### 📚 [Reference Document Querying](docs/prd/done/reference-docs.md) ✅
 
 Index and link world-building notes, research, and continuity scratchpads as a reference system.
 
 **Example:** "Find all continuity notes mentioning Elena", "What are the rules of magic in this world?", or "What reference docs directly inform this scene?"
 
-**Status:** In progress. Phase 4A is shipped and Phase 4B is underway.
+**Status:** Completed. Phase 4A–4D are shipped; follow-up candidates are documented in the PRD.
 
 ---
 

--- a/docs/prd/done/reference-docs.md
+++ b/docs/prd/done/reference-docs.md
@@ -1,6 +1,6 @@
 # Reference Document Querying
 
-**Status:** ✅ Phase 4A–4C complete; Phase 4D (optional authoring helpers) in scope
+**Status:** ✅ Phase 4A–4D complete; post-Phase-4D follow-up items tracked below
 
 ## Motivation
 
@@ -194,7 +194,7 @@ Do not require semantic auto-linking in the first version.
 - Phase 4A: Reference docs become indexed entities with lightweight search
 - Phase 4B: Add explicit scene-to-reference and reference-to-reference links plus query/read tools
 - Phase 4C: Durable write-through to source metadata files and final ownership/merge rules
-- Phase 4D: Optional helper flows for authoring/suggesting links
+- Phase 4D: Optional helper flows for authoring/suggesting links (implemented)
 
 ## Current Implementation Status
 
@@ -220,7 +220,19 @@ Completed (Phase 4C durability & merge rules):
 - ownership semantics finalized: per-source-kind context (informs for scenes, related for references)
 - full test coverage for write-through, rebuild durability, and merge scenarios (v2.17.0)
 
-## Next Implementation Slice (Phase 4D)
+Completed (Phase 4D suggestion/apply helpers):
+- `upsert_reference_link` supports `character` and `place` as `source_kind` values with sidecar write-through for canonical character/place files
+- `sync()` indexes character/place explicit reference links with existing explicit-vs-inferred precedence rules
+- `suggest_scene_references(scene_id, project_id?, mode?, selected_doc_ids?, max_apply?, min_score?)` is implemented with preview/apply modes
+- project isolation hardening is implemented for scene suggestions:
+  - successful metadata reads are authoritative (including empty entity lists)
+  - join-table fallback is used only when metadata cannot be read/no indexed file path
+- suggestion safety hardening is implemented:
+  - candidates whose target docs are missing from `reference_docs` are filtered out
+  - apply mode deduplicates by `doc_id` with deterministic ordering (one applied relation per doc per call)
+  - explicit scene-link index upsert is atomic (transaction/savepoint-safe)
+
+## Phase 4D Design (Implemented)
 
 Authoring and auto-suggestion helpers through entity-based reference linking.
 
@@ -308,14 +320,20 @@ Behavioral guardrails:
 - missing target docs should produce warnings, not crashes
 - cyclic links must not cause repeated or recursive output
 
-## Known Gaps (Phase 4D candidates)
+## Follow-up Backlog (Post-Phase-4D candidates)
 
-- No finalized authoring UX helpers for suggesting links based on scene/reference proximity
-- No auto-suggestion flow for likely scene references based on keyword overlap or character mentions
+- Authoring UX beyond preview/apply remains open (for example, structured approval and batch-confirmation flows)
+- No secondary suggestion model based on keyword overlap or mention heuristics (entity-link aggregation is implemented)
 - Deferred feature: reference-document "logline-like" summaries as explicit metadata fields
 - Open design for deferred feature: summaries may be handwritten by users or generated/suggested and then user-edited
 - Bulk link editing workflows (especially cross-project scenarios) not yet scoped
 - Cross-project/shared-universe ownership enforcement may need refinement once used on larger series projects
+
+## Issue Tracking
+
+- No dedicated follow-up issue exists yet for most post-Phase-4D backlog bullets.
+- Potentially related (partial overlap): https://github.com/hannasdev/mcp-writing/issues/155
+- Recommendation: open one issue per backlog bullet when the item is pulled into active planning.
 
 ## Resolved Items
 


### PR DESCRIPTION
## Summary

- Moves Reference Document Querying PRD from in-progress to done.
- Updates the document status to reflect Phase 4A–4D completion.
- Reframes remaining items as post-Phase-4D follow-up backlog and adds a small issue-tracking note.
- Aligns the top-level PRD index entry/path/status for Reference Document Querying.

## Motivation

The feature work for Phase 4D is merged, but PRD metadata still presented Reference Document Querying as in-progress. This caused planning drift between implementation reality and docs.

## Implementation

- Renamed docs/prd/in-progress/reference-docs.md to docs/prd/done/reference-docs.md.
- Updated rollout/status wording in the reference-docs PRD to mark Phase 4D implemented.
- Added a concise issue-tracking subsection for follow-up backlog triage.
- Updated PRD.md to point to docs/prd/done/reference-docs.md and mark the item completed.

## Testing

- Not run: documentation-only change.

## Risks and tradeoffs

- Low risk; this is docs-only.
- The issue-tracking subsection includes one partially related open issue and keeps other backlog items explicitly unassigned until scoped.

## Follow-up

- Optionally open one issue per post-Phase-4D backlog bullet when each item is pulled into active planning.
