### PR TITLE
fix: suppress epigraph titles and refine review replies

### DIFF
--- a/docs/release-log.md
+++ b/docs/release-log.md
@@ -8,6 +8,14 @@ This complements `CHANGELOG.md`:
 
 ## Unreleased
 
+### 2026-05-08 — Suppress epigraph document titles in beta exports
+
+- What changed: Beta review-bundle rendering now suppresses epigraph scene headings more robustly, including cases where epigraph metadata tags are missing/case-variant and the scene title starts with "Epigraph ...".
+- Why it matters: Prevents duplicate or unwanted heading output (for example, "Epigraph Chapter 15") while keeping chapter headings and epigraph prose intact.
+- Who is affected: Authors generating `beta_reader_personalized` review-bundle exports.
+- Action needed: None.
+- PR: TBD
+
 ### 2026-05-08 — Add standardized post-merge cleanup skill and helper
 
 - What changed: Added `skills/post-merge-cleanup/SKILL.md` and `skills/post-merge-cleanup/scripts/post-merge-cleanup.mjs` to run a consistent post-merge workflow (verify merged PR state, sync `main` from `origin/main`, clean local/optional remote branch, and report unresolved review threads).

--- a/docs/release-log.md
+++ b/docs/release-log.md
@@ -14,7 +14,7 @@ This complements `CHANGELOG.md`:
 - Why it matters: Prevents duplicate or unwanted heading output (for example, "Epigraph Chapter 15") while keeping chapter headings and epigraph prose intact.
 - Who is affected: Authors generating `beta_reader_personalized` review-bundle exports.
 - Action needed: None.
-- PR: TBD
+- PR: [#187](https://github.com/hannasdev/mcp-writing/pull/187)
 
 ### 2026-05-08 — Add standardized post-merge cleanup skill and helper
 

--- a/skills/review-comment-resolution/SKILL.md
+++ b/skills/review-comment-resolution/SKILL.md
@@ -44,8 +44,8 @@ After applying fixes:
 3. Push branch updates.
 4. Reply on each addressed thread with a concise resolution note (what changed + validation evidence).
 5. Resolve only threads that are fully addressed.
-5. Re-check unresolved thread count.
-6. Re-check PR checks status.
+6. Re-check unresolved thread count.
+7. Re-check PR checks status.
 
 ## Non-negotiable rules
 

--- a/skills/review-comment-resolution/SKILL.md
+++ b/skills/review-comment-resolution/SKILL.md
@@ -42,13 +42,15 @@ After applying fixes:
 1. Run relevant validation (lint/tests/docs generation as applicable).
 2. Commit with a focused message.
 3. Push branch updates.
-4. Resolve only threads that are fully addressed.
+4. Reply on each addressed thread with a concise resolution note (what changed + validation evidence).
+5. Resolve only threads that are fully addressed.
 5. Re-check unresolved thread count.
 6. Re-check PR checks status.
 
 ## Non-negotiable rules
 
 - Do not resolve a thread before the fix is pushed.
+- Do not resolve a thread without a resolution reply comment unless explicitly requested by the user.
 - Do not resolve threads that are only partially addressed.
 - Do not batch unrelated refactors into review-response commits.
 - Do not blindly apply every reviewer request if it conflicts with product intent.
@@ -81,7 +83,7 @@ Use the bundled helper to run the thread workflow consistently:
 - Behavior: strict (non-zero exit on invalid thread IDs, already-resolved IDs, and failing/pending PR checks)
 - Commands:
    - `list` - show unresolved review threads (or all with `--all`)
-   - `resolve` - resolve specific thread IDs
+   - `resolve` - comment + resolve specific thread IDs (`--no-comment` only when explicitly desired)
    - `status` - print unresolved count and run `gh pr checks`
 
 Examples:
@@ -89,6 +91,7 @@ Examples:
 ```bash
 node skills/review-comment-resolution/scripts/review-comments.mjs list --pr 171
 node skills/review-comment-resolution/scripts/review-comments.mjs resolve --pr 171 --ids PRRT_xxx,PRRT_yyy
+node skills/review-comment-resolution/scripts/review-comments.mjs resolve --pr 171 --ids PRRT_xxx,PRRT_yyy --comment "Addressed in 1234abc. Added regression test."
 node skills/review-comment-resolution/scripts/review-comments.mjs status --pr 171
 ```
 
@@ -114,7 +117,8 @@ query($owner:String!, $name:String!, $pr:Int!, $endCursor:String) {\
    }\
 }' -f owner='hannasdev' -f name='mcp-writing' -F pr=<number>
 
-# 2) Resolve addressed thread IDs
+# 2) Reply and resolve addressed thread IDs
+gh api graphql -f query='mutation($threadId:ID!, $body:String!){addPullRequestReviewThreadReply(input:{pullRequestReviewThreadId:$threadId, body:$body}){comment{id}}}' -f threadId='<thread_id>' -f body='Addressed in <commit>. Validation: <test command>'
 gh api graphql -f query='mutation($id:ID!){resolveReviewThread(input:{threadId:$id}){thread{id isResolved}}}' -f id='<thread_id>'
 
 # 3) Verify unresolved count and check status

--- a/skills/review-comment-resolution/SKILL.md
+++ b/skills/review-comment-resolution/SKILL.md
@@ -42,7 +42,7 @@ After applying fixes:
 1. Run relevant validation (lint/tests/docs generation as applicable).
 2. Commit with a focused message.
 3. Push branch updates.
-4. Reply on each addressed thread with a concise resolution note (what changed + validation evidence).
+4. Reply on each addressed thread with a concise resolution note (what changed + validation evidence), tailored to that thread by default.
 5. Resolve only threads that are fully addressed.
 6. Re-check unresolved thread count.
 7. Re-check PR checks status.
@@ -51,6 +51,7 @@ After applying fixes:
 
 - Do not resolve a thread before the fix is pushed.
 - Do not resolve a thread without a resolution reply comment unless explicitly requested by the user.
+- Do not use one generic reply across unrelated threads; use shared wording only when comments are functionally overlapping.
 - Do not resolve threads that are only partially addressed.
 - Do not batch unrelated refactors into review-response commits.
 - Do not blindly apply every reviewer request if it conflicts with product intent.
@@ -83,7 +84,7 @@ Use the bundled helper to run the thread workflow consistently:
 - Behavior: strict (non-zero exit on invalid thread IDs, already-resolved IDs, and failing/pending PR checks)
 - Commands:
    - `list` - show unresolved review threads (or all with `--all`)
-   - `resolve` - comment + resolve specific thread IDs (`--no-comment` only when explicitly desired)
+   - `resolve` - comment + resolve specific thread IDs (thread-specific by default)
    - `status` - print unresolved count and run `gh pr checks`
 
 Examples:
@@ -92,6 +93,8 @@ Examples:
 node skills/review-comment-resolution/scripts/review-comments.mjs list --pr 171
 node skills/review-comment-resolution/scripts/review-comments.mjs resolve --pr 171 --ids PRRT_xxx,PRRT_yyy
 node skills/review-comment-resolution/scripts/review-comments.mjs resolve --pr 171 --ids PRRT_xxx,PRRT_yyy --comment "Addressed in 1234abc. Added regression test."
+node skills/review-comment-resolution/scripts/review-comments.mjs resolve --pr 171 --ids PRRT_xxx,PRRT_yyy --comment "Shared root cause fixed in 1234abc." --shared-comment
+node skills/review-comment-resolution/scripts/review-comments.mjs resolve --pr 171 --ids PRRT_xxx,PRRT_yyy --comments-file /tmp/thread-comments.json
 node skills/review-comment-resolution/scripts/review-comments.mjs status --pr 171
 ```
 

--- a/skills/review-comment-resolution/SKILL.md
+++ b/skills/review-comment-resolution/SKILL.md
@@ -98,6 +98,15 @@ node skills/review-comment-resolution/scripts/review-comments.mjs resolve --pr 1
 node skills/review-comment-resolution/scripts/review-comments.mjs status --pr 171
 ```
 
+Minimal `--comments-file` example:
+
+```json
+{
+   "PRRT_xxx": "Addressed in 1234abc. What changed: fixed numbering in SKILL.md. Validation: node --experimental-sqlite --test src/test/unit/review-comments-script.test.mjs.",
+   "PRRT_yyy": "Addressed in 1234abc. What changed: added tag-normalization regression test. Validation: node --experimental-sqlite --test src/test/unit/review-bundles.test.mjs."
+}
+```
+
 ## Recommended command sequence (GitHub CLI)
 
 Prefer the helper script above. Use raw commands only as fallback.

--- a/skills/review-comment-resolution/scripts/review-comments.mjs
+++ b/skills/review-comment-resolution/scripts/review-comments.mjs
@@ -11,6 +11,8 @@ function parseArgs(argv) {
     usedIdFlags: false,
     usedAllFlag: false,
     repo: "hannasdev/mcp-writing",
+    comment: null,
+    skipComment: false,
   };
 
   if (argv.length === 0 || argv.includes("-h") || argv.includes("--help")) {
@@ -72,6 +74,22 @@ function parseArgs(argv) {
       const value = readFlagValue("--repo", argv[i + 1]);
       args.repo = value;
       i += 1;
+      continue;
+    }
+
+    if (token === "--comment") {
+      const value = readFlagValue("--comment", argv[i + 1]);
+      const trimmed = String(value).trim();
+      if (trimmed.length === 0) {
+        throw new Error("Provide a non-empty comment with --comment <text>");
+      }
+      args.comment = trimmed;
+      i += 1;
+      continue;
+    }
+
+    if (token === "--no-comment") {
+      args.skipComment = true;
       continue;
     }
 
@@ -230,11 +248,36 @@ function resolveThread(threadId) {
   }
 }
 
-function resolveThreads({ pr, ids, repo }) {
+function replyToThread(threadId, body) {
+  const mutation = "mutation($threadId:ID!, $body:String!){addPullRequestReviewThreadReply(input:{pullRequestReviewThreadId:$threadId, body:$body}){comment{id body}}}";
+  const payload = runGhJson([
+    "api",
+    "graphql",
+    "-f",
+    `query=${mutation}`,
+    "-f",
+    `threadId=${threadId}`,
+    "-f",
+    `body=${body}`,
+  ]);
+  const createdId = payload?.data?.addPullRequestReviewThreadReply?.comment?.id;
+  if (!createdId) {
+    throw new Error(`Failed to add reply comment for thread ${threadId}`);
+  }
+}
+
+function resolveThreads({ pr, ids, repo, comment, skipComment }) {
   ensurePrNumber(pr);
   if (ids.length === 0) {
     throw new Error("Provide at least one thread id using --id or --ids");
   }
+  if (comment && skipComment) {
+    throw new Error("--comment and --no-comment cannot be used together");
+  }
+
+  const replyComment = skipComment
+    ? null
+    : (comment ?? "Addressed in the latest update. Resolving this thread.");
 
   const threads = fetchReviewThreads(pr, repo);
   const threadById = new Map(threads.map((thread) => [thread.id, thread]));
@@ -251,6 +294,10 @@ function resolveThreads({ pr, ids, repo }) {
   }
 
   for (const id of uniqueIds) {
+    if (replyComment) {
+      replyToThread(id, replyComment);
+      console.log(`commented: ${id}`);
+    }
     resolveThread(id);
     console.log(`resolved: ${id}`);
   }
@@ -283,8 +330,8 @@ function printHelp() {
   console.log("");
   console.log("Usage:");
   console.log("  node skills/review-comment-resolution/scripts/review-comments.mjs list --pr <number> [--all] [--repo <owner/name>]");
-  console.log("  node skills/review-comment-resolution/scripts/review-comments.mjs resolve --pr <number> --ids <id1,id2> [--repo <owner/name>]");
-  console.log("  node skills/review-comment-resolution/scripts/review-comments.mjs resolve --pr <number> --id <id1> --id <id2> [--repo <owner/name>]");
+  console.log("  node skills/review-comment-resolution/scripts/review-comments.mjs resolve --pr <number> --ids <id1,id2> [--comment <text>] [--no-comment] [--repo <owner/name>]");
+  console.log("  node skills/review-comment-resolution/scripts/review-comments.mjs resolve --pr <number> --id <id1> --id <id2> [--comment <text>] [--no-comment] [--repo <owner/name>]");
   console.log("  node skills/review-comment-resolution/scripts/review-comments.mjs status --pr <number> [--repo <owner/name>]");
 }
 
@@ -297,8 +344,8 @@ function main() {
   }
 
   if (args.command === "list") {
-    if (args.usedIdFlags) {
-      throw new Error("--id and --ids are not valid for 'list'. Use 'list' to view threads.");
+    if (args.usedIdFlags || args.comment !== null || args.skipComment) {
+      throw new Error("--id, --ids, --comment, and --no-comment are not valid for 'list'. Use 'list' to view threads.");
     }
     printThreads({ pr: args.pr, includeResolved: args.includeResolved, repo: args.repo });
     return;
@@ -311,13 +358,13 @@ function main() {
     if (args.ids.length === 0) {
       throw new Error("'resolve' requires --id <id> or --ids <id1,id2>.");
     }
-    resolveThreads({ pr: args.pr, ids: args.ids, repo: args.repo });
+    resolveThreads({ pr: args.pr, ids: args.ids, repo: args.repo, comment: args.comment, skipComment: args.skipComment });
     return;
   }
 
   if (args.command === "status") {
-    if (args.usedIdFlags || args.usedAllFlag) {
-      throw new Error("--id, --ids, and --all are not valid for 'status'. Use 'status' to view PR review state.");
+    if (args.usedIdFlags || args.usedAllFlag || args.comment !== null || args.skipComment) {
+      throw new Error("--id, --ids, --all, --comment, and --no-comment are not valid for 'status'. Use 'status' to view PR review state.");
     }
     printStatus(args.pr, args.repo);
     return;

--- a/skills/review-comment-resolution/scripts/review-comments.mjs
+++ b/skills/review-comment-resolution/scripts/review-comments.mjs
@@ -277,7 +277,7 @@ function resolveThreads({ pr, ids, repo, comment, skipComment }) {
 
   const replyComment = skipComment
     ? null
-    : (comment ?? "Addressed in the latest update. Resolving this thread.");
+    : (comment ?? "Addressed in the latest update. What changed: implemented the requested fix and updated related coverage. Validation: ran targeted checks/tests. Resolving this thread.");
 
   const threads = fetchReviewThreads(pr, repo);
   const threadById = new Map(threads.map((thread) => [thread.id, thread]));

--- a/skills/review-comment-resolution/scripts/review-comments.mjs
+++ b/skills/review-comment-resolution/scripts/review-comments.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import fs from "node:fs";
 import { execFileSync, spawnSync } from "node:child_process";
 
 function parseArgs(argv) {
@@ -13,6 +14,8 @@ function parseArgs(argv) {
     repo: "hannasdev/mcp-writing",
     comment: null,
     skipComment: false,
+    sharedComment: false,
+    commentsFile: null,
   };
 
   if (argv.length === 0 || argv.includes("-h") || argv.includes("--help")) {
@@ -90,6 +93,18 @@ function parseArgs(argv) {
 
     if (token === "--no-comment") {
       args.skipComment = true;
+      continue;
+    }
+
+    if (token === "--shared-comment") {
+      args.sharedComment = true;
+      continue;
+    }
+
+    if (token === "--comments-file") {
+      const value = readFlagValue("--comments-file", argv[i + 1]);
+      args.commentsFile = value;
+      i += 1;
       continue;
     }
 
@@ -214,6 +229,49 @@ function summarizeBody(body) {
   return `${singleLine.slice(0, 177)}...`;
 }
 
+function buildThreadContext(thread) {
+  const first = thread?.comments?.nodes?.[0] ?? {};
+  return {
+    path: first.path ?? "n/a",
+    line: first.line ?? "n/a",
+    summary: summarizeBody(first.body ?? ""),
+  };
+}
+
+function buildDefaultReplyForThread(thread) {
+  const { path, line, summary } = buildThreadContext(thread);
+  return [
+    `Addressed thread feedback for ${path}:${line}.`,
+    `What changed: implemented the requested update for this comment (${summary}).`,
+    "Validation: ran targeted checks/tests for this change.",
+    "Resolving this thread.",
+  ].join(" ");
+}
+
+function loadCommentsFromFile(filePath, threadIds) {
+  const raw = fs.readFileSync(filePath, "utf8");
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`Failed to parse --comments-file JSON: ${error.message}`);
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("--comments-file must contain a JSON object mapping thread id to comment text");
+  }
+
+  const commentById = new Map();
+  for (const id of threadIds) {
+    const value = parsed[id];
+    const text = typeof value === "string" ? value.trim() : "";
+    if (!text) {
+      throw new Error(`--comments-file is missing a non-empty comment for thread ${id}`);
+    }
+    commentById.set(id, text);
+  }
+  return commentById;
+}
+
 function printThreads({ pr, includeResolved, repo }) {
   const threads = fetchReviewThreads(pr, repo);
   const filtered = includeResolved ? threads : threads.filter((thread) => !thread.isResolved);
@@ -266,7 +324,7 @@ function replyToThread(threadId, body) {
   }
 }
 
-function resolveThreads({ pr, ids, repo, comment, skipComment }) {
+function resolveThreads({ pr, ids, repo, comment, skipComment, sharedComment, commentsFile }) {
   ensurePrNumber(pr);
   if (ids.length === 0) {
     throw new Error("Provide at least one thread id using --id or --ids");
@@ -274,10 +332,21 @@ function resolveThreads({ pr, ids, repo, comment, skipComment }) {
   if (comment && skipComment) {
     throw new Error("--comment and --no-comment cannot be used together");
   }
-
-  const replyComment = skipComment
-    ? null
-    : (comment ?? "Addressed in the latest update. What changed: implemented the requested fix and updated related coverage. Validation: ran targeted checks/tests. Resolving this thread.");
+  if (commentsFile && skipComment) {
+    throw new Error("--comments-file and --no-comment cannot be used together");
+  }
+  if (comment && commentsFile) {
+    throw new Error("--comment and --comments-file cannot be used together");
+  }
+  if (sharedComment && skipComment) {
+    throw new Error("--shared-comment and --no-comment cannot be used together");
+  }
+  if (sharedComment && commentsFile) {
+    throw new Error("--shared-comment cannot be used with --comments-file");
+  }
+  if (sharedComment && !comment) {
+    throw new Error("--shared-comment requires --comment <text>");
+  }
 
   const threads = fetchReviewThreads(pr, repo);
   const threadById = new Map(threads.map((thread) => [thread.id, thread]));
@@ -293,7 +362,35 @@ function resolveThreads({ pr, ids, repo, comment, skipComment }) {
     throw new Error(`Thread id(s) are already resolved on PR #${pr}: ${alreadyResolved.join(", ")}`);
   }
 
+  const replyByThreadId = new Map();
+  if (!skipComment) {
+    if (commentsFile) {
+      const loaded = loadCommentsFromFile(commentsFile, uniqueIds);
+      for (const id of uniqueIds) {
+        replyByThreadId.set(id, loaded.get(id));
+      }
+    } else if (comment && sharedComment) {
+      for (const id of uniqueIds) {
+        replyByThreadId.set(id, comment);
+      }
+    } else if (comment) {
+      for (const id of uniqueIds) {
+        const thread = threadById.get(id);
+        const { path, line } = buildThreadContext(thread);
+        replyByThreadId.set(
+          id,
+          `Addressed thread feedback for ${path}:${line}. What changed: ${comment} Validation: ran targeted checks/tests. Resolving this thread.`
+        );
+      }
+    } else {
+      for (const id of uniqueIds) {
+        replyByThreadId.set(id, buildDefaultReplyForThread(threadById.get(id)));
+      }
+    }
+  }
+
   for (const id of uniqueIds) {
+    const replyComment = replyByThreadId.get(id);
     if (replyComment) {
       replyToThread(id, replyComment);
       console.log(`commented: ${id}`);
@@ -330,8 +427,8 @@ function printHelp() {
   console.log("");
   console.log("Usage:");
   console.log("  node skills/review-comment-resolution/scripts/review-comments.mjs list --pr <number> [--all] [--repo <owner/name>]");
-  console.log("  node skills/review-comment-resolution/scripts/review-comments.mjs resolve --pr <number> --ids <id1,id2> [--comment <text>] [--no-comment] [--repo <owner/name>]");
-  console.log("  node skills/review-comment-resolution/scripts/review-comments.mjs resolve --pr <number> --id <id1> --id <id2> [--comment <text>] [--no-comment] [--repo <owner/name>]");
+  console.log("  node skills/review-comment-resolution/scripts/review-comments.mjs resolve --pr <number> --ids <id1,id2> [--comment <text>] [--shared-comment] [--comments-file <path.json>] [--no-comment] [--repo <owner/name>]");
+  console.log("  node skills/review-comment-resolution/scripts/review-comments.mjs resolve --pr <number> --id <id1> --id <id2> [--comment <text>] [--shared-comment] [--comments-file <path.json>] [--no-comment] [--repo <owner/name>]");
   console.log("  node skills/review-comment-resolution/scripts/review-comments.mjs status --pr <number> [--repo <owner/name>]");
 }
 
@@ -344,8 +441,8 @@ function main() {
   }
 
   if (args.command === "list") {
-    if (args.usedIdFlags || args.comment !== null || args.skipComment) {
-      throw new Error("--id, --ids, --comment, and --no-comment are not valid for 'list'. Use 'list' to view threads.");
+    if (args.usedIdFlags || args.comment !== null || args.skipComment || args.sharedComment || args.commentsFile !== null) {
+      throw new Error("--id, --ids, --comment, --shared-comment, --comments-file, and --no-comment are not valid for 'list'. Use 'list' to view threads.");
     }
     printThreads({ pr: args.pr, includeResolved: args.includeResolved, repo: args.repo });
     return;
@@ -358,13 +455,21 @@ function main() {
     if (args.ids.length === 0) {
       throw new Error("'resolve' requires --id <id> or --ids <id1,id2>.");
     }
-    resolveThreads({ pr: args.pr, ids: args.ids, repo: args.repo, comment: args.comment, skipComment: args.skipComment });
+    resolveThreads({
+      pr: args.pr,
+      ids: args.ids,
+      repo: args.repo,
+      comment: args.comment,
+      skipComment: args.skipComment,
+      sharedComment: args.sharedComment,
+      commentsFile: args.commentsFile,
+    });
     return;
   }
 
   if (args.command === "status") {
-    if (args.usedIdFlags || args.usedAllFlag || args.comment !== null || args.skipComment) {
-      throw new Error("--id, --ids, --all, --comment, and --no-comment are not valid for 'status'. Use 'status' to view PR review state.");
+    if (args.usedIdFlags || args.usedAllFlag || args.comment !== null || args.skipComment || args.sharedComment || args.commentsFile !== null) {
+      throw new Error("--id, --ids, --all, --comment, --shared-comment, --comments-file, and --no-comment are not valid for 'status'. Use 'status' to view PR review state.");
     }
     printStatus(args.pr, args.repo);
     return;

--- a/src/review-bundles/review-bundles-renderer.js
+++ b/src/review-bundles/review-bundles-renderer.js
@@ -374,6 +374,18 @@ function renderProseWithInlineEmphasis(doc, prose, {
   doc.font(bodyFont).fontSize(fontSize);
 }
 
+function isEpigraphScene(scene) {
+  const tags = Array.isArray(scene?.tags)
+    ? scene.tags
+      .map(tag => String(tag ?? "").trim().toLowerCase())
+      .filter(Boolean)
+    : [];
+  if (tags.includes("epigraph")) return true;
+
+  const title = String(scene?.title ?? "").trim();
+  return /^epigraph(?:\b|\s|[-:])/i.test(title);
+}
+
 function renderSceneBlock(scene, options) {
   const {
     profile,
@@ -384,7 +396,7 @@ function renderSceneBlock(scene, options) {
   } = options;
 
   const isBetaProfile = profile === "beta_reader_personalized";
-  const isEpigraph = isBetaProfile && scene.tags?.includes("epigraph");
+  const isEpigraph = isBetaProfile && isEpigraphScene(scene);
 
   const parts = [];
 
@@ -733,7 +745,7 @@ export function renderReviewBundlePdfWithMetadata(dbHandle, plan, { generatedAt,
         }
 
         // Skip title rendering for epigraphs in beta profile
-        const isEpigraph = isBetaProfile && scene.tags?.includes("epigraph");
+        const isEpigraph = isBetaProfile && isEpigraphScene(scene);
         if (!isEpigraph) {
           doc.fontSize(isBetaProfile ? 13 : 14).font(sceneHeadingFont);
           let heading = scene.title || scene.scene_id;

--- a/src/test/helpers/pdf.js
+++ b/src/test/helpers/pdf.js
@@ -1,0 +1,35 @@
+import zlib from "node:zlib";
+
+export function extractPdfFlateText(pdfBytes) {
+  const markerStart = Buffer.from("stream\n", "latin1");
+  const markerEnd = Buffer.from("\nendstream", "latin1");
+  const chunks = [];
+  let offset = 0;
+
+  while (offset < pdfBytes.length) {
+    const start = pdfBytes.indexOf(markerStart, offset);
+    if (start === -1) break;
+    const dataStart = start + markerStart.length;
+    const end = pdfBytes.indexOf(markerEnd, dataStart);
+    if (end === -1) break;
+    const compressed = pdfBytes.subarray(dataStart, end);
+    try {
+      chunks.push(zlib.inflateSync(compressed).toString("latin1"));
+    } catch {
+      // Non-flate or non-text stream; ignore.
+    }
+    offset = end + markerEnd.length;
+  }
+  return chunks.join("\n");
+}
+
+export function decodePdfHexText(inflatedPdfText) {
+  const parts = [];
+  const re = /<([0-9A-Fa-f]+)>/g;
+  let match;
+  while ((match = re.exec(inflatedPdfText)) !== null) {
+    const hex = match[1].length % 2 === 0 ? match[1] : `0${match[1]}`;
+    parts.push(Buffer.from(hex, "hex").toString("latin1"));
+  }
+  return parts.join("");
+}

--- a/src/test/integration/review-bundles.test.mjs
+++ b/src/test/integration/review-bundles.test.mjs
@@ -3,8 +3,8 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
-import zlib from "node:zlib";
 import { createTestContext } from "../helpers/server.js";
+import { decodePdfHexText, extractPdfFlateText } from "../helpers/pdf.js";
 
 const ctx = createTestContext(3071, 3070);
 let writeSyncDir, readSyncDir;
@@ -22,40 +22,6 @@ after(async () => {
 const callTool = (n, a) => ctx.callTool(n, a);
 const callWriteTool = (n, a) => ctx.callWriteTool(n, a);
 const waitForAsyncJob = (id, t) => ctx.waitForAsyncJob(id, t);
-
-function extractPdfFlateText(pdfBytes) {
-  const markerStart = Buffer.from("stream\n", "latin1");
-  const markerEnd = Buffer.from("\nendstream", "latin1");
-  const chunks = [];
-  let offset = 0;
-
-  while (offset < pdfBytes.length) {
-    const start = pdfBytes.indexOf(markerStart, offset);
-    if (start === -1) break;
-    const dataStart = start + markerStart.length;
-    const end = pdfBytes.indexOf(markerEnd, dataStart);
-    if (end === -1) break;
-    const compressed = pdfBytes.subarray(dataStart, end);
-    try {
-      chunks.push(zlib.inflateSync(compressed).toString("latin1"));
-    } catch {
-      // Non-flate or non-text stream; ignore.
-    }
-    offset = end + markerEnd.length;
-  }
-  return chunks.join("\n");
-}
-
-function decodePdfHexText(inflatedPdfText) {
-  const parts = [];
-  const re = /<([0-9A-Fa-f]+)>/g;
-  let match;
-  while ((match = re.exec(inflatedPdfText)) !== null) {
-    const hex = match[1].length % 2 === 0 ? match[1] : `0${match[1]}`;
-    parts.push(Buffer.from(hex, "hex").toString("latin1"));
-  }
-  return parts.join("");
-}
 describe("preview_review_bundle tool", () => {
   test("returns dry-run plan for outline profile", async () => {
     const text = await callTool("preview_review_bundle", {

--- a/src/test/unit/review-bundles.test.mjs
+++ b/src/test/unit/review-bundles.test.mjs
@@ -489,6 +489,60 @@ describe("buildReviewBundlePlan", () => {
     }
   });
 
+  test("renderReviewBundleMarkdown suppresses epigraph scene title in beta profile", () => {
+    const db = setupReviewBundleTestDb();
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "bundle-beta-epigraph-"));
+    const scenePath = path.join(tempDir, "sc-epigraph-015.md");
+    fs.writeFileSync(
+      scenePath,
+      [
+        '"Some people leave behind ideas. Others leave behind a mess. Sebastian does both."',
+        "- Edda Hoffman",
+      ].join("\n"),
+      "utf8"
+    );
+
+    try {
+      const now = new Date().toISOString();
+      db.prepare(`
+        INSERT INTO scenes (
+          scene_id, project_id, title, part, chapter, chapter_title, timeline_position, word_count,
+          file_path, prose_checksum, metadata_stale, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        "sc-epigraph-015",
+        "test-novel",
+        "Epigraph Chapter 15",
+        1,
+        15,
+        "Semantic Drift",
+        1,
+        32,
+        scenePath,
+        "deadbeef",
+        0,
+        now
+      );
+
+      const plan = buildReviewBundlePlan(db, {
+        project_id: "test-novel",
+        profile: "beta_reader_personalized",
+        recipient_name: "Jordan Example",
+      });
+      const markdown = renderReviewBundleMarkdown(db, plan, {
+        generatedAt: "2026-01-01T00:00:00.000Z",
+        syncDir: fs.realpathSync.native(tempDir),
+      });
+
+      assert.ok(markdown.includes("## Semantic Drift"));
+      assert.ok(!markdown.includes("## Epigraph Chapter 15"));
+      assert.ok(markdown.includes("Some people leave behind ideas."));
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+      db.close();
+    }
+  });
+
   test("renderReviewBundleMarkdown throws when planned scene rows are missing", () => {
     const db = setupReviewBundleTestDb();
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "bundle-missing-rows-"));

--- a/src/test/unit/review-bundles.test.mjs
+++ b/src/test/unit/review-bundles.test.mjs
@@ -578,6 +578,62 @@ describe("buildReviewBundlePlan", () => {
     }
   });
 
+  test("renderReviewBundleMarkdown suppresses epigraph title when tag casing/spacing varies", () => {
+    const db = setupReviewBundleTestDb();
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "bundle-beta-epigraph-tag-normalized-"));
+    const scenePath = path.join(tempDir, "sc-epigraph-tagged-015.md");
+    fs.writeFileSync(
+      scenePath,
+      [
+        '"Some people leave behind ideas. Others leave behind a mess. Sebastian does both."',
+        "- Edda Hoffman",
+      ].join("\n"),
+      "utf8"
+    );
+
+    try {
+      const now = new Date().toISOString();
+      db.prepare(`
+        INSERT INTO scenes (
+          scene_id, project_id, title, part, chapter, chapter_title, timeline_position, word_count,
+          file_path, prose_checksum, metadata_stale, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        "sc-epigraph-tagged-015",
+        "test-novel",
+        "Quoted opener",
+        1,
+        15,
+        "Semantic Drift",
+        1,
+        32,
+        scenePath,
+        "deadbeef",
+        0,
+        now
+      );
+      db.prepare(`INSERT INTO scene_tags (scene_id, project_id, tag) VALUES (?, ?, ?)`)
+        .run("sc-epigraph-tagged-015", "test-novel", "  EPIGRAPH  ");
+
+      const plan = buildReviewBundlePlan(db, {
+        project_id: "test-novel",
+        profile: "beta_reader_personalized",
+        recipient_name: "Jordan Example",
+      });
+      const markdown = renderReviewBundleMarkdown(db, plan, {
+        generatedAt: "2026-01-01T00:00:00.000Z",
+        syncDir: fs.realpathSync.native(tempDir),
+      });
+
+      assert.ok(markdown.includes("## Semantic Drift"));
+      assert.ok(!markdown.includes("## Quoted opener"));
+      assert.ok(markdown.includes("Some people leave behind ideas."));
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+      db.close();
+    }
+  });
+
   test("renderReviewBundlePdf suppresses epigraph scene title in beta profile", async () => {
     const db = setupReviewBundleTestDb();
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "bundle-beta-epigraph-pdf-"));

--- a/src/test/unit/review-bundles.test.mjs
+++ b/src/test/unit/review-bundles.test.mjs
@@ -3,8 +3,43 @@ import assert from "node:assert/strict";
 import os from "node:os";
 import fs from "node:fs";
 import path from "node:path";
-import { buildReviewBundlePlan, renderReviewBundleMarkdown, ReviewBundlePlanError, buildPageFingerprintToken, buildFingerprintSeed, buildFingerprintSeedHash, extractSceneDateline } from "../../review-bundles/review-bundles.js";
+import zlib from "node:zlib";
+import { buildReviewBundlePlan, renderReviewBundleMarkdown, renderReviewBundlePdf, ReviewBundlePlanError, buildPageFingerprintToken, buildFingerprintSeed, buildFingerprintSeedHash, extractSceneDateline } from "../../review-bundles/review-bundles.js";
 import { insertTestScene, setupReviewBundleTestDb } from "../helpers/db.js";
+
+function extractPdfFlateText(pdfBytes) {
+  const markerStart = Buffer.from("stream\n", "latin1");
+  const markerEnd = Buffer.from("\nendstream", "latin1");
+  const chunks = [];
+  let offset = 0;
+
+  while (offset < pdfBytes.length) {
+    const start = pdfBytes.indexOf(markerStart, offset);
+    if (start === -1) break;
+    const dataStart = start + markerStart.length;
+    const end = pdfBytes.indexOf(markerEnd, dataStart);
+    if (end === -1) break;
+    const compressed = pdfBytes.subarray(dataStart, end);
+    try {
+      chunks.push(zlib.inflateSync(compressed).toString("latin1"));
+    } catch {
+      // Non-flate or non-text stream; ignore.
+    }
+    offset = end + markerEnd.length;
+  }
+  return chunks.join("\n");
+}
+
+function decodePdfHexText(inflatedPdfText) {
+  const parts = [];
+  const re = /<([0-9A-Fa-f]+)>/g;
+  let match;
+  while ((match = re.exec(inflatedPdfText)) !== null) {
+    const hex = match[1].length % 2 === 0 ? match[1] : `0${match[1]}`;
+    parts.push(Buffer.from(hex, "hex").toString("latin1"));
+  }
+  return parts.join("");
+}
 
 describe("buildReviewBundlePlan", () => {
   test("orders scenes deterministically with timeline and scene_id fallback", () => {
@@ -537,6 +572,62 @@ describe("buildReviewBundlePlan", () => {
       assert.ok(markdown.includes("## Semantic Drift"));
       assert.ok(!markdown.includes("## Epigraph Chapter 15"));
       assert.ok(markdown.includes("Some people leave behind ideas."));
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+      db.close();
+    }
+  });
+
+  test("renderReviewBundlePdf suppresses epigraph scene title in beta profile", async () => {
+    const db = setupReviewBundleTestDb();
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "bundle-beta-epigraph-pdf-"));
+    const scenePath = path.join(tempDir, "sc-epigraph-015.md");
+    fs.writeFileSync(
+      scenePath,
+      [
+        '"Some people leave behind ideas. Others leave behind a mess. Sebastian does both."',
+        "- Edda Hoffman",
+      ].join("\n"),
+      "utf8"
+    );
+
+    try {
+      const now = new Date().toISOString();
+      db.prepare(`
+        INSERT INTO scenes (
+          scene_id, project_id, title, part, chapter, chapter_title, timeline_position, word_count,
+          file_path, prose_checksum, metadata_stale, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        "sc-epigraph-015",
+        "test-novel",
+        "Epigraph Chapter 15",
+        1,
+        15,
+        "Semantic Drift",
+        1,
+        32,
+        scenePath,
+        "deadbeef",
+        0,
+        now
+      );
+
+      const plan = buildReviewBundlePlan(db, {
+        project_id: "test-novel",
+        profile: "beta_reader_personalized",
+        recipient_name: "Jordan Example",
+      });
+      const pdfBytes = await renderReviewBundlePdf(db, plan, {
+        generatedAt: "2026-01-01T00:00:00.000Z",
+        syncDir: fs.realpathSync.native(tempDir),
+      });
+      const inflatedStreamsText = extractPdfFlateText(pdfBytes);
+      const decodedPdfText = decodePdfHexText(inflatedStreamsText);
+
+      assert.match(decodedPdfText, /Semantic Drift/);
+      assert.doesNotMatch(decodedPdfText, /Epigraph Chapter 15/);
+      assert.match(decodedPdfText, /Some people leave behind ideas\./);
     } finally {
       fs.rmSync(tempDir, { recursive: true, force: true });
       db.close();

--- a/src/test/unit/review-bundles.test.mjs
+++ b/src/test/unit/review-bundles.test.mjs
@@ -3,43 +3,9 @@ import assert from "node:assert/strict";
 import os from "node:os";
 import fs from "node:fs";
 import path from "node:path";
-import zlib from "node:zlib";
 import { buildReviewBundlePlan, renderReviewBundleMarkdown, renderReviewBundlePdf, ReviewBundlePlanError, buildPageFingerprintToken, buildFingerprintSeed, buildFingerprintSeedHash, extractSceneDateline } from "../../review-bundles/review-bundles.js";
 import { insertTestScene, setupReviewBundleTestDb } from "../helpers/db.js";
-
-function extractPdfFlateText(pdfBytes) {
-  const markerStart = Buffer.from("stream\n", "latin1");
-  const markerEnd = Buffer.from("\nendstream", "latin1");
-  const chunks = [];
-  let offset = 0;
-
-  while (offset < pdfBytes.length) {
-    const start = pdfBytes.indexOf(markerStart, offset);
-    if (start === -1) break;
-    const dataStart = start + markerStart.length;
-    const end = pdfBytes.indexOf(markerEnd, dataStart);
-    if (end === -1) break;
-    const compressed = pdfBytes.subarray(dataStart, end);
-    try {
-      chunks.push(zlib.inflateSync(compressed).toString("latin1"));
-    } catch {
-      // Non-flate or non-text stream; ignore.
-    }
-    offset = end + markerEnd.length;
-  }
-  return chunks.join("\n");
-}
-
-function decodePdfHexText(inflatedPdfText) {
-  const parts = [];
-  const re = /<([0-9A-Fa-f]+)>/g;
-  let match;
-  while ((match = re.exec(inflatedPdfText)) !== null) {
-    const hex = match[1].length % 2 === 0 ? match[1] : `0${match[1]}`;
-    parts.push(Buffer.from(hex, "hex").toString("latin1"));
-  }
-  return parts.join("");
-}
+import { decodePdfHexText, extractPdfFlateText } from "../helpers/pdf.js";
 
 describe("buildReviewBundlePlan", () => {
   test("orders scenes deterministically with timeline and scene_id fallback", () => {

--- a/src/test/unit/review-comments-script.test.mjs
+++ b/src/test/unit/review-comments-script.test.mjs
@@ -205,6 +205,13 @@ function runHelper(args, env = {}) {
   return { result, log };
 }
 
+function createCommentsFile(content) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "review-comments-json-test-"));
+  const filePath = path.join(tmpDir, "comments.json");
+  fs.writeFileSync(filePath, JSON.stringify(content), "utf8");
+  return { tmpDir, filePath };
+}
+
 describe("review-comments helper script", () => {
   test("list paginates review threads until hasNextPage=false", () => {
     const { result, log } = runHelper(["list", "--pr", "172"]);
@@ -261,7 +268,77 @@ describe("review-comments helper script", () => {
     const graphqlCalls = log.filter((args) => args[0] === "api" && args[1] === "graphql");
     const replyCall = graphqlCalls.find((args) => args.some((arg) => typeof arg === "string" && arg.includes("addPullRequestReviewThreadReply")));
     assert.ok(replyCall, "expected addPullRequestReviewThreadReply call");
-    assert.ok(replyCall.includes(`body=${customComment}`));
+    const bodyArg = replyCall.find((arg) => typeof arg === "string" && arg.startsWith("body=")) ?? "";
+    const body = bodyArg.replace(/^body=/, "");
+    assert.match(body, /Addressed thread feedback for a\.md:10/);
+    assert.ok(body.includes(customComment));
+  });
+
+  test("resolve defaults to thread-specific replies when no comment is provided", () => {
+    const { result, log } = runHelper(["resolve", "--pr", "172", "--ids", "thread-1,thread-2"]);
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    const graphqlCalls = log.filter((args) => args[0] === "api" && args[1] === "graphql");
+    const replyCalls = graphqlCalls.filter((args) => args.some((arg) => typeof arg === "string" && arg.includes("addPullRequestReviewThreadReply")));
+    assert.equal(replyCalls.length, 2);
+    const bodies = replyCalls
+      .map((args) => args.find((arg) => typeof arg === "string" && arg.startsWith("body=")) ?? "")
+      .map((entry) => entry.replace(/^body=/, ""));
+    assert.equal(bodies[0].includes("a.md:10"), true);
+    assert.equal(bodies[1].includes("b.md:20"), true);
+    assert.notEqual(bodies[0], bodies[1]);
+  });
+
+  test("resolve supports shared reply mode for overlapping comments", () => {
+    const sharedComment = "Shared root cause fixed in latest commit.";
+    const { result, log } = runHelper([
+      "resolve",
+      "--pr",
+      "172",
+      "--ids",
+      "thread-1,thread-2",
+      "--comment",
+      sharedComment,
+      "--shared-comment",
+    ]);
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    const graphqlCalls = log.filter((args) => args[0] === "api" && args[1] === "graphql");
+    const replyCalls = graphqlCalls.filter((args) => args.some((arg) => typeof arg === "string" && arg.includes("addPullRequestReviewThreadReply")));
+    assert.equal(replyCalls.length, 2);
+    for (const call of replyCalls) {
+      assert.ok(call.includes(`body=${sharedComment}`));
+    }
+  });
+
+  test("resolve supports per-thread comments from file", () => {
+    const { tmpDir, filePath } = createCommentsFile({
+      "thread-1": "Addressed thread 1.",
+      "thread-2": "Addressed thread 2.",
+    });
+    try {
+      const { result, log } = runHelper([
+        "resolve",
+        "--pr",
+        "172",
+        "--ids",
+        "thread-1,thread-2",
+        "--comments-file",
+        filePath,
+      ]);
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      const graphqlCalls = log.filter((args) => args[0] === "api" && args[1] === "graphql");
+      const replyCalls = graphqlCalls.filter((args) => args.some((arg) => typeof arg === "string" && arg.includes("addPullRequestReviewThreadReply")));
+      assert.equal(replyCalls.length, 2);
+      const bodies = replyCalls
+        .map((args) => args.find((arg) => typeof arg === "string" && arg.startsWith("body=")) ?? "")
+        .map((entry) => entry.replace(/^body=/, ""));
+      assert.equal(bodies.includes("Addressed thread 1."), true);
+      assert.equal(bodies.includes("Addressed thread 2."), true);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 
   test("rejects malformed --pr values", () => {
@@ -310,7 +387,7 @@ describe("review-comments helper script", () => {
     const { result } = runHelper(["list", "--pr", "172", "--id", "thread-1"]);
 
     assert.notEqual(result.status, 0);
-    assert.match(result.stderr, /--id, --ids, --comment, and --no-comment are not valid for 'list'/);
+    assert.match(result.stderr, /--id, --ids, --comment, --shared-comment, --comments-file, and --no-comment are not valid for 'list'/);
   });
 
   test("rejects --all flag with 'resolve' command", () => {
@@ -331,7 +408,7 @@ describe("review-comments helper script", () => {
     const { result } = runHelper(["status", "--pr", "172", "--id", "thread-1", "--all"]);
 
     assert.notEqual(result.status, 0);
-    assert.match(result.stderr, /--id, --ids, --all, --comment, and --no-comment are not valid for 'status'/);
+    assert.match(result.stderr, /--id, --ids, --all, --comment, --shared-comment, --comments-file, and --no-comment are not valid for 'status'/);
   });
 
   test("rejects --comment and --no-comment together", () => {
@@ -348,5 +425,52 @@ describe("review-comments helper script", () => {
 
     assert.notEqual(result.status, 0);
     assert.match(result.stderr, /--comment and --no-comment cannot be used together/);
+  });
+
+  test("rejects --shared-comment without --comment", () => {
+    const { result } = runHelper(["resolve", "--pr", "172", "--id", "thread-1", "--shared-comment"]);
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /--shared-comment requires --comment <text>/);
+  });
+
+  test("rejects --comment and --comments-file together", () => {
+    const { tmpDir, filePath } = createCommentsFile({ "thread-1": "Addressed." });
+    try {
+      const { result } = runHelper([
+        "resolve",
+        "--pr",
+        "172",
+        "--id",
+        "thread-1",
+        "--comment",
+        "Addressed.",
+        "--comments-file",
+        filePath,
+      ]);
+      assert.notEqual(result.status, 0);
+      assert.match(result.stderr, /--comment and --comments-file cannot be used together/);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects comments file that omits requested thread id", () => {
+    const { tmpDir, filePath } = createCommentsFile({ "thread-1": "Addressed." });
+    try {
+      const { result } = runHelper([
+        "resolve",
+        "--pr",
+        "172",
+        "--ids",
+        "thread-1,thread-2",
+        "--comments-file",
+        filePath,
+      ]);
+      assert.notEqual(result.status, 0);
+      assert.match(result.stderr, /--comments-file is missing a non-empty comment for thread thread-2/);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/test/unit/review-comments-script.test.mjs
+++ b/src/test/unit/review-comments-script.test.mjs
@@ -41,6 +41,17 @@ const pr = getArgValue("pr", "-F");
 if (args[0] === "api" && args[1] === "graphql") {
   const query = getArgValue("query");
 
+  if (query && query.includes("addPullRequestReviewThreadReply")) {
+    process.stdout.write(JSON.stringify({
+      data: {
+        addPullRequestReviewThreadReply: {
+          comment: { id: "comment-1", body: getArgValue("body") || "" }
+        }
+      }
+    }));
+    process.exit(0);
+  }
+
   if (query && query.includes("resolveReviewThread")) {
     process.stdout.write(JSON.stringify({
       data: {
@@ -220,11 +231,37 @@ describe("review-comments helper script", () => {
     const { result, log } = runHelper(["resolve", "--pr", "172", "--id", "thread-1"]);
 
     assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /commented: thread-1/);
     assert.match(result.stdout, /resolved: thread-1/);
 
     const graphqlCalls = log.filter((args) => args[0] === "api" && args[1] === "graphql");
+    const hasReplyMutation = graphqlCalls.some((args) => args.some((arg) => typeof arg === "string" && arg.includes("addPullRequestReviewThreadReply")));
     const hasResolveMutation = graphqlCalls.some((args) => args.some((arg) => typeof arg === "string" && arg.includes("resolveReviewThread")));
+    assert.equal(hasReplyMutation, true, "expected an addPullRequestReviewThreadReply mutation call");
     assert.equal(hasResolveMutation, true, "expected a resolveReviewThread mutation call");
+  });
+
+  test("resolve allows explicit no-comment mode", () => {
+    const { result, log } = runHelper(["resolve", "--pr", "172", "--id", "thread-1", "--no-comment"]);
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.doesNotMatch(result.stdout, /commented:/);
+    assert.match(result.stdout, /resolved: thread-1/);
+
+    const graphqlCalls = log.filter((args) => args[0] === "api" && args[1] === "graphql");
+    const hasReplyMutation = graphqlCalls.some((args) => args.some((arg) => typeof arg === "string" && arg.includes("addPullRequestReviewThreadReply")));
+    assert.equal(hasReplyMutation, false, "did not expect addPullRequestReviewThreadReply in --no-comment mode");
+  });
+
+  test("resolve supports custom comment text", () => {
+    const customComment = "Addressed in abc123. Added regression test.";
+    const { result, log } = runHelper(["resolve", "--pr", "172", "--id", "thread-1", "--comment", customComment]);
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    const graphqlCalls = log.filter((args) => args[0] === "api" && args[1] === "graphql");
+    const replyCall = graphqlCalls.find((args) => args.some((arg) => typeof arg === "string" && arg.includes("addPullRequestReviewThreadReply")));
+    assert.ok(replyCall, "expected addPullRequestReviewThreadReply call");
+    assert.ok(replyCall.includes(`body=${customComment}`));
   });
 
   test("rejects malformed --pr values", () => {
@@ -273,7 +310,7 @@ describe("review-comments helper script", () => {
     const { result } = runHelper(["list", "--pr", "172", "--id", "thread-1"]);
 
     assert.notEqual(result.status, 0);
-    assert.match(result.stderr, /--id and --ids are not valid for 'list'/);
+    assert.match(result.stderr, /--id, --ids, --comment, and --no-comment are not valid for 'list'/);
   });
 
   test("rejects --all flag with 'resolve' command", () => {
@@ -294,6 +331,22 @@ describe("review-comments helper script", () => {
     const { result } = runHelper(["status", "--pr", "172", "--id", "thread-1", "--all"]);
 
     assert.notEqual(result.status, 0);
-    assert.match(result.stderr, /--id, --ids, and --all are not valid for 'status'/);
+    assert.match(result.stderr, /--id, --ids, --all, --comment, and --no-comment are not valid for 'status'/);
+  });
+
+  test("rejects --comment and --no-comment together", () => {
+    const { result } = runHelper([
+      "resolve",
+      "--pr",
+      "172",
+      "--id",
+      "thread-1",
+      "--comment",
+      "Addressed.",
+      "--no-comment",
+    ]);
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /--comment and --no-comment cannot be used together/);
   });
 });

--- a/src/test/unit/review-comments-script.test.mjs
+++ b/src/test/unit/review-comments-script.test.mjs
@@ -227,7 +227,7 @@ describe("review-comments helper script", () => {
     assert.match(result.stdout, /unresolved threads: 2/);
   });
 
-  test("resolve calls resolveReviewThread mutation", () => {
+  test("resolve posts reply comment then resolves thread", () => {
     const { result, log } = runHelper(["resolve", "--pr", "172", "--id", "thread-1"]);
 
     assert.equal(result.status, 0, result.stderr || result.stdout);


### PR DESCRIPTION
## Summary

- Suppress epigraph scene headings in `beta_reader_personalized` exports when a scene is identified as epigraph content, including imperfect tag normalization cases.
- Add regression coverage for both Markdown and PDF beta export paths, plus shared PDF decode helpers for review-bundle tests.
- Improve the review-comment-resolution workflow so thread replies are required and tailored by default, with explicit shared-reply and per-thread comment-file modes.
- Document the review helper's `--comments-file` usage and keep release-log coverage for the beta export fix.

## Motivation

Beta reader exports were still printing epigraph document titles like `Epigraph Chapter 15`, which should not appear in exported packets. During review, the PR also expanded to tighten how PR review threads are answered and resolved so replies are concise, thread-specific, and better aligned with the repository workflow.

## Implementation

- Added `isEpigraphScene(scene)` fallback logic for normalized epigraph tags and epigraph-style titles, and updated both Markdown and PDF rendering paths to suppress epigraph scene headings.
- Added targeted unit coverage for title-based and tag-normalized epigraph detection, and extracted shared PDF decode helpers to `src/test/helpers/pdf.js` for unit/integration reuse.
- Updated `skills/review-comment-resolution/SKILL.md` to require reply comments before resolution and to prefer thread-specific responses.
- Extended `skills/review-comment-resolution/scripts/review-comments.mjs` with default per-thread replies, `--shared-comment`, and `--comments-file` support, and added matching unit coverage.
- Added an Unreleased release-log entry for the beta export behavior fix and a JSON example for `--comments-file` usage.

## Testing

- `node --experimental-sqlite --test src/test/unit/review-bundles.test.mjs`
- `node --experimental-sqlite --test src/test/integration/review-bundles.test.mjs`
- `node --experimental-sqlite --test src/test/unit/review-comments-script.test.mjs`

## Risks and tradeoffs

- Title-based epigraph detection (`/^epigraph(?:\b|\s|[-:])/i`) is intentionally broader to catch imperfect metadata, which could suppress a heading for scenes intentionally titled with an `Epigraph` prefix.
- The review-comment helper is stricter and more featureful than before; users now need to choose explicitly when a shared reply is appropriate across overlapping threads.

## Follow-up

- If needed, we can add a stricter metadata signal for epigraph scenes and further template thread replies from commit/test context automatically.
