### PR TITLE
Improve beta prose flow and centered scene dateline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules/
 sync/
 txt/
 my-project-sync/
+tmp/

--- a/src/review-bundles/review-bundles-renderer.js
+++ b/src/review-bundles/review-bundles-renderer.js
@@ -233,6 +233,122 @@ function readProse(filePath, { syncDir } = {}) {
   }
 }
 
+function normalizeHardWrappedProse(rawProse) {
+  const prose = String(rawProse ?? "").replace(/\r\n?/g, "\n").trim();
+  if (!prose) return "";
+  const paragraphs = prose
+    .split(/\n\s*\n/g)
+    .map(paragraph => paragraph.replace(/\s*\n\s*/g, " ").trim())
+    .filter(Boolean);
+  return paragraphs.join("\n\n");
+}
+
+function extractSceneDateline(prose) {
+  const normalized = String(prose ?? "").replace(/\r\n?/g, "\n").trim();
+  if (!normalized) {
+    return { dateline: null, body: "" };
+  }
+
+  const lines = normalized
+    .split("\n")
+    .map(line => line.trim())
+    .filter(Boolean);
+  if (lines.length === 0) {
+    return { dateline: null, body: "" };
+  }
+
+  const firstParagraph = lines[0];
+  const dashMatch = firstParagraph.match(/^(.+?)\s*[–-]\s*(.+)$/);
+  const left = dashMatch?.[1]?.trim() ?? "";
+  const right = dashMatch?.[2]?.trim() ?? "";
+  const totalWords = firstParagraph.split(/\s+/).filter(Boolean).length;
+  const looksLikeDateline = (
+    firstParagraph.length >= 6
+    && firstParagraph.length <= 90
+    && Boolean(dashMatch)
+    && left.length >= 2
+    && right.length >= 2
+    && totalWords <= 14
+    && !/[!?]/.test(firstParagraph)
+    && !/[“”"']/.test(firstParagraph)
+  );
+
+  if (!looksLikeDateline) {
+    return { dateline: null, body: normalized };
+  }
+
+  return {
+    dateline: firstParagraph,
+    body: lines.slice(1).join("\n"),
+  };
+}
+
+function normalizeBetaProseFlow(prose) {
+  const normalized = String(prose ?? "").replace(/\r\n?/g, "\n").trim();
+  if (!normalized) return "";
+  const paragraphs = normalized
+    .split(/\n\s*\n/g)
+    .map(paragraph => paragraph
+      .split("\n")
+      .map(line => line.trim())
+      .filter(Boolean)
+      .join("\n"))
+    .filter(Boolean);
+  // For beta exports, convert paragraph blocks into regular line breaks so the
+  // reading flow stays continuous without large section gaps.
+  return paragraphs.join("\n");
+}
+
+function normalizeBetaTypography(prose) {
+  return String(prose ?? "")
+    .replace(/(^|\s)--(\s|$)/g, "$1—$2");
+}
+
+function renderProseWithInlineEmphasis(doc, prose, {
+  bodyFont,
+  italicFont,
+  fontSize,
+  width,
+  align = "left",
+  lineGap = 0,
+  paragraphGap = 0,
+  blankLineMoveDown = 0.15,
+}) {
+  const lines = String(prose ?? "").split("\n");
+  for (const line of lines) {
+    if (line.length === 0) {
+      doc.moveDown(blankLineMoveDown);
+      continue;
+    }
+
+    if (line.trim() === "***") {
+      doc.moveDown(0.5);
+      doc.fontSize(fontSize).font(bodyFont);
+      doc.text("***", { align: "center", width, lineGap, paragraphGap: 0 });
+      doc.moveDown(0.5);
+      continue;
+    }
+
+    const segments = line.split(/(\*[^*\n]+\*)/g).filter(Boolean);
+
+    for (let index = 0; index < segments.length; index += 1) {
+      const segment = segments[index];
+      const isItalic = /^\*[^*\n]+\*$/.test(segment);
+      const text = isItalic ? segment.slice(1, -1) : segment;
+      if (!text) continue;
+      doc.fontSize(fontSize).font(isItalic ? italicFont : bodyFont);
+      doc.text(text, {
+        align,
+        width,
+        lineGap,
+        paragraphGap,
+        continued: index < segments.length - 1,
+      });
+    }
+  }
+  doc.font(bodyFont).fontSize(fontSize);
+}
+
 function renderSceneBlock(scene, options) {
   const {
     profile,
@@ -278,11 +394,11 @@ function renderSceneBlock(scene, options) {
 
   const prose = scene.prose ?? "";
   if (!includeParagraphAnchors || prose.length === 0) {
-    parts.push(prose);
+    parts.push(normalizeHardWrappedProse(prose));
     return parts.join("\n\n");
   }
 
-  const paragraphs = prose
+  const paragraphs = normalizeHardWrappedProse(prose)
     .split(/\n\s*\n/g)
     .map(p => p.trim())
     .filter(Boolean);
@@ -433,12 +549,13 @@ export function renderReviewBundlePdfWithMetadata(dbHandle, plan, { generatedAt,
   const syncDir = syncDirOpt ?? process.env.WRITING_SYNC_DIR ?? null;
   const isBetaProfile = profile === "beta_reader_personalized";
   const proseFontSize = isBetaProfile ? 8 : 10;
-  const proseLineGap = isBetaProfile ? 3.2 : 3;
+  const proseLineGap = isBetaProfile ? 1.6 : 3;
   const bodyFont = profile === "beta_reader_personalized" ? "Times-Roman" : "Helvetica";
   const coverHeadingFont = profile === "beta_reader_personalized" ? "Times-Bold" : "Helvetica-Bold";
   // Beta scene headings intentionally use body font (non-bold) per product direction.
   const sceneHeadingFont = isBetaProfile ? bodyFont : coverHeadingFont;
-  const metaFont = profile === "beta_reader_personalized" ? "Times-Italic" : "Helvetica-Oblique";
+  const italicFont = profile === "beta_reader_personalized" ? "Times-Italic" : "Helvetica-Oblique";
+  const metaFont = italicFont;
 
   const sceneIds = plan.ordering.map(row => row.scene_id);
   const rows = loadBundleSceneRows(dbHandle, plan.resolved_scope.project_id, sceneIds);
@@ -494,7 +611,7 @@ export function renderReviewBundlePdfWithMetadata(dbHandle, plan, { generatedAt,
     doc.restore();
     // Restore prose style so auto-flowed text keeps consistent typography
     // on pages added during long text rendering.
-    doc.font(bodyFont).fontSize(proseFontSize);
+    doc.font(bodyFont).fontSize(proseFontSize).fillColor("#000000");
     doc.x = previousX;
     doc.y = previousY;
   };
@@ -530,8 +647,9 @@ export function renderReviewBundlePdfWithMetadata(dbHandle, plan, { generatedAt,
 
     try {
       doc.addPage();
-      doc.fontSize(24).font(coverHeadingFont).text(`Review Bundle: ${plan.resolved_scope.project_id}`, { align: "left" });
-      doc.moveDown(0.5);
+      const coverLabel = `Review Bundle: ${plan.resolved_scope.project_id}`;
+      doc.fontSize(isBetaProfile ? 11 : 24).font(coverHeadingFont).text(coverLabel, { align: "left" });
+      doc.moveDown(isBetaProfile ? 0.2 : 0.5);
       doc.fontSize(11).font(bodyFont);
       if (profile !== "beta_reader_personalized") {
         doc.text(`Profile: ${profile}`, { align: "left" });
@@ -604,14 +722,34 @@ export function renderReviewBundlePdfWithMetadata(dbHandle, plan, { generatedAt,
               }
             );
           }
-          prose = resolved;
+          prose = normalizeHardWrappedProse(resolved);
+          let sceneDateline = null;
+          if (isBetaProfile) {
+            prose = normalizeBetaProseFlow(resolved);
+            const extracted = extractSceneDateline(prose);
+            sceneDateline = extracted.dateline;
+            prose = normalizeBetaTypography(extracted.body);
+          }
+
+          if (sceneDateline) {
+            doc.fontSize(10).font(metaFont);
+            doc.text(sceneDateline, {
+              align: "center",
+              width: doc.page.width - doc.page.margins.left - doc.page.margins.right,
+            });
+            doc.moveDown(1.0);
+          }
 
           const textWidth = doc.page.width - doc.page.margins.left - doc.page.margins.right;
-          doc.fontSize(proseFontSize).font(bodyFont);
-          doc.text(prose, {
+          renderProseWithInlineEmphasis(doc, prose, {
+            bodyFont,
+            italicFont,
+            fontSize: proseFontSize,
             align: "left",
             width: textWidth,
             lineGap: proseLineGap,
+            paragraphGap: 0,
+            blankLineMoveDown: isBetaProfile ? 0.15 : 0.65,
           });
         }
 
@@ -642,4 +780,5 @@ export {
   buildPageFingerprintToken,
   buildFingerprintSeed,
   buildFingerprintSeedHash,
+  extractSceneDateline,
 };

--- a/src/review-bundles/review-bundles-renderer.js
+++ b/src/review-bundles/review-bundles-renderer.js
@@ -722,13 +722,14 @@ export function renderReviewBundlePdfWithMetadata(dbHandle, plan, { generatedAt,
               }
             );
           }
-          prose = normalizeHardWrappedProse(resolved);
           let sceneDateline = null;
           if (isBetaProfile) {
             prose = normalizeBetaProseFlow(resolved);
             const extracted = extractSceneDateline(prose);
-            sceneDateline = extracted.dateline;
+            sceneDateline = extracted.dateline ? normalizeBetaTypography(extracted.dateline) : null;
             prose = normalizeBetaTypography(extracted.body);
+          } else {
+            prose = normalizeHardWrappedProse(resolved);
           }
 
           if (sceneDateline) {

--- a/src/review-bundles/review-bundles.js
+++ b/src/review-bundles/review-bundles.js
@@ -13,6 +13,7 @@ export {
   buildPageFingerprintToken,
   buildFingerprintSeed,
   buildFingerprintSeedHash,
+  extractSceneDateline,
 } from "./review-bundles-renderer.js";
 
 export { createReviewBundleArtifacts } from "./review-bundles-writer.js";

--- a/src/test/unit/review-bundles.test.mjs
+++ b/src/test/unit/review-bundles.test.mjs
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import os from "node:os";
 import fs from "node:fs";
 import path from "node:path";
-import { buildReviewBundlePlan, renderReviewBundleMarkdown, ReviewBundlePlanError, buildPageFingerprintToken, buildFingerprintSeed, buildFingerprintSeedHash } from "../../review-bundles/review-bundles.js";
+import { buildReviewBundlePlan, renderReviewBundleMarkdown, ReviewBundlePlanError, buildPageFingerprintToken, buildFingerprintSeed, buildFingerprintSeedHash, extractSceneDateline } from "../../review-bundles/review-bundles.js";
 import { insertTestScene, setupReviewBundleTestDb } from "../helpers/db.js";
 
 describe("buildReviewBundlePlan", () => {
@@ -421,9 +421,68 @@ describe("buildReviewBundlePlan", () => {
         project_id: "test-novel",
         profile: "outline_discussion",
       });
-      const markdown = renderReviewBundleMarkdown(db, plan, { generatedAt: "2026-01-01T00:00:00.000Z" });
+      const markdown = renderReviewBundleMarkdown(db, plan, {
+        generatedAt: "2026-01-01T00:00:00.000Z",
+        syncDir: fs.realpathSync.native(tempDir),
+      });
 
       assert.ok(markdown.includes("A \\*bold\\* \\[link\\] \\`code\\` logline"));
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+      db.close();
+    }
+  });
+
+  test("renderReviewBundleMarkdown normalizes hard-wrapped prose lines into paragraph flow", () => {
+    const db = setupReviewBundleTestDb();
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "bundle-hard-wrap-"));
+    const scenePath = path.join(tempDir, "sc-001.md");
+    fs.writeFileSync(
+      scenePath,
+      [
+        "Sebastian walks into the kitchen in the early morning, humming a tune, with Mneme flying in",
+        "behind him and landing on the kitchen counter.",
+        "",
+        "Edda glances up as he approaches, sipping her morning coffee and scrolling through the news on",
+        "her tablet.",
+      ].join("\n"),
+      "utf8"
+    );
+
+    try {
+      const now = new Date().toISOString();
+      db.prepare(`
+        INSERT INTO scenes (
+          scene_id, project_id, title, part, chapter, timeline_position, word_count,
+          file_path, prose_checksum, metadata_stale, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        "sc-001",
+        "test-novel",
+        "Hard Wrap Test",
+        1,
+        1,
+        1,
+        10,
+        scenePath,
+        "deadbeef",
+        0,
+        now
+      );
+
+      const plan = buildReviewBundlePlan(db, {
+        project_id: "test-novel",
+        profile: "editor_detailed",
+      });
+      const markdown = renderReviewBundleMarkdown(db, plan, {
+        generatedAt: "2026-01-01T00:00:00.000Z",
+        syncDir: fs.realpathSync.native(tempDir),
+      });
+
+      assert.ok(markdown.includes("with Mneme flying in behind him and landing on the kitchen counter."));
+      assert.ok(markdown.includes("through the news on her tablet."));
+      assert.ok(!markdown.includes("with Mneme flying in\nbehind him"));
+      assert.ok(!markdown.includes("news on\nher tablet"));
     } finally {
       fs.rmSync(tempDir, { recursive: true, force: true });
       db.close();
@@ -571,6 +630,28 @@ describe("review-bundle fingerprint helpers", () => {
 
     assert.equal(token1a, token1b);
     assert.notEqual(token1a, token2);
+  });
+});
+
+describe("review-bundle dateline helpers", () => {
+  test("extractSceneDateline recognizes place-time lines with punctuation", () => {
+    const prose = [
+      "St. Louis – 6:30 a.m.",
+      "The envelope had been slipped under the door.",
+    ].join("\n");
+    const extracted = extractSceneDateline(prose);
+    assert.equal(extracted.dateline, "St. Louis – 6:30 a.m.");
+    assert.equal(extracted.body, "The envelope had been slipped under the door.");
+  });
+
+  test("extractSceneDateline ignores normal sentence openings", () => {
+    const prose = [
+      "The envelope had been slipped under the door.",
+      "She kept staring at it.",
+    ].join("\n");
+    const extracted = extractSceneDateline(prose);
+    assert.equal(extracted.dateline, null);
+    assert.equal(extracted.body, prose);
   });
 });
 


### PR DESCRIPTION
## Summary
- Improve beta-reader PDF prose formatting fidelity to source writing conventions.
- Add clearer in-scene transition rendering for manuscript-style section breaks.
- Keep renderer behavior metadata-driven (no filename-based title rewriting fallback).

## Motivation
Beta-reader exports still showed formatting mismatches versus expected manuscript output: emphasis markers were literal, sentence/line break flow could look like paragraph chunking, and in-scene separators were not visually treated as transitions. This made review packets feel less book-like and harder to evaluate.

## Implementation
- Updated beta prose flow normalization in the PDF renderer to preserve intended line-level flow while avoiding oversized paragraph spacing artifacts.
- Added PDF-only beta dateline extraction/centering under scene headings when the first line matches place/time style formatting.
- Added inline emphasis rendering for `*...*` spans so emphasized prose is rendered in italic (without literal asterisks).
- Added beta typography normalization for spaced double-hyphen usage (` -- ` -> ` — `).
- Added centered transition rendering for `***` with surrounding whitespace.
- Removed renderer-side scene-title cleanup fallback so scene titles remain metadata/index driven.
- Added/updated tests for prose normalization and dateline extraction behavior; validated no regressions in review-bundle suites.

## Testing
- `node --test src/test/unit/review-bundles.test.mjs src/test/integration/review-bundles.test.mjs`
- Manual test of generated beta PDFs from fixture and real-prose sample scenes.

## Risks and tradeoffs
- Inline emphasis currently targets single-asterisk spans and avoids aggressive markdown parsing to reduce false positives; more complex markdown emphasis patterns are intentionally out of scope for this patch.
- Typography normalization for ` -- ` is intentionally scoped to beta prose output and may need further editorial tuning if additional punctuation conventions are desired.
- Dateline extraction/centering is currently PDF-only for beta output and not yet mirrored in markdown rendering.

## Follow-up
None