### PR TITLE
docs: align styleguide existing-config response with VS Code UX contract

### DIFF
--- a/docs/prd/in-progress/client-agnostic-setup-vscode-milestones.md
+++ b/docs/prd/in-progress/client-agnostic-setup-vscode-milestones.md
@@ -136,3 +136,25 @@ For `mcp-writing`, the completion target is:
 2. M5 complete for server-side contract/runtime/parity coverage.
 3. M6 contract lifecycle documentation complete.
 4. VS Code adapter implementation is explicitly deferred to the separate extension repository (`mcp-writing-vscode`) as the next phase.
+
+## VS Code Existing-Config UX Acceptance Criteria
+
+When setup encounters an existing prose styleguide config, the extension must treat it as a first-class UX branch rather than a generic failure.
+
+Acceptance criteria:
+
+1. When setup returns `STYLEGUIDE_CONFIG_EXISTS`, the extension shows a dedicated state instead of generic failure.
+2. Dedicated state copy:
+   - Title: `Styleguide already set up`
+   - Body: `A prose styleguide config already exists for this project.`
+3. Dedicated state actions:
+   - Primary: `Edit existing styleguide`
+   - Secondary: `Cancel`
+4. Primary action opens the existing styleguide update/edit flow directly.
+5. UI does not display MCP implementation details (`overwrite=true`, raw paths, or raw payload blobs).
+6. If the update flow cannot be opened, show fallback guidance:
+   - `Couldn't open styleguide editor. Try the styleguide update command from Command Palette.`
+7. Tests:
+   - Unit test for error-to-UI-state mapping (`STYLEGUIDE_CONFIG_EXISTS`).
+   - Integration test for setup with pre-existing config landing on dedicated state.
+   - Integration test verifying primary action routes to edit/update flow (not create flow).

--- a/docs/prd/in-progress/client-agnostic-setup-vscode-milestones.md
+++ b/docs/prd/in-progress/client-agnostic-setup-vscode-milestones.md
@@ -146,7 +146,7 @@ Acceptance criteria:
 1. When setup returns `STYLEGUIDE_CONFIG_EXISTS`, the extension shows a dedicated state instead of generic failure.
 2. Dedicated state copy:
    - Title: `Styleguide already set up`
-   - Body: `A prose styleguide config already exists for this project.`
+   - Body: `A prose styleguide config already exists at the target location.`
 3. Dedicated state actions:
    - Primary: `Edit existing styleguide`
    - Secondary: `Cancel`

--- a/docs/release-log.md
+++ b/docs/release-log.md
@@ -8,6 +8,14 @@ This complements `CHANGELOG.md`:
 
 ## Unreleased
 
+### 2026-05-07 — Align existing-styleguide setup message with cross-scope UX contract
+
+- What changed: Updated `STYLEGUIDE_CONFIG_EXISTS` copy to a scope-neutral message and documented matching VS Code existing-config acceptance criteria so both `project_root` and `sync_root` setup flows use the same user-facing contract.
+- Why it matters: Prevents scope-specific wording confusion and keeps server/extension behavior consistent when setup encounters an existing styleguide config.
+- Who is affected: Users running prose styleguide setup and maintainers/client implementers relying on dedicated existing-config UX handling.
+- Action needed: Optional. If client-side UX hard-codes prior copy, update it to `A prose styleguide config already exists at the target location.`.
+- PR: [#178](https://github.com/hannasdev/mcp-writing/pull/178)
+
 ### 2026-05-05 — Add client-agnostic setup contract runtime and VS Code handoff docs
 
 - What changed: Added a versioned styleguide setup contract (`src/setup/contracts/styleguide_setup_v1.json`), shared setup runtime helpers (`src/setup/setup-contract.js`), `describe_workflows` setup contract status/plan preview metadata, contract parity tests, and documentation links to the new VS Code extension repository.

--- a/src/tools/styleguide.js
+++ b/src/tools/styleguide.js
@@ -251,7 +251,7 @@ export function registerStyleguideTools(s, {
       if (fs.existsSync(targetPath) && !overwrite) {
         return errorResponse(
           "STYLEGUIDE_CONFIG_EXISTS",
-          "Styleguide config already exists at target path. Set overwrite=true to replace it.",
+          "A prose styleguide config already exists for this project.",
           { target_path: path.resolve(targetPath) }
         );
       }

--- a/src/tools/styleguide.js
+++ b/src/tools/styleguide.js
@@ -251,7 +251,7 @@ export function registerStyleguideTools(s, {
       if (fs.existsSync(targetPath) && !overwrite) {
         return errorResponse(
           "STYLEGUIDE_CONFIG_EXISTS",
-          "A prose styleguide config already exists for this project.",
+          "A prose styleguide config already exists at the target location.",
           { target_path: path.resolve(targetPath) }
         );
       }


### PR DESCRIPTION
## Summary

- Align server-side existing-config copy with the VS Code existing-config UX branch.
- Add explicit acceptance criteria for the VS Code existing-config path to the active client-agnostic setup milestones.

## Motivation

The extension now treats `STYLEGUIDE_CONFIG_EXISTS` as a dedicated UX state. The server response copy and milestone contract should be explicit and stable so client behavior remains deterministic and user-facing copy is consistent.

## Implementation

- Updated `setup_prose_styleguide_config` existing-config error message in `src/tools/styleguide.js` to:
  - `A prose styleguide config already exists at the target location.`
- Added a new section in `docs/prd/in-progress/client-agnostic-setup-vscode-milestones.md`:
  - `VS Code Existing-Config UX Acceptance Criteria`
- Documented required dedicated state copy, actions, fallback guidance, and expected unit/integration test coverage for the extension.
- Added an `## Unreleased` entry in `docs/release-log.md` (5-bullet format) for this user-facing copy/contract alignment.

## Testing

- `node --test src/test/unit/styleguide.test.mjs`
- Manual verification: checked diff alignment across server copy, milestone acceptance copy, and release-log entry.

## Risks and tradeoffs

- Low risk: this is copy/contract alignment only.
- Minor coordination risk if extension copy diverges later; mitigated by documenting the acceptance criteria in the milestone file.

## Follow-up

None
