### PR TITLE
fix(review-bundles): keep epigraph prose without epigraph titles in beta exports

### DIFF
--- a/src/review-bundles/review-bundles-renderer.js
+++ b/src/review-bundles/review-bundles-renderer.js
@@ -86,7 +86,6 @@ function loadBundleSceneRowsWithTags(dbHandle, projectId, sceneIds) {
     rows.push(...chunkRows);
   }
 
-  const rowMap = new Map(rows.map(row => [row.scene_id, row]));
   const orderedRows = [];
   const missingSceneIds = [];
 

--- a/src/review-bundles/review-bundles-renderer.js
+++ b/src/review-bundles/review-bundles-renderer.js
@@ -57,7 +57,7 @@ function renderBetaFeedbackFormMarkdown({ projectId, recipientName, generatedAt 
   ].join("\n") + "\n";
 }
 
-function loadBundleSceneRows(dbHandle, projectId, sceneIds) {
+function loadBundleSceneRowsWithTags(dbHandle, projectId, sceneIds) {
   if (!Array.isArray(sceneIds) || sceneIds.length === 0) return [];
   const rows = [];
   // 900 is safely below SQLite's per-query bound of 999 host parameters
@@ -74,6 +74,7 @@ function loadBundleSceneRows(dbHandle, projectId, sceneIds) {
         title,
         part,
         chapter,
+        chapter_title,
         timeline_position,
         logline,
         pov,
@@ -89,8 +90,16 @@ function loadBundleSceneRows(dbHandle, projectId, sceneIds) {
   const orderedRows = [];
   const missingSceneIds = [];
 
+  // Load tags for all scenes
+  const tagStmt = dbHandle.prepare(`SELECT tag FROM scene_tags WHERE scene_id = ? AND project_id = ?`);
+  const rowsWithTags = rows.map(row => ({
+    ...row,
+    tags: tagStmt.all(row.scene_id, projectId).map(t => t.tag),
+  }));
+  const rowMapWithTags = new Map(rowsWithTags.map(row => [row.scene_id, row]));
+
   for (const sceneId of sceneIds) {
-    const row = rowMap.get(sceneId);
+    const row = rowMapWithTags.get(sceneId);
     if (row) {
       orderedRows.push(row);
     } else {
@@ -357,12 +366,28 @@ function renderSceneBlock(scene, options) {
     includeParagraphAnchors,
   } = options;
 
-  const title = scene.title || scene.scene_id;
-  const sceneHeading = includeSceneIds
-    ? `## ${escapeMarkdown(title)} (${escapeMarkdown(scene.scene_id)})`
-    : `## ${escapeMarkdown(title)}`;
+  const isBetaProfile = profile === "beta_reader_personalized";
+  const isEpigraph = isBetaProfile && scene.tags?.includes("epigraph");
 
-  const parts = [sceneHeading];
+  const parts = [];
+
+  // Add chapter heading for beta profile on first scene of a new chapter
+  if (isBetaProfile && scene.chapter_title) {
+    // Note: Since renderSceneBlock is called per scene in a loop, we can't easily detect
+    // "first scene in chapter" here. This would be better handled at the caller level.
+    // For now, we'll add the chapter title but it may appear on every scene in the chapter.
+    // TODO: Pass chapter change detection from renderReviewBundleMarkdown.
+    parts.push(`# ${escapeMarkdown(scene.chapter_title)}`);
+  }
+
+  // Only render heading if not an epigraph
+  if (!isEpigraph) {
+    const title = scene.title || scene.scene_id;
+    const sceneHeading = includeSceneIds
+      ? `## ${escapeMarkdown(title)} (${escapeMarkdown(scene.scene_id)})`
+      : `## ${escapeMarkdown(title)}`;
+    parts.push(sceneHeading);
+  }
 
   if (profile === "outline_discussion") {
     const summaryParts = [];
@@ -478,7 +503,7 @@ export function renderReviewBundleMarkdown(dbHandle, plan, { generatedAt, syncDi
   const syncDir = syncDirOpt ?? process.env.WRITING_SYNC_DIR ?? null;
 
   const sceneIds = plan.ordering.map(row => row.scene_id);
-  const rows = loadBundleSceneRows(dbHandle, plan.resolved_scope.project_id, sceneIds);
+  const rows = loadBundleSceneRowsWithTags(dbHandle, plan.resolved_scope.project_id, sceneIds);
   const sections = [];
   const recipientName = plan.resolved_scope?.options?.recipient_name;
   const recipientDisplayName = normalizeRecipientDisplayName(recipientName);
@@ -558,7 +583,7 @@ export function renderReviewBundlePdfWithMetadata(dbHandle, plan, { generatedAt,
   const metaFont = italicFont;
 
   const sceneIds = plan.ordering.map(row => row.scene_id);
-  const rows = loadBundleSceneRows(dbHandle, plan.resolved_scope.project_id, sceneIds);
+  const rows = loadBundleSceneRowsWithTags(dbHandle, plan.resolved_scope.project_id, sceneIds);
   const recipientName = plan.resolved_scope?.options?.recipient_name;
   const recipientDisplayName = normalizeRecipientDisplayName(recipientName);
   const footerRecipientDisplayName = sanitizeFooterRecipientDisplayName(recipientDisplayName);
@@ -680,13 +705,38 @@ export function renderReviewBundlePdfWithMetadata(dbHandle, plan, { generatedAt,
           // print-like opening feel before prose begins.
           doc.moveDown(2.0);
         }
-        doc.fontSize(isBetaProfile ? 13 : 14).font(sceneHeadingFont);
-        let heading = scene.title || scene.scene_id;
-        if (includeSceneIds) {
-          heading += ` [${scene.scene_id}]`;
+        // Render chapter header if this is the first scene in a new chapter (and chapter_title exists)
+        if (isBetaProfile && scene.chapter_title && (scene !== rows[0] || scene.chapter !== rows[0]?.chapter)) {
+          const prevScene = rows[rows.indexOf(scene) - 1];
+          if (!prevScene || prevScene.chapter !== scene.chapter) {
+            doc.fontSize(16).font(coverHeadingFont);
+            doc.text(scene.chapter_title, { align: "center" });
+            doc.moveDown(1.0);
+          }
         }
-        doc.text(heading, { align: isBetaProfile ? "center" : "left" });
-        doc.moveDown(isBetaProfile ? 1.6 : 0.2);
+
+        // Render chapter header if this is the first scene in a new chapter (and chapter_title exists in beta profile)
+        if (isBetaProfile && scene.chapter_title) {
+          const sceneIndex = rows.indexOf(scene);
+          const prevScene = sceneIndex > 0 ? rows[sceneIndex - 1] : null;
+          if (!prevScene || prevScene.chapter !== scene.chapter) {
+            doc.fontSize(16).font(coverHeadingFont);
+            doc.text(scene.chapter_title, { align: "center" });
+            doc.moveDown(1.0);
+          }
+        }
+
+        // Skip title rendering for epigraphs in beta profile
+        const isEpigraph = isBetaProfile && scene.tags?.includes("epigraph");
+        if (!isEpigraph) {
+          doc.fontSize(isBetaProfile ? 13 : 14).font(sceneHeadingFont);
+          let heading = scene.title || scene.scene_id;
+          if (includeSceneIds) {
+            heading += ` [${scene.scene_id}]`;
+          }
+          doc.text(heading, { align: isBetaProfile ? "center" : "left" });
+          doc.moveDown(isBetaProfile ? 1.6 : 0.2);
+        }
 
         const metaParts = [];
         if (profile !== "beta_reader_personalized") {

--- a/src/review-bundles/review-bundles-renderer.js
+++ b/src/review-bundles/review-bundles-renderer.js
@@ -89,11 +89,28 @@ function loadBundleSceneRowsWithTags(dbHandle, projectId, sceneIds) {
   const orderedRows = [];
   const missingSceneIds = [];
 
-  // Load tags for all scenes
-  const tagStmt = dbHandle.prepare(`SELECT tag FROM scene_tags WHERE scene_id = ? AND project_id = ?`);
+  // Load tags in batches to avoid N+1 queries for large bundles.
+  const tagsBySceneId = new Map(rows.map(row => [row.scene_id, []]));
+  const tagChunkSize = 900;
+  for (let offset = 0; offset < rows.length; offset += tagChunkSize) {
+    const chunk = rows.slice(offset, offset + tagChunkSize);
+    const chunkSceneIds = chunk.map(row => row.scene_id);
+    if (chunkSceneIds.length === 0) continue;
+    const placeholders = chunkSceneIds.map(() => "?").join(",");
+    const tagRows = dbHandle.prepare(`
+      SELECT scene_id, tag
+      FROM scene_tags
+      WHERE project_id = ? AND scene_id IN (${placeholders})
+    `).all(projectId, ...chunkSceneIds);
+    for (const tagRow of tagRows) {
+      const tags = tagsBySceneId.get(tagRow.scene_id);
+      if (tags) tags.push(tagRow.tag);
+    }
+  }
+
   const rowsWithTags = rows.map(row => ({
     ...row,
-    tags: tagStmt.all(row.scene_id, projectId).map(t => t.tag),
+    tags: tagsBySceneId.get(row.scene_id) ?? [],
   }));
   const rowMapWithTags = new Map(rowsWithTags.map(row => [row.scene_id, row]));
 
@@ -363,6 +380,7 @@ function renderSceneBlock(scene, options) {
     includeSceneIds,
     includeMetadataSidebar,
     includeParagraphAnchors,
+    showChapterHeading,
   } = options;
 
   const isBetaProfile = profile === "beta_reader_personalized";
@@ -370,12 +388,8 @@ function renderSceneBlock(scene, options) {
 
   const parts = [];
 
-  // Add chapter heading for beta profile on first scene of a new chapter
-  if (isBetaProfile && scene.chapter_title) {
-    // Note: Since renderSceneBlock is called per scene in a loop, we can't easily detect
-    // "first scene in chapter" here. This would be better handled at the caller level.
-    // For now, we'll add the chapter title but it may appear on every scene in the chapter.
-    // TODO: Pass chapter change detection from renderReviewBundleMarkdown.
+  // Render chapter heading only when the caller detects a chapter transition.
+  if (isBetaProfile && scene.chapter_title && showChapterHeading) {
     parts.push(`# ${escapeMarkdown(scene.chapter_title)}`);
   }
 
@@ -531,7 +545,8 @@ export function renderReviewBundleMarkdown(dbHandle, plan, { generatedAt, syncDi
     );
   }
 
-  for (const scene of rows) {
+  for (let sceneIndex = 0; sceneIndex < rows.length; sceneIndex += 1) {
+    const scene = rows[sceneIndex];
     let prose = "";
     if (profile === "editor_detailed" || profile === "beta_reader_personalized") {
       const resolved = readProse(scene.file_path, { syncDir });
@@ -549,11 +564,16 @@ export function renderReviewBundleMarkdown(dbHandle, plan, { generatedAt, syncDi
       prose = resolved;
     }
     const withProse = { ...scene, prose };
+    const prevScene = sceneIndex > 0 ? rows[sceneIndex - 1] : null;
+    const showChapterHeading = isBetaProfile
+      && Boolean(scene.chapter_title)
+      && (!prevScene || prevScene.chapter !== scene.chapter);
     sections.push(renderSceneBlock(withProse, {
       profile,
       includeSceneIds,
       includeMetadataSidebar,
       includeParagraphAnchors,
+      showChapterHeading,
     }));
   }
 
@@ -698,31 +718,18 @@ export function renderReviewBundlePdfWithMetadata(dbHandle, plan, { generatedAt,
         doc.moveDown();
       }
 
-      for (const scene of rows) {
+      for (let sceneIndex = 0; sceneIndex < rows.length; sceneIndex += 1) {
+        const scene = rows[sceneIndex];
+        const prevScene = sceneIndex > 0 ? rows[sceneIndex - 1] : null;
         if (isBetaProfile) {
           // Give chapter titles generous vertical breathing room for a
           // print-like opening feel before prose begins.
           doc.moveDown(2.0);
         }
-        // Render chapter header if this is the first scene in a new chapter (and chapter_title exists)
-        if (isBetaProfile && scene.chapter_title && (scene !== rows[0] || scene.chapter !== rows[0]?.chapter)) {
-          const prevScene = rows[rows.indexOf(scene) - 1];
-          if (!prevScene || prevScene.chapter !== scene.chapter) {
-            doc.fontSize(16).font(coverHeadingFont);
-            doc.text(scene.chapter_title, { align: "center" });
-            doc.moveDown(1.0);
-          }
-        }
-
-        // Render chapter header if this is the first scene in a new chapter (and chapter_title exists in beta profile)
-        if (isBetaProfile && scene.chapter_title) {
-          const sceneIndex = rows.indexOf(scene);
-          const prevScene = sceneIndex > 0 ? rows[sceneIndex - 1] : null;
-          if (!prevScene || prevScene.chapter !== scene.chapter) {
-            doc.fontSize(16).font(coverHeadingFont);
-            doc.text(scene.chapter_title, { align: "center" });
-            doc.moveDown(1.0);
-          }
+        if (isBetaProfile && scene.chapter_title && (!prevScene || prevScene.chapter !== scene.chapter)) {
+          doc.fontSize(16).font(coverHeadingFont);
+          doc.text(scene.chapter_title, { align: "center" });
+          doc.moveDown(1.0);
         }
 
         // Skip title rendering for epigraphs in beta profile
@@ -807,7 +814,7 @@ export function renderReviewBundlePdfWithMetadata(dbHandle, plan, { generatedAt,
         // Add page break between scenes only for prose-including profiles where
         // clear scene separation matters. For outline_discussion, let content flow.
         const includesProse = profile === "editor_detailed" || profile === "beta_reader_personalized";
-        if (includesProse && scene !== rows[rows.length - 1]) {
+        if (includesProse && sceneIndex < rows.length - 1) {
           doc.addPage();
         }
       }

--- a/src/review-bundles/review-bundles-renderer.js
+++ b/src/review-bundles/review-bundles-renderer.js
@@ -390,7 +390,7 @@ function renderSceneBlock(scene, options) {
 
   // Render chapter heading only when the caller detects a chapter transition.
   if (isBetaProfile && scene.chapter_title && showChapterHeading) {
-    parts.push(`# ${escapeMarkdown(scene.chapter_title)}`);
+    parts.push(`## ${escapeMarkdown(scene.chapter_title)}`);
   }
 
   // Only render heading if not an epigraph

--- a/src/sync/importer.js
+++ b/src/sync/importer.js
@@ -370,6 +370,10 @@ export function importScrivenerSync({
     const destFile = path.join(targetDir, `${seq.toString().padStart(3, "0")} ${rawTitle} [${binderId}].${ext}`);
     const sidecar = destFile.replace(/\.(txt|md)$/, ".meta.yaml");
 
+    const existingTags = Array.isArray(existingScene?.meta?.tags)
+      ? existingScene.meta.tags
+      : [];
+
     const meta = {
       ...(existingScene?.meta ?? {}),
       scene_id: sceneId,
@@ -378,7 +382,7 @@ export function importScrivenerSync({
       title,
       timeline_position: seq,
       ...(beatCarry ? { save_the_cat_beat: beatCarry } : {}),
-      ...(isEpigraphScene ? { tags: [...(existingScene?.meta?.tags ?? []), "epigraph"].filter((v, i, a) => a.indexOf(v) === i) } : {}),
+      ...(isEpigraphScene ? { tags: [...existingTags, "epigraph"].filter((v, i, a) => a.indexOf(v) === i) } : {}),
     };
 
     if (!beatCarry && existingScene?.meta && Object.hasOwn(existingScene.meta, "save_the_cat_beat")) {

--- a/src/sync/importer.js
+++ b/src/sync/importer.js
@@ -358,12 +358,7 @@ export function importScrivenerSync({
       continue;
     }
 
-    if (isEpigraph(rawTitle)) {
-      logger(`  SKIP  (epigraph) ${filename}`);
-      skipped++;
-      continue;
-    }
-
+    const isEpigraphScene = isEpigraph(rawTitle);
     const title = cleanTitle(rawTitle);
     const existingScene = existingScenes.get(String(binderId)) ?? null;
     const sceneId = existingScene?.meta?.scene_id ?? makeSceneId(binderId, title);
@@ -383,6 +378,7 @@ export function importScrivenerSync({
       title,
       timeline_position: seq,
       ...(beatCarry ? { save_the_cat_beat: beatCarry } : {}),
+      ...(isEpigraphScene ? { tags: [...(existingScene?.meta?.tags ?? []), "epigraph"].filter((v, i, a) => a.indexOf(v) === i) } : {}),
     };
 
     if (!beatCarry && existingScene?.meta && Object.hasOwn(existingScene.meta, "save_the_cat_beat")) {
@@ -424,7 +420,7 @@ export function importScrivenerSync({
   logger("");
   logger(`${"-".repeat(50)}`);
   logger(`Created:  ${created} sidecars${dryRun ? " (dry run)" : ""}`);
-  logger(`Skipped:  ${skipped} (empty / epigraph / pattern)`);
+  logger(`Skipped:  ${skipped} (empty / pattern)`);
   if (existing) logger(`Existing: ${existing} already had sidecars`);
   logger(`Beat markers seen: ${beatMarkersSeen}`);
 

--- a/src/test/integration/sync.test.mjs
+++ b/src/test/integration/sync.test.mjs
@@ -65,9 +65,9 @@ describe("import_scrivener_sync tool", () => {
     assert.equal(parsed.ok, true);
     assert.equal(parsed.import.project_id, projectId);
     assert.equal(parsed.import.dry_run, true);
-    assert.equal(parsed.import.created, 2);
+    assert.equal(parsed.import.created, 3);
     assert.equal(parsed.import.existing, 0);
-    assert.equal(parsed.import.skipped, 3);
+    assert.equal(parsed.import.skipped, 2);
     assert.equal(parsed.import.beat_markers_seen, 1);
     assert.equal(parsed.sync, null);
     assert.equal(fs.existsSync(scenesDir), false);
@@ -88,16 +88,16 @@ describe("import_scrivener_sync tool", () => {
     assert.equal(parsed.ok, true);
     assert.equal(parsed.import.project_id, projectId);
     assert.equal(parsed.import.dry_run, false);
-    assert.equal(parsed.import.created, 2);
+    assert.equal(parsed.import.created, 3);
     assert.equal(parsed.import.existing, 0);
-    assert.equal(parsed.import.skipped, 3);
+    assert.equal(parsed.import.skipped, 2);
     assert.equal(parsed.import.beat_markers_seen, 1);
     assert.equal(parsed.sync, null);
 
     assert.equal(fs.existsSync(scenesDir), true);
     const files = fs.readdirSync(scenesDir);
     const sidecars = files.filter(name => name.endsWith(".meta.yaml"));
-    assert.equal(sidecars.length, 2);
+    assert.equal(sidecars.length, 3);
     assert.ok(sidecars.some(name => name.includes("001 Scene Arrival [10].meta.yaml")));
     assert.ok(sidecars.some(name => name.includes("004 Scene Debate [13].meta.yaml")));
   });
@@ -143,7 +143,7 @@ describe("import_scrivener_sync tool", () => {
     assert.equal(parsed.import.scenes_dir, expectedScenesDir);
     assert.equal(fs.existsSync(expectedScenesDir), true);
     const sidecars = fs.readdirSync(expectedScenesDir).filter(n => n.endsWith(".meta.yaml"));
-    assert.equal(sidecars.length, 2);
+    assert.equal(sidecars.length, 3);
   });
 });
 
@@ -178,7 +178,7 @@ describe("merge_scrivener_project_beta tool", () => {
     assert.equal(done.job.result.beta, undefined);
     assert.equal(done.job.result.merge.project_id, projectId);
     assert.equal(done.job.result.merge.dry_run, true);
-    assert.equal(done.job.result.merge.sidecar_files, 2);
+    assert.equal(done.job.result.merge.sidecar_files, 3);
     assert.equal(done.job.result.merge.updated, 2);
     assert.ok(done.job.result.merge.field_add_counts.synopsis >= 1);
     assert.ok(Array.isArray(done.job.result.merge.preview_changes));
@@ -246,9 +246,10 @@ describe("merge_scrivener_project_beta tool", () => {
     assert.equal(done.job.status, "completed");
     assert.equal(done.job.result.ok, true);
     assert.equal(done.job.result.merge.warning_summary.missing_bracket_id.count, 1);
-    assert.equal(done.job.result.merge.warning_summary.missing_uuid_mapping.count, 1);
+    assert.equal(done.job.result.merge.warning_summary.missing_uuid_mapping.count, 2);
     assert.ok(done.job.result.merge.warnings.some(w => w.code === "missing_bracket_id"));
     assert.ok(done.job.result.merge.warnings.some(w => w.code === "missing_uuid_mapping" && w.sync_number === "999"));
+    assert.ok(done.job.result.merge.warnings.some(w => w.code === "missing_uuid_mapping" && w.sync_number === "12"));
   });
 
   test("returns ambiguity warning taxonomy for conflicting sidecar mappings", async () => {
@@ -321,7 +322,7 @@ describe("merge_scrivener_project_beta tool", () => {
     const done = await waitForAsyncJob(started.job.job_id);
     assert.equal(done.ok, true);
     assert.equal(done.job.result.merge.scenes_dir, derivedScenesDir);
-    assert.equal(done.job.result.merge.sidecar_files, 2);
+    assert.equal(done.job.result.merge.sidecar_files, 3);
     assert.equal(done.job.result.merge.updated, 2);
   });
 
@@ -348,7 +349,7 @@ describe("merge_scrivener_project_beta tool", () => {
     const done = await waitForAsyncJob(started.job.job_id);
     assert.equal(done.ok, true);
     assert.equal(done.job.result.merge.scenes_dir, actualScenesDir);
-    assert.equal(done.job.result.merge.sidecar_files, 2);
+    assert.equal(done.job.result.merge.sidecar_files, 3);
   });
 
   test("idempotent: second merge run finds no updates", async () => {
@@ -385,7 +386,8 @@ describe("merge_scrivener_project_beta tool", () => {
 
     assert.equal(secondDone.ok, true);
     assert.equal(secondDone.job.result.merge.updated, 0);
-    assert.equal(secondDone.job.result.merge.unchanged, secondDone.job.result.merge.sidecar_files);
+    const unmappedCount = secondDone.job.result.merge.warning_summary?.missing_uuid_mapping?.count ?? 0;
+    assert.equal(secondDone.job.result.merge.unchanged + unmappedCount, secondDone.job.result.merge.sidecar_files);
     assert.deepEqual(secondDone.job.result.merge.field_add_counts, {});
     assert.deepEqual(secondDone.job.result.merge.preview_changes, []);
   });
@@ -429,8 +431,9 @@ describe("merge_scrivener_project_beta tool", () => {
     const scenesText = await callWriteTool("find_scenes", { project_id: projectId });
     const scenes = JSON.parse(scenesText);
     assert.ok(Array.isArray(scenes.results));
-    assert.equal(scenes.results[0].chapter, 1);
-    assert.equal(scenes.results[0].chapter_title, "Arrival");
+    const chapterOneScene = scenes.results.find(scene => scene.chapter === 1);
+    assert.ok(chapterOneScene);
+    assert.equal(chapterOneScene.chapter_title, "Arrival");
   });
 
   test("organize_by_chapters: false keeps scenes in place", async () => {
@@ -470,7 +473,8 @@ describe("merge_scrivener_project_beta tool", () => {
     const scenesText = await callWriteTool("find_scenes", { project_id: projectId });
     const scenes = JSON.parse(scenesText);
     assert.ok(Array.isArray(scenes.results));
-    assert.equal(scenes.results[0].chapter, 1);
+    const chapterOneScene = scenes.results.find(scene => scene.chapter === 1);
+    assert.ok(chapterOneScene);
   });
 });
 
@@ -495,7 +499,7 @@ describe("async import/merge job tools", () => {
     assert.equal(done.job.status, "completed");
     assert.equal(done.job.result.ok, true);
     assert.equal(done.job.result.import.project_id, projectId);
-    assert.equal(done.job.result.import.created, 2);
+    assert.equal(done.job.result.import.created, 3);
   });
 
   test("cancel_async_job sets transitional 'cancelling' status and resolves to terminal state", async () => {


### PR DESCRIPTION
## Summary
- index epigraph scenes during Scrivener import instead of skipping them
- tag imported epigraph scenes with `epigraph`
- keep epigraph prose in beta reader exports while suppressing epigraph scene titles
- include `chapter_title` in review-bundle scene loading

## Motivation
Beta exports should keep epigraph content but not expose epigraph file/scene titles. Chapter names should render when metadata provides them.

## Implementation
- importer now creates sidecars for epigraph inputs and marks them with tag `epigraph`
- beta renderer loads scene tags and suppresses heading/title output for epigraph-tagged scenes while preserving prose
- beta rendering uses chapter metadata (`chapter_title`) for chapter header rendering
- integration tests were updated where import/merge counts changed due to epigraph indexing

## Testing
- `npm run lint`
- `node --test src/test/integration/sync.test.mjs`
- `node --test src/test/unit/review-bundles.test.mjs src/test/integration/review-bundles.test.mjs`

## Risks and tradeoffs
- indexing epigraphs changes historical import/merge counts in tests and tooling output
- merge workflows may count sidecars differently from updated sidecars when epigraph sidecars are intentionally unmapped
- chapter headers depend on existing metadata population; projects without `chapter_title` remain unchanged

## Follow-up
- evaluate whether epigraph tagging should be applied to legacy imported scenes during sync/enrich migration
- decide whether merge result payload should expose a separate `unmapped` counter for clearer accounting
