### PR TITLE
chore: track VS Code existing-config setup rollout and add guardrail test

### DIFF
--- a/docs/prd/in-progress/client-agnostic-setup-vscode-milestones.md
+++ b/docs/prd/in-progress/client-agnostic-setup-vscode-milestones.md
@@ -158,3 +158,39 @@ Acceptance criteria:
    - Unit test for error-to-UI-state mapping (`STYLEGUIDE_CONFIG_EXISTS`).
    - Integration test for setup with pre-existing config landing on dedicated state.
    - Integration test verifying primary action routes to edit/update flow (not create flow).
+
+## Implementation Plan — 2026-05-07
+
+Status: In progress (server-side guardrail complete; VS Code existing-config slice verified complete)
+
+Execution order:
+1. Lock MCP error contract with regression coverage in `mcp-writing`:
+   - Add integration test asserting `setup_prose_styleguide_config` returns `STYLEGUIDE_CONFIG_EXISTS` for existing target config without `overwrite=true`.
+2. Implement VS Code existing-config setup branch in `mcp-writing-vscode`:
+   - Map `STYLEGUIDE_CONFIG_EXISTS` to dedicated `styleguideAlreadySetup` UI state.
+   - Render dedicated copy and actions (`Edit existing styleguide`, `Cancel`).
+   - Route primary action to styleguide update/edit flow.
+   - Add fallback guidance if update flow cannot be opened.
+3. Add VS Code tests in `mcp-writing-vscode`:
+   - Unit test for error-to-UI-state mapping.
+   - Integration test for pre-existing config entering dedicated state.
+   - Integration test for primary-action routing to update flow.
+
+Test strategy:
+1. `mcp-writing`:
+   - Run `src/test/integration/styleguide.test.mjs` after adding the error-contract test.
+2. `mcp-writing-vscode`:
+   - Run setup-flow unit/integration suite covering the existing-config branch and action routing.
+
+Notes:
+1. Server-side contract/runtime milestones (M1-M3 and server-side M5/M6 checkpoint) remain complete.
+2. This plan tracks the next execution slice and preserves the client-agnostic boundary: setup UX in client, durable behavior in MCP.
+
+Progress update (verified 2026-05-07):
+1. Step 1 complete in `mcp-writing`:
+   - Added integration test coverage for `STYLEGUIDE_CONFIG_EXISTS` in `src/test/integration/styleguide.test.mjs`.
+   - Verified with `node --experimental-sqlite --test src/test/integration/styleguide.test.mjs` (pass).
+2. Steps 2 and 3 complete in `mcp-writing-vscode` (branch `chore/client-agnostic-followup`):
+   - Dedicated existing-config UI state, copy, actions, primary-action routing, and fallback guidance are implemented in `src/extension.js`.
+   - Tests for mapping, dedicated state handling, routing, and fallback are implemented in `test/extension.test.cjs`.
+   - Verified with `npm --prefix /Users/hanna/Code/mcp-writing-vscode test` (pass).

--- a/docs/prd/in-progress/client-agnostic-setup-vscode-milestones.md
+++ b/docs/prd/in-progress/client-agnostic-setup-vscode-milestones.md
@@ -161,7 +161,7 @@ Acceptance criteria:
 
 ## Implementation Plan — 2026-05-07
 
-Status: In progress (server-side guardrail complete; VS Code existing-config slice verified complete)
+Status: Complete for this execution slice (server-side guardrail complete; VS Code existing-config slice verified complete)
 
 Execution order:
 1. Lock MCP error contract with regression coverage in `mcp-writing`:

--- a/docs/prd/in-progress/client-agnostic-setup-vscode-milestones.md
+++ b/docs/prd/in-progress/client-agnostic-setup-vscode-milestones.md
@@ -193,4 +193,4 @@ Progress update (verified 2026-05-07):
 2. Steps 2 and 3 complete in `mcp-writing-vscode` (branch `chore/client-agnostic-followup`):
    - Dedicated existing-config UI state, copy, actions, primary-action routing, and fallback guidance are implemented in `src/extension.js`.
    - Tests for mapping, dedicated state handling, routing, and fallback are implemented in `test/extension.test.cjs`.
-   - Verified with `npm --prefix /Users/hanna/Code/mcp-writing-vscode test` (pass).
+   - Verified with `npm --prefix <path-to-mcp-writing-vscode> test` (pass).

--- a/src/test/integration/styleguide.test.mjs
+++ b/src/test/integration/styleguide.test.mjs
@@ -198,6 +198,8 @@ describe("setup_prose_styleguide_config tool", () => {
 
     assert.equal(parsed.ok, false);
     assert.equal(parsed.error.code, "STYLEGUIDE_CONFIG_EXISTS");
+    const persisted = yaml.load(fs.readFileSync(configPath, "utf8"));
+    assert.equal(persisted.language, "english_us");
   });
 });
 

--- a/src/test/integration/styleguide.test.mjs
+++ b/src/test/integration/styleguide.test.mjs
@@ -181,6 +181,21 @@ describe("setup_prose_styleguide_config tool", () => {
     assert.equal(parsed.config.pov, "first");
     assert.equal(parsed.config.spelling, "uk");
   });
+
+  test("returns STYLEGUIDE_CONFIG_EXISTS when config already exists and overwrite=false", async () => {
+    const configPath = path.join(writeSyncDir, "prose-styleguide.config.yaml");
+    fs.writeFileSync(configPath, "language: english_us\n", "utf8");
+
+    const text = await callWriteTool("setup_prose_styleguide_config", {
+      scope: "sync_root",
+      language: "english_uk",
+      overwrite: false,
+    });
+    const parsed = JSON.parse(text);
+
+    assert.equal(parsed.ok, false);
+    assert.equal(parsed.error.code, "STYLEGUIDE_CONFIG_EXISTS");
+  });
 });
 
 describe("get_prose_styleguide_config tool", () => {

--- a/src/test/integration/styleguide.test.mjs
+++ b/src/test/integration/styleguide.test.mjs
@@ -183,11 +183,14 @@ describe("setup_prose_styleguide_config tool", () => {
   });
 
   test("returns STYLEGUIDE_CONFIG_EXISTS when config already exists and overwrite=false", async () => {
-    const configPath = path.join(writeSyncDir, "prose-styleguide.config.yaml");
+    const projectId = `styleguide-exists-${Date.now()}`;
+    const configPath = path.join(writeSyncDir, "projects", projectId, "prose-styleguide.config.yaml");
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
     fs.writeFileSync(configPath, "language: english_us\n", "utf8");
 
     const text = await callWriteTool("setup_prose_styleguide_config", {
-      scope: "sync_root",
+      scope: "project_root",
+      project_id: projectId,
       language: "english_uk",
       overwrite: false,
     });


### PR DESCRIPTION
## Summary

- Adds an implementation-plan checkpoint for the client-agnostic setup VS Code existing-config UX slice.
- Records verified progress for both repositories (mcp-writing and mcp-writing-vscode) in the milestones doc.
- Adds an integration regression test asserting setup_prose_styleguide_config returns STYLEGUIDE_CONFIG_EXISTS when a target config already exists and overwrite=false.

## Motivation

The VS Code existing-config setup branch depends on a stable server-side error contract. We also need explicit plan tracking in the PRD milestone document so progress is visible and auditable.

## Implementation

- Updated docs/prd/in-progress/client-agnostic-setup-vscode-milestones.md with:
  - a dated implementation plan,
  - execution order,
  - test strategy,
  - and verified progress notes.
- Added a new test case in src/test/integration/styleguide.test.mjs under setup_prose_styleguide_config tool to lock the STYLEGUIDE_CONFIG_EXISTS behavior.

## Testing

- `node --experimental-sqlite --test src/test/integration/styleguide.test.mjs`

## Risks and tradeoffs

- Low risk. The code change is test-only plus planning documentation.
- Main tradeoff is maintaining plan-state accuracy over time; stale progress notes could drift if follow-up work changes scope.

## Follow-up

- Align the PR state in mcp-writing-vscode for the already-implemented existing-config UX slice (branch: chore/client-agnostic-followup).
