### PR TITLE
docs: split PRD overview and add client-agnostic setup PRD

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -16,135 +16,19 @@ The writing environment is a plain-text sync folder, integrated with Scrivener v
 
 ---
 
-## Feature Overview by Theme
+## Completed Capabilities
 
-### 🎯 [Metadata Architecture & Ownership](docs/prd/done/metadata.md) ✅
+Completed feature summaries now live in [docs/prd/completed-features.md](docs/prd/completed-features.md).
 
-How metadata is stored, managed, and kept in sync with prose. Covers sidecar files, staleness detection, and re-enrichment.
-
-**Completed:**
-- Tier 1 (structural) and Tier 2 (editorial) metadata split
-- Sidecar-based storage (`.meta.yaml`)
-- Auto-migration from legacy frontmatter
-- Staleness detection and `enrich_scene` tool
-
-**Key Concepts:**
-- Scrivener owns prose (`.md` files); MCP owns metadata (`.meta.yaml` sidecars)
-- Frontmatter remains read-only legacy; sidecars always win
-- `update_scene_metadata`, `update_character_sheet`, `update_place_sheet` write to sidecars only
-
----
-
-### 📦 [Import & Sync Operations](docs/prd/done/import-sync.md) ✅
-
-How manuscripts are imported from Scrivener and synced. Covers folder structure, identity reconciliation, and edge cases.
-
-**Completed:**
-- SQLite index with universe/project/scene/character/place/thread schema
-- Scrivener binder-ID based identity (stable even when scenes are reordered)
-- World folder structure (characters/, places/, reference/)
-- Stale metadata warnings on sync
-- Symlink support in sync folder walks
-
-**Key Concepts:**
-- External identity (Scrivener binder ID) vs internal identity (`scene_id`)
-- Universes (shared world for series) vs Projects (individual books)
-- Canonical files (one `sheet.md` per character/place) with optional supporting notes
-
----
-
-### ✏️ [Prose Editing & Version Control](docs/prd/done/editing.md) ✅
-
-Two-step editing workflow with git-backed version history. Covers prose proposals, commits, and rollback.
-
-**Completed:**
-- `propose_edit` → review diff → `commit_edit` workflow
-- Git-based version history (no database snapshots)
-- Manual `snapshot_scene` for explicit restore points
-- Pre-edit snapshots before every `commit_edit`
-
-**Key Concepts:**
-- AI proposes, human approves — no silent writes
-- Every edit is a git commit with scene ID and instruction message
-- Can revert to any past version via `get_scene_prose(scene_id, commit=hash)`
-- Branching for experimental rewrites (user-managed in git)
-
----
-
-### 🔍 [Search, Querying & Analysis](docs/prd/done/search-analysis.md) ✅
-
-Fast metadata-only retrieval and intelligent search. Covers FTS5, pagination, and reasoning flows.
-
-**Completed:**
-- `find_scenes()` with filters (character, beat, tag, part, chapter, POV)
-- `get_arc()` — ordered scene metadata for a character's journey
-- `search_metadata()` — FTS5 full-text search across titles, loglines, keywords
-- `get_character_sheet()`, `get_place_sheet()` with supporting notes
-- Staleness warnings before analysis
-- Paginated results for large result sets
-
-**Key Concepts:**
-- Metadata fast; prose on demand
-- Always warn if scenes are stale (prose changed since metadata last updated)
-- FTS5 with fuzzy/prefix matching for flexible queries
-- Character and place entities support both project-local and universe-shared scopes
-
----
-
-### 🧾 [Review Bundles for Editorial Workflows](docs/prd/done/review-bundles.md) ✅
-
-Deterministic, collaboration-focused bundle generation for editorial workflows. Three profiles: outline discussion, detailed editing, and personalized beta reads.
-
-**Completed:**
-- `preview_review_bundle` — dry-run planner with scope, ordering, and warnings
-- `create_review_bundle` — artifact writer (PDF default, markdown optional)
-- `outline_discussion` profile: scene headings, loglines, beats — no prose
-- `editor_detailed` profile: full prose with stable scene anchors and page breaks
-- `beta_reader_personalized` profile: named recipient, usage notice, feedback form
-- PDF export via pdfkit; companion `manifest.json`, `notice.md`, `feedback-form.md`
-
-**Key Concepts:**
-- Review artifacts only — not a publishing or typesetting surface
-- Deterministic ordering from indexed scene structure
-- Provenance manifest with source commit hash and warning summary
-- `warn` vs `fail` strictness mode for stale/incomplete metadata
-
-**Known Issue:**
-- Logline renders unconditionally in all profiles; should be `outline_discussion` only. Prose profiles (`editor_detailed`, `beta_reader_personalized`) should suppress it.
-
----
-
-### 🗂️ [Scrivener Direct Extraction](docs/prd/done/scrivener-direct-extraction-beta.md) ✅
-
-Direct ingestion from Scrivener project internals (`.scriv`/`.scrivx`) for richer metadata extraction. Graduated from beta to stable in v1.14.
-
-**Completed:**
-- Official ingestion path reading `.scrivx` binder structure
-- Richer metadata extraction compared to External Folder Sync path
-- Scoped safeguards to avoid schema-coupled regressions
-- Stable alongside sync-folder import as the default path
-
----
-
-### 📚 [Reference Document Querying](docs/prd/done/reference-docs.md) ✅
-
-Index and link world-building notes, research, and continuity scratchpads as a reference system.
-
-**Example:** "Find all continuity notes mentioning Elena", "What are the rules of magic in this world?", or "What reference docs directly inform this scene?"
-
-**Status:** Completed. Phase 4A–4D are shipped; follow-up candidates are documented in the PRD.
-
----
-
-## Recently Delivered
-
-### 🪄 [Guideline Generation](docs/prd/done/guideline-generation.md) ✅
-
-Build a reusable prose styleguide system with config resolution, skill generation, and in-edit behavior that helps authors preserve voice and structural consistency.
-
-**Status:** Delivered. Core styleguide capabilities are live and tracked in done PRDs; follow-up onboarding and long-term UX refinements are tracked separately.
-
-Onboarding and config lifecycle requirements are tracked separately in [Onboarding Framework](docs/prd/todo/onboarding-framework.md).
+Core completed areas:
+- [Metadata Architecture & Ownership](docs/prd/done/metadata.md)
+- [Import & Sync Operations](docs/prd/done/import-sync.md)
+- [Prose Editing & Version Control](docs/prd/done/editing.md)
+- [Search, Querying & Analysis](docs/prd/done/search-analysis.md)
+- [Review Bundles for Editorial Workflows](docs/prd/done/review-bundles.md)
+- [Scrivener Direct Extraction](docs/prd/done/scrivener-direct-extraction-beta.md)
+- [Reference Document Querying](docs/prd/done/reference-docs.md)
+- [Guideline Generation](docs/prd/done/guideline-generation.md)
 
 ---
 
@@ -156,17 +40,15 @@ Deploy Writing MCP as a service in the OpenClaw runtime with the Writing World a
 
 **Status:** In progress. Runtime shape, deployment targets, and agent integration points are defined; remaining work is implementation and rollout.
 
+### 🧭 [Client-Agnostic Setup Contract](docs/prd/in-progress/client-agnostic-setup.md) 🚧
+
+Define a shared setup contract for configuration-driven writing features so setup can live in client-native UI surfaces while the MCP remains focused on durable capabilities.
+
+**Status:** In progress. Product direction is shifting away from onboarding-heavy MCP workflow expansion and toward a shared contract plus thin client adapters.
+
 ---
 
 ## Deferred Backlog (Not Active)
-
-### 🧭 [Onboarding Framework](docs/prd/todo/onboarding-framework.md) 📋
-
-Define a shared onboarding and configuration lifecycle for writing-assistant features, including setup scope, defaults, bootstrap, and boot-file publication behavior.
-
-**Status:** Deferred backlog (not active).
-
----
 
 ### 📊 [Embedding-Based Search](docs/prd/todo/embeddings-search.md) 📋
 
@@ -244,22 +126,17 @@ Additional completed structural proposal:
 
 Writing MCP is now in continuous development rather than sequential phase delivery.
 
-- **Core platform complete:** metadata architecture, import/sync, prose editing, search/analysis, review bundles, and Scrivener Direct extraction are all implemented.
-- **Active development:** OpenClaw integration.
-- **Deferred backlog:** embeddings search and onboarding framework.
+- **Core platform complete:** the major shipped capabilities are indexed in [docs/prd/completed-features.md](docs/prd/completed-features.md).
+- **Active development:** OpenClaw integration and the client-agnostic setup contract.
+- **Deferred backlog:** embeddings search.
 - **Ideas and open questions:** tracked separately so future exploration does not distort the active roadmap.
 
 ---
 
 ## For More Details
 
-- [Metadata Architecture](docs/prd/done/metadata.md) — sidecar design, staleness, re-enrichment
-- [Import & Sync](docs/prd/done/import-sync.md) — folder structure, identity, reconciliation
-- [Prose Editing](docs/prd/done/editing.md) — two-step workflow, git history
-- [Search & Analysis](docs/prd/done/search-analysis.md) — querying, reasoning flows, pagination
-- [Review Bundles](docs/prd/done/review-bundles.md) — editorial workflows, profiles, known issues
-- [Scrivener Direct Extraction](docs/prd/done/scrivener-direct-extraction-beta.md) — direct .scriv ingestion
+- [Completed Features Index](docs/prd/completed-features.md) — shipped capability summaries and links
 - [OpenClaw Integration](docs/prd/in-progress/openclaw-integration.md) — deployment and runtime integration
-- [Guideline Generation](docs/prd/done/guideline-generation.md) — styleguide generation, skill publishing, and convention enforcement
+- [Client-Agnostic Setup Contract](docs/prd/in-progress/client-agnostic-setup.md) — shared setup contract and client-hosted setup UI direction
 - [Open Ideas](docs/prd/inbox/ideas-and-questions.md) — design questions, feature ideas
 - [Workflow Discovery](docs/prd/done/describe-workflows.md) — `describe_workflows` tool, entry-point for AI navigation

--- a/PRD.md
+++ b/PRD.md
@@ -75,39 +75,7 @@ Additional completed structural proposal:
 
 ## Tool Reference
 
-### Fast Metadata Tools (no prose loaded)
-
-- `find_scenes(character?, beat?, tag?, ...)` — filter by metadata
-- `get_arc(character_id)` — character's scene journey
-- `get_character_sheet(character_id)` — full character metadata
-- `list_characters()`, `list_places()`, `list_threads()`
-- `search_metadata(query)` — FTS5 search
-- `get_runtime_config()` — system status and diagnostics
-
-### Prose Tools (loads file content)
-
-- `get_scene_prose(scene_id)` — current prose
-- `get_chapter_prose(project_id, part, chapter)` — all scenes in a chapter
-- `list_snapshots(scene_id)` — git commit history
-
-### Editing Tools (two-step confirm)
-
-- `propose_edit(scene_id, instruction, revised_prose)` — stage a change
-- `commit_edit(scene_id, proposal_id)` — apply it (git-backed)
-- `discard_edit(proposal_id)` — reject it
-- `snapshot_scene(scene_id, project_id, reason)` — manual restore point
-
-### Metadata Update Tools (write to sidecars)
-
-- `update_scene_metadata(scene_id, fields)` — update beat, tags, logline, status, etc.
-- `update_character_sheet(character_id, fields)` — update character metadata
-- `update_place_sheet(place_id, fields)` — update place metadata
-- `flag_scene(scene_id, note)` — mark for AI follow-up
-
-### Sync Tools
-
-- `sync()` — re-read sync folder and update index
-- `enrich_scene(scene_id)` — refresh metadata from current prose
+The canonical tool list and contracts are maintained in [docs/tools.md](docs/tools.md), which is auto-generated from the server source.
 
 ---
 

--- a/docs/prd/completed-features.md
+++ b/docs/prd/completed-features.md
@@ -1,0 +1,96 @@
+# Completed Features
+
+This document indexes completed product areas that were previously summarized inline in [PRD.md](/Users/hanna/Code/mcp-writing/PRD.md).
+
+Use this page when you want shipped capability summaries and links to the underlying done PRDs. Use `PRD.md` for the high-level product overview, active development, backlog, and navigation.
+
+## Core Platform
+
+### 🎯 [Metadata Architecture & Ownership](done/metadata.md)
+
+How metadata is stored, managed, and kept in sync with prose.
+
+Highlights:
+- Tier 1 (structural) and Tier 2 (editorial) metadata split
+- Sidecar-based storage with `.meta.yaml`
+- Auto-migration from legacy frontmatter
+- Staleness detection and `enrich_scene`
+
+### 📦 [Import & Sync Operations](done/import-sync.md)
+
+How manuscripts are imported from Scrivener and synced into the indexed workspace.
+
+Highlights:
+- SQLite index with universe/project/scene/character/place/thread schema
+- Scrivener binder-ID based identity
+- World folder structure for characters, places, and reference docs
+- Stale metadata warnings on sync
+
+### ✏️ [Prose Editing & Version Control](done/editing.md)
+
+Two-step editing workflow with git-backed history.
+
+Highlights:
+- `propose_edit` to `commit_edit` confirmation flow
+- Pre-edit snapshots before every commit
+- Manual snapshots for restore points
+- Git-backed version history rather than database snapshots
+
+### 🔍 [Search, Querying & Analysis](done/search-analysis.md)
+
+Fast metadata-first discovery with prose loaded on demand.
+
+Highlights:
+- `find_scenes()` with metadata filters
+- `get_arc()` for ordered scene journeys
+- `search_metadata()` with FTS5
+- Staleness warnings before analysis
+
+### 🧾 [Review Bundles for Editorial Workflows](done/review-bundles.md)
+
+Deterministic bundle generation for outline discussion, detailed editing, and beta reading.
+
+Highlights:
+- `preview_review_bundle` planning step
+- `create_review_bundle` artifact generation
+- PDF export with manifest and review companion files
+- Strictness modes for stale or incomplete metadata
+
+Known issue:
+- Logline currently renders in all bundle profiles and should be limited to `outline_discussion`.
+
+### 🗂️ [Scrivener Direct Extraction](done/scrivener-direct-extraction-beta.md)
+
+Direct ingestion from `.scriv` and `.scrivx` internals for richer metadata extraction.
+
+Highlights:
+- Official direct binder ingestion path
+- Richer metadata than External Folder Sync alone
+- Safeguards to avoid schema-coupled regressions
+
+### 📚 [Reference Document Querying](done/reference-docs.md)
+
+Reference note indexing and linkage for world-building, continuity, and research material.
+
+Highlights:
+- Query reference docs alongside manuscript metadata
+- Link reference docs to scenes
+- Support continuity and rules-of-the-world questions
+
+## Recently Delivered
+
+### 🪄 [Guideline Generation](done/guideline-generation.md)
+
+Reusable prose styleguide system with config resolution, skill generation, and edit-time enforcement behavior.
+
+Follow-up work:
+- [Client-Agnostic Setup Contract](in-progress/client-agnostic-setup.md)
+
+## Additional Completed PRDs
+
+- [Workflow Discovery](done/describe-workflows.md)
+- [Root Structure Reorganization](done/root-structure-reorganization.md)
+- [MCP Tooling Usability](done/mcp-tooling-usability.md)
+- [MCP Tooling Usability Milestones](done/mcp-tooling-usability-milestones.md)
+- [Refactoring](done/refactoring.md)
+- [Resolved Design Questions](done/resolved-design-questions.md)

--- a/docs/prd/completed-features.md
+++ b/docs/prd/completed-features.md
@@ -1,6 +1,6 @@
 # Completed Features
 
-This document indexes completed product areas that were previously summarized inline in [PRD.md](/Users/hanna/Code/mcp-writing/PRD.md).
+This document indexes completed product areas that were previously summarized inline in [PRD.md](../../PRD.md).
 
 Use this page when you want shipped capability summaries and links to the underlying done PRDs. Use `PRD.md` for the high-level product overview, active development, backlog, and navigation.
 

--- a/docs/prd/in-progress/client-agnostic-setup.md
+++ b/docs/prd/in-progress/client-agnostic-setup.md
@@ -1,0 +1,306 @@
+# PRD: Client-Agnostic Setup Contract
+
+**Status:** 🚧 In Progress
+
+## Goal
+
+Define a client-agnostic setup contract for configuration-driven writing features so setup can be presented through client-native UI surfaces without expanding the MCP tool list with onboarding-only commands.
+
+The product goal is:
+- one shared setup contract
+- multiple client-specific setup UIs
+- the same canonical project files regardless of which client was used
+
+This PRD supersedes the broader "onboarding framework" direction for future implementation planning. The old proposal tried to model more of first-run setup inside the MCP workflow surface. This proposal keeps durable capabilities in MCP and moves guided setup UX to clients.
+
+## Problem
+
+The current product has durable setup-related capabilities, but the user experience for reaching them is awkward:
+- a raw tool list is already hard to navigate
+- first-run setup is structurally different from day-to-day usage
+- setup questions are better expressed as structured UI than as tool-parameter discovery
+- adding more onboarding-only tools creates long-term surface area for short-lived tasks
+
+This is especially true for prose styleguide setup and related project conventions:
+- the resulting config matters continuously after setup
+- the setup wizard itself matters mostly on first run and during occasional maintenance
+
+We want to improve setup without permanently increasing MCP complexity.
+
+## Product Boundary
+
+This work is about setup architecture and config lifecycle, not about changing feature behavior.
+
+In scope:
+- a shared setup contract that is not tied to any one IDE or desktop client
+- client-native setup entry points such as command palette flows, forms, or desktop dialogs
+- canonical output files written into the project
+- validation, preview, and confirmation rules shared across clients
+- setup triggers for missing or invalid configuration
+- migration guidance for existing styleguide setup flows
+
+Out of scope:
+- a new MCP onboarding tool that owns the full wizard
+- client-specific UI implementation details for every host
+- adding new feature-specific config domains without a present product need
+- replacing feature PRDs that define the actual writing rules
+
+## Design Principles
+
+1. **Durable in MCP, transient in clients**
+   The MCP surface should expose reusable capabilities, not one-time ceremony.
+
+2. **One contract, many UIs**
+   VS Code, Cursor, Claude Desktop, and future clients may present setup differently, but they should all follow the same setup contract.
+
+3. **Canonical files are the source of truth**
+   Setup is complete when the real config artifacts exist and validate, not when a wizard says it ran.
+
+4. **Prefer derivation over wizard state**
+   "Is setup complete?" should usually be derived from actual project files and runtime checks.
+
+5. **Structured questions beat conversational guessing**
+   High-leverage setup choices should be defined declaratively so clients can render them deterministically.
+
+6. **Do not grow the tool list for first-run-only value**
+   Add MCP surface only when the underlying capability remains useful outside onboarding.
+
+## Proposed Architecture
+
+The setup system has three layers.
+
+### 1. Shared setup contract
+
+A declarative contract defines:
+- which setup flows exist
+- which questions each flow asks
+- which values are required, inferred, or optional
+- which validations apply
+- which files are produced or updated
+- which follow-up actions are suggested after completion
+
+This contract is implementation-neutral. It is not a VS Code wizard, a Cursor dialog, or a Claude Desktop sheet. It is the shared definition those clients consume.
+
+Suggested artifact:
+- `docs/onboarding/setup-contract.json`
+
+The exact file name can change, but the important part is that the schema is stable and versioned.
+
+### 2. Client-specific setup UI
+
+Each client renders the shared contract in its own native UX:
+- VS Code: command palette entry plus structured quick-pick/input flow
+- Cursor: command palette or settings workflow
+- Claude Desktop: setup panel, prompt flow, or missing-config action
+- other hosts: any equivalent guided UI
+
+Client responsibilities:
+- launch the appropriate setup flow
+- render questions in the right order
+- show previews and confirmations
+- collect user overrides
+- write canonical output files or call shared write helpers
+- surface validation errors clearly
+
+The client owns the presentation layer. It does not invent the rules.
+
+### 3. Canonical project artifacts
+
+Regardless of client, setup produces the same durable files.
+
+For prose styleguide V1, the primary artifacts remain:
+- `prose-styleguide.config.yaml`
+- `skills/prose-styleguide/SKILL.md` when sync-root skill generation is applicable
+- vendor wiring files only where needed by the chosen client/tooling environment
+
+The source of truth is still the actual project config, not an onboarding session record.
+
+## Why Not "Just One config.json"?
+
+A shared JSON file is useful, but only if it represents a formal setup contract rather than becoming a second source of truth.
+
+The important distinction:
+- good: a schema or contract file that defines questions, defaults, tiers, and validation
+- risky: a generic wizard-state file that clients write however they want
+
+The setup contract should describe the flow. The final output should still live in the canonical project config files that the runtime already uses.
+
+## MCP Boundary
+
+The MCP should keep exposing durable primitives such as:
+- config creation and update operations
+- bootstrap analysis from existing prose
+- validation and drift detection
+- sync/import operations
+- workflow discovery and runtime diagnostics
+
+The MCP should not become the primary UI host for setup.
+
+That means:
+- no large new onboarding-only tool family
+- no requirement that agents simulate a wizard through repeated tool calls
+- no persistent protocol complexity just to support first-run UX
+
+If a capability is only useful for a wizard and not otherwise reusable, it probably belongs outside the MCP tool surface.
+
+## Relationship to `describe_workflows`
+
+`describe_workflows` should remain the MCP navigation layer, not the full onboarding engine.
+
+Its role in this design:
+- indicate whether relevant config appears missing or invalid
+- point to the recommended setup flow
+- explain whether the missing setup is blocking or advisory
+
+Its role is not:
+- carrying every branching question for the setup flow
+- acting as the main wizard transport
+- expanding into a cross-client UI description language
+
+In other words, `describe_workflows` can recommend setup, but clients should host setup.
+
+## Setup Contract Shape
+
+The shared contract should define setup in a way that any client can render.
+
+Suggested sections:
+- `schema_version`
+- `flows`
+- `questions`
+- `defaults`
+- `validation_rules`
+- `artifact_targets`
+- `completion_rules`
+
+Each question should specify:
+- stable `id`
+- label and help text
+- whether it is blocking
+- whether it is always asked, inferred with confirmation, or low-risk keep/change
+- allowed values or input type
+- default derivation source
+- validation rules
+- where accepted values are written
+
+This preserves the useful tiering idea from the previous proposal without requiring the tier logic to be embodied as new MCP tools.
+
+## First Candidate Flow: Prose Styleguide Setup
+
+The first implementation target should remain prose styleguide setup because it already has:
+- a real recurring value after setup
+- existing write/update/bootstrap capabilities
+- clear missing-config behavior
+- enough structure to validate the contract approach
+
+The flow should cover:
+1. Choose scope and project path context where needed.
+2. Choose language.
+3. Apply language-aware defaults.
+4. Confirm or override high-impact conventions.
+5. Optionally bootstrap from existing prose.
+6. Preview the resulting config.
+7. Write canonical config artifacts.
+8. Optionally publish client- or vendor-specific instruction wiring where applicable.
+
+This is a better fit for a client-side guided flow than for a larger MCP tool family.
+
+## Completion Model
+
+Setup completion should be derived from the real artifacts whenever possible.
+
+For styleguide V1, that means checking:
+- does the relevant config file exist?
+- is it valid?
+- is the required skill file present when the selected scope requires it?
+- if a client depends on vendor-specific wiring, is that wiring present?
+
+Only add persisted setup state if resumability or ambiguity proves impossible to solve from actual files and runtime checks.
+
+Default stance:
+- no mandatory global `onboarding-state.json`
+- derive first, persist second
+
+## Missing-Setup Triggers
+
+Clients should be able to launch the setup flow from:
+- explicit command-palette invocation
+- first-run detection
+- missing config during an editing workflow
+- invalid config or drift checks
+
+The key behavior distinction:
+- blocking setup should interrupt only when the runtime truly cannot proceed
+- advisory setup should be offered without pretending the product is unusable
+
+For styleguide setup, default behavior remains advisory in `warn` mode and blocking only when enforcement mode is explicitly `required`.
+
+## Tradeoffs
+
+### Benefits
+
+- keeps first-run ceremony out of the long-lived MCP tool list
+- gives users a much better UX for structural setup decisions
+- lets different clients provide native-feeling setup without forking the product model
+- keeps source of truth in real project files
+- makes setup easier to evolve without changing the core protocol each time
+
+### Costs
+
+- requires a maintained shared contract/schema
+- requires at least one client implementation to realize the UX benefit
+- introduces coordination between runtime logic and client adapters
+- some cross-client parity work will still be needed
+
+## Non-Goals for V1
+
+- a universal GUI toolkit inside the server
+- onboarding flows for hypothetical future features
+- a generalized persistence layer for every setup interaction
+- replacing the current config files with a new master wizard-state file
+
+## Migration Strategy
+
+This proposal should replace the previous "onboarding inside workflow surface" direction gradually.
+
+Near-term migration:
+- keep existing durable tools
+- keep existing config artifacts
+- stop planning large onboarding-only additions to the MCP surface
+- move future setup guidance toward client-hosted flows backed by a shared contract
+
+The previous onboarding framework document can remain as historical design context, but this PRD should become the active direction for setup architecture.
+
+## Open Questions
+
+1. Where should the shared setup contract live in the repository: product docs, runtime-readable asset, or both?
+2. Should clients write config files directly, or should they call a small set of shared write helpers to avoid divergence?
+3. Which vendor/client wiring files are truly canonical product concerns versus optional adapters?
+4. How much of the current styleguide setup logic should remain in MCP versus move into shared client-agnostic libraries?
+
+## Test Strategy
+
+Unit:
+- validate the setup contract schema
+- validate question ordering, defaults, and tier metadata
+- validate artifact-target mapping from accepted answers to output fields
+- validate completion-rule derivation from filesystem/config state
+
+Integration:
+- verify the prose styleguide setup flow can be completed from the shared contract to canonical files
+- verify `describe_workflows` reports missing/advisory setup accurately without becoming the wizard itself
+- verify bootstrap, config update, and drift tools still work independently of any specific client UI
+- verify different client adapters produce equivalent final config for the same answers
+
+Manual:
+- run the same styleguide setup flow through at least two clients and confirm the resulting project files are equivalent
+- confirm first-run, missing-config, and explicit reconfigure entry points all land in the same contract-driven flow
+
+## Definition of Done
+
+1. A versioned client-agnostic setup contract exists for prose styleguide setup.
+2. The contract can express required questions, inferred defaults, validation, preview, and artifact targets.
+3. At least one client-native setup UI consumes that contract successfully.
+4. The flow writes the same canonical project files regardless of client.
+5. `describe_workflows` recommends setup when appropriate without becoming the setup transport.
+6. No new onboarding-only MCP tool family is introduced to support the flow.
+7. Tests cover contract validity, artifact generation, and setup-completion detection.

--- a/docs/release-log.md
+++ b/docs/release-log.md
@@ -10,7 +10,7 @@ This complements `CHANGELOG.md`:
 
 ### 2026-05-05 — Split PRD overview from completed-feature archive
 
-- What changed: Restructured `PRD.md` into a lighter project overview, moved completed-feature summaries into a dedicated `docs/prd/completed-features.md` index, and added a new in-progress PRD (`docs/prd/in-progress/client-agnostic-setup.md`) that defines a client-agnostic setup contract with client-hosted UI flows.
+- What changed: Restructured `PRD.md` into a lighter project overview, moved completed-feature summaries into a dedicated `docs/prd/completed-features.md` index, replaced the inlined tool summary with a pointer to auto-generated `docs/tools.md`, and added a new in-progress PRD (`docs/prd/in-progress/client-agnostic-setup.md`) that defines a client-agnostic setup contract with client-hosted UI flows.
 - Why it matters: Maintainers and contributors can navigate roadmap status faster, while setup direction now favors reusable MCP capabilities plus client-native onboarding UX instead of growing the tool list for first-run-only workflows.
 - Who is affected: Maintainers and contributors updating PRDs, setup UX direction, or roadmap documentation.
 - Action needed: Optional. Use `docs/prd/completed-features.md` for shipped capability summaries and keep `PRD.md` focused on active direction and navigation.

--- a/docs/release-log.md
+++ b/docs/release-log.md
@@ -14,7 +14,7 @@ This complements `CHANGELOG.md`:
 - Why it matters: Maintainers and contributors can navigate roadmap status faster, while setup direction now favors reusable MCP capabilities plus client-native onboarding UX instead of growing the tool list for first-run-only workflows.
 - Who is affected: Maintainers and contributors updating PRDs, setup UX direction, or roadmap documentation.
 - Action needed: Optional. Use `docs/prd/completed-features.md` for shipped capability summaries and keep `PRD.md` focused on active direction and navigation.
-- PR: (this PR)
+- PR: [#175](https://github.com/hannasdev/mcp-writing/pull/175)
 
 ### 2026-05-03 — Prose styleguide skill with formal output contract
 

--- a/docs/release-log.md
+++ b/docs/release-log.md
@@ -8,6 +8,14 @@ This complements `CHANGELOG.md`:
 
 ## Unreleased
 
+### 2026-05-05 — Split PRD overview from completed-feature archive
+
+- What changed: Restructured `PRD.md` into a lighter project overview, moved completed-feature summaries into a dedicated `docs/prd/completed-features.md` index, and added a new in-progress PRD (`docs/prd/in-progress/client-agnostic-setup.md`) that defines a client-agnostic setup contract with client-hosted UI flows.
+- Why it matters: Maintainers and contributors can navigate roadmap status faster, while setup direction now favors reusable MCP capabilities plus client-native onboarding UX instead of growing the tool list for first-run-only workflows.
+- Who is affected: Maintainers and contributors updating PRDs, setup UX direction, or roadmap documentation.
+- Action needed: Optional. Use `docs/prd/completed-features.md` for shipped capability summaries and keep `PRD.md` focused on active direction and navigation.
+- PR: (this PR)
+
 ### 2026-05-03 — Prose styleguide skill with formal output contract
 
 - What changed: Enhanced `skills/prose-styleguide/SKILL.md` generation to include a formal "Review Mode Output Contract" section with structured critique categories (Structural Issues, Convention Drift, Prose Issues) and sample feedback templates. Updated prose styleguide PRD status from in-progress to completed (tracked at `docs/prd/done/guideline-generation.md`) and annotated success criteria.


### PR DESCRIPTION
## Summary

- Restructures PRD.md into a lighter overview document focused on current direction, active development, backlog, and navigation.
- Moves completed capability summaries into a dedicated index at docs/prd/completed-features.md.
- Adds a new in-progress PRD at docs/prd/in-progress/client-agnostic-setup.md that defines a client-agnostic setup contract with client-hosted UI flows.
- Adds a release-log entry documenting maintainer-facing impact and navigation changes.

## Motivation

PRD.md had grown heavy with historical completed-feature detail, which made active roadmap navigation slower. We also needed to capture a clearer setup direction that avoids growing the MCP tool surface for first-run-only workflows.

## Implementation

- Replaced the long in-file completed-feature section in PRD.md with a compact Completed Capabilities section that links out.
- Added docs/prd/completed-features.md as the canonical completed-feature summary index with links to done PRDs.
- Added docs/prd/in-progress/client-agnostic-setup.md to define the new architecture direction: shared setup contract + client-native setup UX + canonical output files.
- Updated docs/release-log.md under Unreleased with a plain-language entry for maintainers.

## Testing

- Not run: documentation-only change.

## Risks and tradeoffs

- This introduces one extra click for historical feature detail, but significantly improves PRD.md scanability.
- The new setup PRD is directional and may evolve before implementation details are finalized.

## Follow-up

- Align docs/tools.md and related setup docs as implementation planning progresses under the new setup-contract PRD.
