### PR TITLE
refactor: move styleguide skill output to skills/prose-styleguide/SKILL.md

### DIFF
--- a/docs/prd/in-progress/guideline-generation.md
+++ b/docs/prd/in-progress/guideline-generation.md
@@ -6,7 +6,7 @@ Provide a reusable system that helps authors maintain consistent prose quality, 
 
 The system consists of four components:
 - `prose-styleguide.config.yaml` — author-selected conventions (enumerable, config-driven)
-- `prose-styleguide.md` — universal craft rules + voice notes injected from config
+- `skills/prose-styleguide/SKILL.md` — universal craft rules + voice notes injected from config
 - An interactive wizard for onboarding (generates the config)
 - Optional MCP support to bootstrap the config from existing writing and suggest updates
 
@@ -57,7 +57,7 @@ Non-expert users especially struggle to encode their style into reusable instruc
 
 ## Invocation Model
 
-The styleguide is a **standing order**, not an on-demand command. Whenever the AI edits prose — whether via `propose_edit`, `commit_edit`, or direct in-scene editing — it loads `prose-styleguide.md` and the resolved config automatically as part of its working context. The author does not need to invoke it explicitly.
+The styleguide is a **standing order**, not an on-demand command. Whenever the AI edits prose — whether via `propose_edit`, `commit_edit`, or direct in-scene editing — it loads `skills/prose-styleguide/SKILL.md` and the resolved config automatically as part of its working context. The author does not need to invoke it explicitly.
 
 This means:
 - Every prose edit applies the styleguide by default
@@ -75,7 +75,8 @@ There is no vendor-neutral standard for AI instruction files. To avoid duplicati
 ```
 {WRITING_SYNC_DIR}/
   skills/
-    prose-styleguide.md          ← single source of truth
+    prose-styleguide/
+      SKILL.md                   ← single source of truth
   prose-styleguide.config.yaml   ← author conventions (project root)
 ```
 
@@ -85,9 +86,9 @@ There is no vendor-neutral standard for AI instruction files. To avoid duplicati
 
 Each AI tool references the canonical file rather than duplicating its content:
 
-- **Claude Code** — `CLAUDE.md` imports the file via `@skills/prose-styleguide.md`
+- **Claude Code** — `CLAUDE.md` imports the file via `@skills/prose-styleguide/SKILL.md`
 - **GitHub Copilot** — `.github/copilot-instructions.md` references it; since Copilot does not support file imports, the content must be inlined at setup time and kept in sync manually
-- **Other tools** — reference or inline as needed; the canonical file is always `skills/prose-styleguide.md`
+- **Other tools** — reference or inline as needed; the canonical file is always `skills/prose-styleguide/SKILL.md`
 
 If the `.ai/` directory becomes an adopted neutral standard, `skills/` can migrate there without changing the canonical filename.
 

--- a/docs/release-log.md
+++ b/docs/release-log.md
@@ -8,6 +8,14 @@ This complements `CHANGELOG.md`:
 
 ## Unreleased
 
+### 2026-05-03 — Move generated styleguide skill to skills/prose-styleguide/SKILL.md
+
+- What changed: `setup_prose_styleguide_skill` now writes to `skills/prose-styleguide/SKILL.md` instead of `skills/prose-styleguide.md`, matching the `skills/skillname/SKILL.md` directory convention used by all other skills.
+- Why it matters: Consistent skill layout makes discovery and vendor wiring (e.g. CLAUDE.md imports) predictable.
+- Who is affected: Any user or automation that references the generated skill file by its old path.
+- Action needed: If you have an existing `skills/prose-styleguide.md`, move it to `skills/prose-styleguide/SKILL.md` or regenerate with `setup_prose_styleguide_skill(overwrite=true)`.
+- PR: [#168](https://github.com/hannasdev/mcp-writing/pull/168)
+
 ### 2026-05-03 — Surface runtime warning for invalid styleguide enforcement mode
 
 - What changed: Server startup now emits an explicit `STYLEGUIDE_ENFORCEMENT_MODE_INVALID` warning when `PROSE_STYLEGUIDE_ENFORCEMENT_MODE` environment variable is set to an invalid value (falling back to default `warn` mode).

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -617,12 +617,12 @@ Detect styleguide drift by comparing declared config conventions against observe
 
 ## setup_prose_styleguide_skill
 
-Generate skills/prose-styleguide.md from the resolved prose styleguide config and universal craft rules.
+Generate skills/prose-styleguide/SKILL.md from the resolved prose styleguide config and universal craft rules.
 
 | Parameter | Type | Required | Description |
 | --- | --- | :---: | --- |
 | `project_id` | `string` | No | Optional project ID for scoped config resolution (e.g. 'the-lamb' or 'universe-1/book-1'). |
-| `overwrite` | `boolean` | No | If true, replaces an existing skills/prose-styleguide.md file. |
+| `overwrite` | `boolean` | No | If true, replaces an existing skills/prose-styleguide/SKILL.md file. |
 
 ---
 

--- a/src/styleguide/prose-styleguide-skill.js
+++ b/src/styleguide/prose-styleguide-skill.js
@@ -1,5 +1,5 @@
-export const PROSE_STYLEGUIDE_SKILL_DIRNAME = "skills";
-export const PROSE_STYLEGUIDE_SKILL_BASENAME = "prose-styleguide.md";
+export const PROSE_STYLEGUIDE_SKILL_DIRNAME = "skills/prose-styleguide";
+export const PROSE_STYLEGUIDE_SKILL_BASENAME = "SKILL.md";
 
 const LANGUAGE_LABELS = {
   english_us: "English (US)",
@@ -63,7 +63,7 @@ export function buildProseStyleguideSkill({ resolvedConfig, sources = [], projec
       ok: false,
       error: {
         code: "INVALID_STYLEGUIDE_CONFIG",
-        message: "Cannot generate prose-styleguide.md without a resolved config object.",
+        message: "Cannot generate skills/prose-styleguide/SKILL.md without a resolved config object.",
       },
     };
   }

--- a/src/test/integration/styleguide.test.mjs
+++ b/src/test/integration/styleguide.test.mjs
@@ -433,7 +433,7 @@ describe("setup_prose_styleguide_skill tool", () => {
     assert.match(parsed.error.details.next_step, /bootstrap_prose_styleguide_config/);
   });
 
-  test("writes skills/prose-styleguide.md from resolved config", async () => {
+  test("writes skills/prose-styleguide/SKILL.md from resolved config", async () => {
     fs.writeFileSync(
       path.join(writeSyncDir, "prose-styleguide.config.yaml"),
       [
@@ -454,7 +454,7 @@ describe("setup_prose_styleguide_skill tool", () => {
     assert.ok(Array.isArray(parsed.injected_rules));
     assert.equal(parsed.injected_rules.length > 0, true);
 
-    const skillPath = path.join(writeSyncDir, "skills", "prose-styleguide.md");
+    const skillPath = path.join(writeSyncDir, "skills", "prose-styleguide", "SKILL.md");
     assert.equal(fs.existsSync(skillPath), true);
     const skillText = fs.readFileSync(skillPath, "utf8");
     assert.match(skillText, /# Prose Styleguide/);

--- a/src/tools/editing.js
+++ b/src/tools/editing.js
@@ -147,7 +147,7 @@ function evaluateStyleguidePolicy({
           ok: false,
           response: errorResponse(
             "STYLEGUIDE_SKILL_REQUIRED",
-            "Cannot propose prose edits before skills/prose-styleguide/SKILL/SKILL.md exists.",
+            "Cannot propose prose edits before skills/prose-styleguide/SKILL.md exists.",
             {
               next_step: "Run setup_prose_styleguide_skill, then retry propose_edit.",
             }

--- a/src/tools/editing.js
+++ b/src/tools/editing.js
@@ -73,7 +73,7 @@ function resolveStyleguideSnapshot({ syncDir, projectId, errorResponse }) {
       ok: false,
       response: errorResponse(
         "STYLEGUIDE_SKILL_IO_ERROR",
-        "Failed to read skills/prose-styleguide.md while resolving styleguide snapshot.",
+        "Failed to read skills/prose-styleguide/SKILL.md while resolving styleguide snapshot.",
         {
           file_path: skillPath,
           reason: err.message,
@@ -147,14 +147,14 @@ function evaluateStyleguidePolicy({
           ok: false,
           response: errorResponse(
             "STYLEGUIDE_SKILL_REQUIRED",
-            "Cannot propose prose edits before skills/prose-styleguide.md exists.",
+            "Cannot propose prose edits before skills/prose-styleguide/SKILL/SKILL.md exists.",
             {
               next_step: "Run setup_prose_styleguide_skill, then retry propose_edit.",
             }
           ),
         };
       }
-      warnings.push("skills/prose-styleguide.md was not found at sync root.");
+      warnings.push("skills/prose-styleguide/SKILL.md was not found at sync root.");
     }
   }
 

--- a/src/tools/styleguide.js
+++ b/src/tools/styleguide.js
@@ -603,10 +603,10 @@ export function registerStyleguideTools(s, {
 
   s.tool(
     "setup_prose_styleguide_skill",
-    "Generate skills/prose-styleguide.md from the resolved prose styleguide config and universal craft rules.",
+    "Generate skills/prose-styleguide/SKILL.md from the resolved prose styleguide config and universal craft rules.",
     {
       project_id: z.string().optional().describe("Optional project ID for scoped config resolution (e.g. 'the-lamb' or 'universe-1/book-1')."),
-      overwrite: z.boolean().optional().describe("If true, replaces an existing skills/prose-styleguide.md file."),
+      overwrite: z.boolean().optional().describe("If true, replaces an existing skills/prose-styleguide/SKILL.md file."),
     },
     async ({ project_id, overwrite = false }) => {
       if (project_id !== undefined) {
@@ -638,7 +638,7 @@ export function registerStyleguideTools(s, {
       if (resolved.setup_required || !resolved.resolved_config) {
         return errorResponse(
           "STYLEGUIDE_CONFIG_REQUIRED",
-          "Cannot generate prose-styleguide.md before prose-styleguide.config.yaml is set up.",
+          "Cannot generate skills/prose-styleguide/SKILL.md before prose-styleguide.config.yaml is set up.",
           {
             project_id: project_id ?? null,
             next_step: "Run setup_prose_styleguide_config or bootstrap_prose_styleguide_config first.",
@@ -658,7 +658,7 @@ export function registerStyleguideTools(s, {
       if (fs.existsSync(skillPath) && !overwrite) {
         return errorResponse(
           "STYLEGUIDE_SKILL_EXISTS",
-          "skills/prose-styleguide.md already exists. Set overwrite=true to replace it.",
+          "skills/prose-styleguide/SKILL.md already exists. Set overwrite=true to replace it.",
           { target_path: path.resolve(skillPath) }
         );
       }


### PR DESCRIPTION
## Summary

Move the generated styleguide skill file from `skills/prose-styleguide.md` to `skills/prose-styleguide/SKILL.md` to align with the standard skill directory structure used by all other skills in this repo.

## Motivation

The repo's `skills/` directory follows a `skills/skillname/SKILL.md` convention (code-review, commit-writing, pr-description). The styleguide skill was generated directly to `skills/prose-styleguide.md`, inconsistent with this pattern.

## Implementation

- **src/styleguide/prose-styleguide-skill.js**: Updated `PROSE_STYLEGUIDE_SKILL_DIRNAME` and `PROSE_STYLEGUIDE_SKILL_BASENAME` constants.
- **src/tools/styleguide.js**: Updated tool description and error messages.
- **src/tools/editing.js**: Updated warning and error message strings.
- **src/test/integration/styleguide.test.mjs**: Updated test assertion to verify new path.
- **docs/prd/in-progress/guideline-generation.md**: Updated documentation to reflect new location.
- **docs/tools.md**: Auto-regenerated tool reference.

## Testing

- `npm run lint`
- `node --experimental-sqlite --test src/test/integration/styleguide.test.mjs` (17/17 ✓)
- `node --experimental-sqlite --test src/test/integration/editing.test.mjs` (18/18 ✓)

## Risks and tradeoffs

- Breaking change for users who have already generated `skills/prose-styleguide.md`: they will need to move the file or regenerate it with `setup_prose_styleguide_skill`. The file is auto-generated so manual edits are uncommon.
- No behavioral change to any tool logic.

## Follow-up

- Ship vendor wiring (CLAUDE.md prose-styleguide import) in separate PR.
- Consider interactive wizard UX for first-time setup (Phase 2 complexity).