### PR TITLE
feat(editing): enforce styleguide automatically in edit flow

### DIFF
--- a/docs/release-log.md
+++ b/docs/release-log.md
@@ -8,6 +8,14 @@ This complements `CHANGELOG.md`:
 
 ## Unreleased
 
+### 2026-05-02 — Enforce prose styleguide automatically in edit proposals
+
+- What changed: `propose_edit` now runs automatic styleguide checks by default, returns structured styleguide diagnostics in the proposal response, supports explicit bypass (`bypass_styleguide` + required `bypass_reason`), and `commit_edit` now rejects stale proposals when styleguide inputs changed after proposal creation.
+- Why it matters: Style consistency checks are now built into the safe edit flow without adding extra setup commands in normal use, and approvals are protected from committing against outdated style rules.
+- Who is affected: Anyone using `propose_edit` and `commit_edit`, especially teams maintaining project style conventions.
+- Action needed: Optional: set `PROSE_STYLEGUIDE_ENFORCEMENT_MODE` to `off`, `warn` (default), or `required` based on your workflow strictness.
+- PR: (pending)
+
 ### 2026-05-02 — Surface legacy migration skips with explicit operator follow-up
 
 - What changed: Legacy join-table upgrade behavior now emits an explicit `LEGACY_JOIN_ROWS_SKIPPED` warning (startup logs plus runtime surfaces such as `get_runtime_config` and `describe_workflows` context) when ambiguous legacy rows are dropped during project-scoping migration.

--- a/docs/release-log.md
+++ b/docs/release-log.md
@@ -14,7 +14,7 @@ This complements `CHANGELOG.md`:
 - Why it matters: Style consistency checks are now built into the safe edit flow without adding extra setup commands in normal use, and approvals are protected from committing against outdated style rules.
 - Who is affected: Anyone using `propose_edit` and `commit_edit`, especially teams maintaining project style conventions.
 - Action needed: Optional: set `PROSE_STYLEGUIDE_ENFORCEMENT_MODE` to `off`, `warn` (default), or `required` based on your workflow strictness.
-- PR: (pending)
+- PR: [#166](https://github.com/hannasdev/mcp-writing/pull/166)
 
 ### 2026-05-02 — Surface legacy migration skips with explicit operator follow-up
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -636,6 +636,8 @@ Generate a proposed revision for a scene. Returns a proposal_id and a diff previ
 | `project_id` | `string` | No | Optional project ID to disambiguate duplicate scene IDs across projects. |
 | `instruction` | `string` | Yes | A brief instruction for the edit (e.g. 'Tighten the opening paragraph'). Used in the git commit message. |
 | `revised_prose` | `string` | Yes | The complete revised prose text for the scene. |
+| `bypass_styleguide` | `boolean` | No | If true, bypasses automatic styleguide checks for this proposal. |
+| `bypass_reason` | `string` | No | Required when bypass_styleguide=true. Explains why this edit should ignore styleguide checks. |
 
 ---
 

--- a/src/index.js
+++ b/src/index.js
@@ -71,6 +71,12 @@ const OWNERSHIP_GUARD_MODE_RAW = (process.env.OWNERSHIP_GUARD_MODE ?? "warn").tr
 const OWNERSHIP_GUARD_MODE = OWNERSHIP_GUARD_MODE_RAW === "fail" || OWNERSHIP_GUARD_MODE_RAW === "warn"
   ? OWNERSHIP_GUARD_MODE_RAW
   : "warn";
+const STYLEGUIDE_ENFORCEMENT_MODE_RAW = (process.env.PROSE_STYLEGUIDE_ENFORCEMENT_MODE ?? "warn").trim().toLowerCase();
+const STYLEGUIDE_ENFORCEMENT_MODE = STYLEGUIDE_ENFORCEMENT_MODE_RAW === "off"
+  || STYLEGUIDE_ENFORCEMENT_MODE_RAW === "warn"
+  || STYLEGUIDE_ENFORCEMENT_MODE_RAW === "required"
+  ? STYLEGUIDE_ENFORCEMENT_MODE_RAW
+  : "warn";
 const OWNERSHIP_GUARD_MODE_RAW_DISPLAY = JSON.stringify(OWNERSHIP_GUARD_MODE_RAW);
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -410,6 +416,7 @@ function createMcpServer() {
     isPathCandidateInsideSyncDir,
     pendingProposals,
     generateProposalId,
+    STYLEGUIDE_ENFORCEMENT_MODE,
   };
   registerSyncTools(s, toolContext);
   registerSearchTools(s, toolContext);
@@ -434,6 +441,7 @@ function createMcpServer() {
         permission_diagnostics: SYNC_OWNERSHIP_DIAGNOSTICS,
         git_available: GIT_AVAILABLE,
         git_enabled: GIT_ENABLED,
+        styleguide_enforcement_mode: STYLEGUIDE_ENFORCEMENT_MODE,
         http_port: HTTP_PORT,
         runtime_warnings: RUNTIME_DIAGNOSTICS.warnings,
         setup_recommendations: RUNTIME_DIAGNOSTICS.recommendations,

--- a/src/test/integration/editing.test.mjs
+++ b/src/test/integration/editing.test.mjs
@@ -6,8 +6,13 @@ import matter from "gray-matter";
 import { createTestContext } from "../helpers/server.js";
 
 const ctx = createTestContext(3069, 3068);
+const requiredCtx = createTestContext(3089, 3088, {
+  PROSE_STYLEGUIDE_ENFORCEMENT_MODE: "required",
+});
 let writeSyncDir;
+let requiredWriteSyncDir;
 const callWriteTool = (n, a) => ctx.callWriteTool(n, a);
+const callRequiredWriteTool = (n, a) => requiredCtx.callWriteTool(n, a);
 const toSceneRows = (parsed) => (Array.isArray(parsed) ? parsed : parsed.results);
 
 before(async () => {
@@ -23,6 +28,21 @@ before(async () => {
 
 after(async () => {
   await ctx.teardown();
+});
+
+before(async () => {
+  try {
+    await requiredCtx.setup();
+    requiredWriteSyncDir = requiredCtx.writeSyncDir;
+  } finally {
+    if (!requiredWriteSyncDir) {
+      await requiredCtx.teardown();
+    }
+  }
+});
+
+after(async () => {
+  await requiredCtx.teardown();
 });
 
 describe("commit_edit behavior", { concurrency: 1 }, () => {
@@ -404,5 +424,120 @@ describe("commit_edit behavior", { concurrency: 1 }, () => {
     assert.equal(parsed.project_id, "beta-edit");
     assert.ok(Array.isArray(parsed.snapshots));
     assert.ok(parsed.snapshots.length >= 1);
+  });
+});
+
+describe("styleguide enforcement behavior", { concurrency: 1 }, () => {
+  test("includes styleguide metadata and violations in propose_edit response", async () => {
+    const setupText = await callWriteTool("setup_prose_styleguide_config", {
+      scope: "sync_root",
+      language: "english_uk",
+      overwrite: true,
+      overrides: {
+        quotation_style: "single",
+      },
+    });
+    const setupParsed = JSON.parse(setupText);
+    assert.equal(setupParsed.ok, true);
+
+    const skillText = await callWriteTool("setup_prose_styleguide_skill", { overwrite: true });
+    const skillParsed = JSON.parse(skillText);
+    assert.equal(skillParsed.ok, true);
+
+    const proposalText = await callWriteTool("propose_edit", {
+      scene_id: "sc-001",
+      instruction: "Styleguide metadata coverage",
+      revised_prose: '"I am here now," she says.',
+    });
+    const proposal = JSON.parse(proposalText);
+
+    assert.equal(typeof proposal.styleguide, "object");
+    assert.equal(proposal.styleguide.styleguide_applied, true);
+    assert.equal(proposal.styleguide.enforcement_mode, "warn");
+    assert.equal(typeof proposal.styleguide.fingerprint, "string");
+    assert.ok(Array.isArray(proposal.styleguide.violations));
+    assert.ok(proposal.styleguide.violations.some((entry) => entry.field === "quotation_style"));
+  });
+
+  test("blocks commit_edit when styleguide changes after propose_edit", async () => {
+    const setupText = await callWriteTool("setup_prose_styleguide_config", {
+      scope: "sync_root",
+      language: "english_uk",
+      overwrite: true,
+      overrides: {
+        quotation_style: "single",
+      },
+    });
+    assert.equal(JSON.parse(setupText).ok, true);
+
+    const skillText = await callWriteTool("setup_prose_styleguide_skill", { overwrite: true });
+    assert.equal(JSON.parse(skillText).ok, true);
+
+    const proposalText = await callWriteTool("propose_edit", {
+      scene_id: "sc-002",
+      instruction: "Prepare proposal before styleguide change",
+      revised_prose: "'I was there,' she said.",
+    });
+    const proposal = JSON.parse(proposalText);
+    assert.ok(proposal.proposal_id);
+
+    const updateText = await callWriteTool("update_prose_styleguide_config", {
+      scope: "sync_root",
+      updates: {
+        quotation_style: "double",
+      },
+    });
+    const updateParsed = JSON.parse(updateText);
+    assert.equal(updateParsed.ok, true);
+
+    const commitText = await callWriteTool("commit_edit", {
+      scene_id: "sc-002",
+      proposal_id: proposal.proposal_id,
+    });
+    const commitParsed = JSON.parse(commitText);
+    assert.equal(commitParsed.ok, false);
+    assert.equal(commitParsed.error.code, "STYLEGUIDE_CHANGED_SINCE_PROPOSAL");
+  });
+
+  test("required mode blocks propose_edit when no styleguide config exists", async () => {
+    const configPath = path.join(requiredWriteSyncDir, "prose-styleguide.config.yaml");
+    fs.rmSync(configPath, { force: true });
+
+    const proposalText = await callRequiredWriteTool("propose_edit", {
+      scene_id: "sc-001",
+      instruction: "Required mode should block",
+      revised_prose: "No config should block this.",
+    });
+    const proposal = JSON.parse(proposalText);
+    assert.equal(proposal.ok, false);
+    assert.equal(proposal.error.code, "STYLEGUIDE_CONFIG_REQUIRED");
+  });
+
+  test("required mode allows bypass with explicit reason", async () => {
+    const proposalText = await callRequiredWriteTool("propose_edit", {
+      scene_id: "sc-001",
+      instruction: "Bypass required mode",
+      revised_prose: "Bypass this styleguide check.",
+      bypass_styleguide: true,
+      bypass_reason: "Intentional one-off exception for draft exploration",
+    });
+    const proposal = JSON.parse(proposalText);
+
+    assert.equal(typeof proposal.proposal_id, "string");
+    assert.equal(proposal.styleguide.bypass_used, true);
+    assert.equal(proposal.styleguide.styleguide_applied, false);
+  });
+
+  test("requires bypass_reason when bypass_styleguide is true", async () => {
+    const proposalText = await callRequiredWriteTool("propose_edit", {
+      scene_id: "sc-001",
+      instruction: "Missing bypass reason",
+      revised_prose: "Bypass should fail without reason.",
+      bypass_styleguide: true,
+    });
+    const proposal = JSON.parse(proposalText);
+
+    assert.equal(proposal.ok, false);
+    assert.equal(proposal.error.code, "STYLEGUIDE_BYPASS_REASON_REQUIRED");
   });
 });

--- a/src/tools/editing.js
+++ b/src/tools/editing.js
@@ -1,9 +1,17 @@
 import { z } from "zod";
 import fs from "node:fs";
+import path from "node:path";
+import { createHash } from "node:crypto";
 import matter from "gray-matter";
 import yaml from "js-yaml";
 import { createSnapshot, listSnapshots } from "../core/git.js";
 import { getFileWriteDiagnostics, readMeta, indexSceneFile } from "../sync/sync.js";
+import { resolveStyleguideConfig } from "../styleguide/prose-styleguide.js";
+import {
+  PROSE_STYLEGUIDE_SKILL_BASENAME,
+  PROSE_STYLEGUIDE_SKILL_DIRNAME,
+} from "../styleguide/prose-styleguide-skill.js";
+import { analyzeSceneStyleguideDrift } from "../styleguide/prose-styleguide-drift.js";
 
 function renderSceneContent(metadata, revisedProse) {
   const hasFrontmatter = metadata && Object.keys(metadata).length > 0;
@@ -13,10 +21,180 @@ function renderSceneContent(metadata, revisedProse) {
     : `${normalizedProse}\n`;
 }
 
+function digestFor(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function buildStyleguideFingerprint({
+  resolvedConfig,
+  sources,
+  skillDigest,
+  setupRequired,
+}) {
+  return digestFor(JSON.stringify({
+    resolved_config: resolvedConfig ?? null,
+    sources: sources ?? [],
+    skill_digest: skillDigest ?? null,
+    setup_required: Boolean(setupRequired),
+  }));
+}
+
+function resolveStyleguideSnapshot({ syncDir, projectId, errorResponse }) {
+  const resolved = resolveStyleguideConfig({
+    syncDir,
+    projectId,
+  });
+  if (!resolved.ok) {
+    return {
+      ok: false,
+      response: errorResponse(
+        resolved.error.code,
+        resolved.error.message,
+        resolved.error.details
+      ),
+    };
+  }
+
+  const skillPath = path.join(
+    syncDir,
+    PROSE_STYLEGUIDE_SKILL_DIRNAME,
+    PROSE_STYLEGUIDE_SKILL_BASENAME
+  );
+  const skillExists = fs.existsSync(skillPath);
+  const skillDigest = skillExists
+    ? digestFor(fs.readFileSync(skillPath, "utf8"))
+    : null;
+  const fingerprint = buildStyleguideFingerprint({
+    resolvedConfig: resolved.resolved_config,
+    sources: resolved.sources,
+    skillDigest,
+    setupRequired: resolved.setup_required,
+  });
+
+  return {
+    ok: true,
+    snapshot: {
+      project_id: projectId ?? null,
+      config_found: resolved.config_found,
+      setup_required: resolved.setup_required,
+      sources: resolved.sources,
+      resolved_config: resolved.resolved_config,
+      skill_file_path: skillPath,
+      skill_found: skillExists,
+      skill_digest: skillDigest,
+      fingerprint,
+    },
+  };
+}
+
+function evaluateStyleguidePolicy({
+  snapshot,
+  revisedProse,
+  bypassStyleguide,
+  bypassReason,
+  enforcementMode,
+  errorResponse,
+}) {
+  if (bypassStyleguide && !bypassReason) {
+    return {
+      ok: false,
+      response: errorResponse(
+        "STYLEGUIDE_BYPASS_REASON_REQUIRED",
+        "bypass_reason is required when bypass_styleguide=true."
+      ),
+    };
+  }
+
+  const warnings = [];
+  if (enforcementMode !== "off") {
+    if (snapshot.setup_required || !snapshot.config_found) {
+      if (enforcementMode === "required" && !bypassStyleguide) {
+        return {
+          ok: false,
+          response: errorResponse(
+            "STYLEGUIDE_CONFIG_REQUIRED",
+            "Cannot propose prose edits before prose-styleguide.config.yaml is configured.",
+            {
+              project_id: snapshot.project_id,
+              next_step: "Run setup_prose_styleguide_config (or bootstrap_prose_styleguide_config), then retry propose_edit.",
+            }
+          ),
+        };
+      }
+      warnings.push("No prose-styleguide.config.yaml is currently resolved for this scene.");
+    }
+
+    if (!snapshot.skill_found) {
+      if (enforcementMode === "required" && !bypassStyleguide) {
+        return {
+          ok: false,
+          response: errorResponse(
+            "STYLEGUIDE_SKILL_REQUIRED",
+            "Cannot propose prose edits before skills/prose-styleguide.md exists.",
+            {
+              next_step: "Run setup_prose_styleguide_skill, then retry propose_edit.",
+            }
+          ),
+        };
+      }
+      warnings.push("skills/prose-styleguide.md was not found at sync root.");
+    }
+  }
+
+  const canApply =
+    enforcementMode !== "off"
+    && !bypassStyleguide
+    && snapshot.config_found
+    && !snapshot.setup_required
+    && Boolean(snapshot.resolved_config);
+
+  const analysis = canApply
+    ? analyzeSceneStyleguideDrift({
+      prose: revisedProse,
+      resolvedConfig: snapshot.resolved_config,
+    })
+    : { observed: {}, drift: [] };
+
+  const violations = analysis.drift.map((entry) => ({
+    field: entry.field,
+    declared: entry.declared,
+    observed: entry.observed,
+    severity: "error",
+  }));
+
+  if (enforcementMode === "required" && violations.length > 0 && !bypassStyleguide) {
+    return {
+      ok: false,
+      response: errorResponse(
+        "STYLEGUIDE_VIOLATIONS",
+        "Revised prose violates required styleguide conventions.",
+        {
+          violations,
+          next_step: "Revise prose to match conventions or retry with bypass_styleguide=true and a bypass_reason.",
+        }
+      ),
+    };
+  }
+
+  return {
+    ok: true,
+    policy: {
+      enforcement_mode: enforcementMode,
+      bypass_used: Boolean(bypassStyleguide),
+      bypass_reason: bypassStyleguide ? bypassReason : null,
+      styleguide_applied: canApply,
+      warnings,
+      observed_signals: analysis.observed,
+      violations,
+    },
+  };
+}
+
 export function registerEditingTools(s, {
   db,
   SYNC_DIR,
   GIT_ENABLED,
+  STYLEGUIDE_ENFORCEMENT_MODE,
   errorResponse,
   jsonResponse,
   pendingProposals,
@@ -31,8 +209,10 @@ export function registerEditingTools(s, {
       project_id: z.string().optional().describe("Optional project ID to disambiguate duplicate scene IDs across projects."),
       instruction: z.string().describe("A brief instruction for the edit (e.g. 'Tighten the opening paragraph'). Used in the git commit message."),
       revised_prose: z.string().describe("The complete revised prose text for the scene."),
+      bypass_styleguide: z.boolean().optional().describe("If true, bypasses automatic styleguide checks for this proposal."),
+      bypass_reason: z.string().optional().describe("Required when bypass_styleguide=true. Explains why this edit should ignore styleguide checks."),
     },
-    async ({ scene_id, project_id, instruction, revised_prose }) => {
+    async ({ scene_id, project_id, instruction, revised_prose, bypass_styleguide = false, bypass_reason }) => {
       if (!GIT_ENABLED) {
         return errorResponse("GIT_UNAVAILABLE", "Git is not available — prose editing is not supported. Ensure git is installed and the sync directory is writable.");
       }
@@ -56,6 +236,27 @@ export function registerEditingTools(s, {
           );
         }
         scene = scenes[0];
+      }
+
+      const styleguideSnapshotResult = resolveStyleguideSnapshot({
+        syncDir: SYNC_DIR,
+        projectId: scene.project_id,
+        errorResponse,
+      });
+      if (!styleguideSnapshotResult.ok) {
+        return styleguideSnapshotResult.response;
+      }
+
+      const styleguidePolicy = evaluateStyleguidePolicy({
+        snapshot: styleguideSnapshotResult.snapshot,
+        revisedProse: revised_prose,
+        bypassStyleguide: bypass_styleguide,
+        bypassReason: bypass_reason,
+        enforcementMode: STYLEGUIDE_ENFORCEMENT_MODE,
+        errorResponse,
+      });
+      if (!styleguidePolicy.ok) {
+        return styleguidePolicy.response;
       }
 
       try {
@@ -90,6 +291,8 @@ export function registerEditingTools(s, {
           rendered_content: renderedContent,
           original_prose: currentProse,
           metadata,
+          styleguide_snapshot: styleguideSnapshotResult.snapshot,
+          styleguide_policy: styleguidePolicy.policy,
           created_at: new Date().toISOString(),
         });
 
@@ -107,6 +310,13 @@ export function registerEditingTools(s, {
           instruction,
           diff_preview: diffPreview,
           noop,
+          styleguide: {
+            ...styleguidePolicy.policy,
+            fingerprint: styleguideSnapshotResult.snapshot.fingerprint,
+            config_found: styleguideSnapshotResult.snapshot.config_found,
+            skill_found: styleguideSnapshotResult.snapshot.skill_found,
+            sources: styleguideSnapshotResult.snapshot.sources,
+          },
           note: noop
             ? "This proposal matches the current scene file. Calling commit_edit will be a no-op."
             : "Review the diff above. Call commit_edit with this proposal_id to apply the change.",
@@ -165,6 +375,35 @@ export function registerEditingTools(s, {
 
       if (project_id && proposal.project_id && proposal.project_id !== project_id) {
         return errorResponse("INVALID_EDIT", `Proposal '${proposal_id}' is for project '${proposal.project_id}', not '${project_id}'.`);
+      }
+
+      if (
+        proposal.styleguide_snapshot
+        && proposal.styleguide_policy
+        && proposal.styleguide_policy.bypass_used !== true
+      ) {
+        const latestStyleguideSnapshot = resolveStyleguideSnapshot({
+          syncDir: SYNC_DIR,
+          projectId: proposal.project_id,
+          errorResponse,
+        });
+        if (!latestStyleguideSnapshot.ok) {
+          return latestStyleguideSnapshot.response;
+        }
+
+        if (latestStyleguideSnapshot.snapshot.fingerprint !== proposal.styleguide_snapshot.fingerprint) {
+          return errorResponse(
+            "STYLEGUIDE_CHANGED_SINCE_PROPOSAL",
+            "Styleguide inputs changed after this proposal was created. Re-run propose_edit against the latest styleguide before commit.",
+            {
+              proposal_id,
+              project_id: proposal.project_id ?? null,
+              previous_fingerprint: proposal.styleguide_snapshot.fingerprint,
+              current_fingerprint: latestStyleguideSnapshot.snapshot.fingerprint,
+              next_step: "Call propose_edit again to regenerate this revision with current styleguide rules.",
+            }
+          );
+        }
       }
 
       try {

--- a/src/tools/editing.js
+++ b/src/tools/editing.js
@@ -60,10 +60,27 @@ function resolveStyleguideSnapshot({ syncDir, projectId, errorResponse }) {
     PROSE_STYLEGUIDE_SKILL_DIRNAME,
     PROSE_STYLEGUIDE_SKILL_BASENAME
   );
-  const skillExists = fs.existsSync(skillPath);
-  const skillDigest = skillExists
-    ? digestFor(fs.readFileSync(skillPath, "utf8"))
-    : null;
+  let skillExists;
+  let skillDigest = null;
+  try {
+    skillExists = fs.existsSync(skillPath);
+    if (skillExists) {
+      skillDigest = digestFor(fs.readFileSync(skillPath, "utf8"));
+    }
+  } catch (error) {
+    const err = error instanceof Error ? error : new Error(String(error));
+    return {
+      ok: false,
+      response: errorResponse(
+        "STYLEGUIDE_SKILL_IO_ERROR",
+        "Failed to read skills/prose-styleguide.md while resolving styleguide snapshot.",
+        {
+          file_path: skillPath,
+          reason: err.message,
+        }
+      ),
+    };
+  }
   const fingerprint = buildStyleguideFingerprint({
     resolvedConfig: resolved.resolved_config,
     sources: resolved.sources,
@@ -80,7 +97,7 @@ function resolveStyleguideSnapshot({ syncDir, projectId, errorResponse }) {
       sources: resolved.sources,
       resolved_config: resolved.resolved_config,
       skill_file_path: skillPath,
-      skill_found: skillExists,
+      skill_found: Boolean(skillExists),
       skill_digest: skillDigest,
       fingerprint,
     },


### PR DESCRIPTION
## Summary

- Adds automatic prose-styleguide enforcement to the safe editing path by running checks during propose_edit.
- Returns structured styleguide diagnostics in proposal responses, including violations, warnings, and a styleguide fingerprint.
- Adds explicit bypass controls (bypass_styleguide, bypass_reason) and commit-time protection that rejects stale proposals when styleguide inputs changed.
- Introduces runtime enforcement configuration via PROSE_STYLEGUIDE_ENFORCEMENT_MODE (off|warn|required, default warn).
- Adds integration coverage for warn/required mode behavior and updates generated tool docs.

## Motivation

- The styleguide PRD expects style rules to apply automatically during prose editing, not as a separate manual step.
- Enforcing style checks inside the existing propose/commit workflow preserves outcome-first UX while keeping approvals explicit and safe.
- Commit-time fingerprint validation prevents applying proposals against outdated style constraints.

## Implementation

- src/tools/editing.js
  - Resolves active styleguide config + skill file snapshot per proposal.
  - Evaluates policy based on enforcement mode and bypass settings.
  - Returns structured styleguide diagnostics in propose_edit responses.
  - Stores styleguide snapshot/policy on pending proposals.
  - Verifies styleguide fingerprint in commit_edit and returns STYLEGUIDE_CHANGED_SINCE_PROPOSAL on mismatch.
- src/index.js
  - Adds PROSE_STYLEGUIDE_ENFORCEMENT_MODE runtime env parsing and threads the mode into editing tools.
  - Exposes styleguide_enforcement_mode in get_runtime_config output.
- src/test/integration/editing.test.mjs
  - Adds enforcement tests for diagnostics, required-mode blocking, explicit bypass, missing bypass reason, and commit-time fingerprint mismatch.
- docs/tools.md
  - Regenerated tool reference for new propose_edit parameters.
- docs/release-log.md
  - Adds an unreleased entry describing user-facing behavior changes.

## Testing

- npm run lint
- node --experimental-sqlite --test --test-concurrency=1 src/test/integration/editing.test.mjs
- npm test
- npm run docs
- Manually reviewed PR diff and runtime behavior changes for propose_edit/commit_edit styleguide enforcement paths.

## Risks and tradeoffs

- required mode can add friction for teams without configured styleguide files; default remains warn to preserve low-friction outcome-first usage.
- Drift detection currently focuses on mechanical signals (quotation style, dash spacing, spelling hints, tense hints), so strict mode can still require author judgment for nuanced prose.

## Follow-up

- Consider adding a dedicated severity taxonomy (warning vs error) per rule family instead of current mechanical-drift defaults.
- Consider exposing styleguide fingerprint metadata in review tooling for easier troubleshooting.
