### PR TITLE
feat(search): normalize metadata-read tool response envelopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Safe parsing pattern:
 
 ```js
 const parsed = JSON.parse(toolText);
+if (parsed.ok === false) throw new Error(parsed.error?.message ?? "tool error");
 const scenes = parsed.results ?? [];
 const totalCount = parsed.total_count ?? scenes.length;
 const warning = parsed.warning ?? null;
@@ -104,6 +105,7 @@ Safe parsing pattern for sheet tools:
 
 ```js
 const parsed = JSON.parse(toolText);
+if (parsed.ok === false) throw new Error(parsed.error?.message ?? "tool error");
 const sheet = parsed.results?.[0] ?? {};
 const nextStep = parsed.next_step ?? null;
 ```
@@ -112,6 +114,7 @@ Safe parsing pattern for list/arc tools:
 
 ```js
 const parsed = JSON.parse(toolText);
+if (parsed.ok === false) throw new Error(parsed.error?.message ?? "tool error");
 const items = parsed.results ?? [];
 const totalCount = parsed.total_count ?? items.length;
 ```

--- a/README.md
+++ b/README.md
@@ -92,6 +92,30 @@ const warning = parsed.warning ?? null;
 const nextStep = parsed.next_step ?? null;
 ```
 
+### `get_character_sheet`, `get_place_sheet`, `list_scene_references`, `get_relationship_arc` response-shape standardization
+
+These metadata-read tools now return structured envelopes instead of flat objects or raw arrays.
+
+- `get_character_sheet` and `get_place_sheet`: previously returned a flat object of field values; now return `{ results: [row], total_count: 1, next_step }`.
+- `list_scene_references`: previously returned `{ references, scene_id, project_id }`; now returns `{ results, total_count, scene_id, project_id }`.
+- `get_relationship_arc`: previously returned a raw JSON array; now returns `{ results, total_count, from_character, to_character }`.
+
+Safe parsing pattern for sheet tools:
+
+```js
+const parsed = JSON.parse(toolText);
+const sheet = parsed.results?.[0] ?? {};
+const nextStep = parsed.next_step ?? null;
+```
+
+Safe parsing pattern for list/arc tools:
+
+```js
+const parsed = JSON.parse(toolText);
+const items = parsed.results ?? [];
+const totalCount = parsed.total_count ?? items.length;
+```
+
 ## Usage scenarios
 
 ### 1) Continuity pass before sending chapters to beta readers

--- a/docs/release-log.md
+++ b/docs/release-log.md
@@ -14,7 +14,7 @@ This complements `CHANGELOG.md`:
 - Why it matters: Agents and integrations can now parse all metadata-read responses with a single consistent pattern, reducing brittle per-tool parsing logic.
 - Who is affected: Any integration or prompt that directly parses the JSON response from these four tools.
 - Action needed: Update parsers. Sheet tools: use `parsed.results[0]` instead of the flat object. `list_scene_references`: use `parsed.results` instead of `parsed.references`. `get_relationship_arc`: use `parsed.results` instead of the top-level array. Safe parsing patterns are in `README.md`.
-- PR: #pending
+- PR: [#189](https://github.com/hannasdev/mcp-writing/pull/189)
 
 ### 2026-05-08 — Suppress epigraph document titles in beta exports
 

--- a/docs/release-log.md
+++ b/docs/release-log.md
@@ -8,6 +8,14 @@ This complements `CHANGELOG.md`:
 
 ## Unreleased
 
+### 2026-05-14 — Consistent response envelopes for metadata-read tools
+
+- What changed: Four metadata-read tools now return structured envelopes `{ results, total_count, ... }` instead of flat objects or raw arrays: `get_character_sheet`, `get_place_sheet`, `list_scene_references`, and `get_relationship_arc`.
+- Why it matters: Agents and integrations can now parse all metadata-read responses with a single consistent pattern, reducing brittle per-tool parsing logic.
+- Who is affected: Any integration or prompt that directly parses the JSON response from these four tools.
+- Action needed: Update parsers. Sheet tools: use `parsed.results[0]` instead of the flat object. `list_scene_references`: use `parsed.results` instead of `parsed.references`. `get_relationship_arc`: use `parsed.results` instead of the top-level array. Safe parsing patterns are in `README.md`.
+- PR: #pending
+
 ### 2026-05-08 — Suppress epigraph document titles in beta exports
 
 - What changed: Beta review-bundle rendering now suppresses epigraph scene headings more robustly, including cases where epigraph metadata tags are missing/case-variant and the scene title starts with "Epigraph ...".

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -248,7 +248,7 @@ List indexed characters with their character_id, name, role, and arc_summary. Us
 
 ## get_character_sheet
 
-Get full character details: role, arc_summary, traits, the canonical sheet content, and any adjacent support notes when the character uses a folder-based layout. Use this when the reasoning task needs the character's canonical profile rather than only their scene progression.
+Get full character details: role, arc_summary, traits, the canonical sheet content, and any adjacent support notes when the character uses a folder-based layout. Use this when the reasoning task needs the character's canonical profile rather than only their scene progression. Response shape note: returns a structured envelope (`results`, `total_count`) with one result row.
 
 | Parameter | Type | Required | Description |
 | --- | --- | :---: | --- |
@@ -269,7 +269,7 @@ List indexed places with their place_id and name. Use this mainly as a lookup an
 
 ## get_place_sheet
 
-Get full place details: associated_characters, tags, the canonical sheet content, and any adjacent support notes when the place uses a folder-based layout. Use this when the current scene or question makes the place itself materially relevant.
+Get full place details: associated_characters, tags, the canonical sheet content, and any adjacent support notes when the place uses a folder-based layout. Use this when the current scene or question makes the place itself materially relevant. Response shape note: returns a structured envelope (`results`, `total_count`) with one result row.
 
 | Parameter | Type | Required | Description |
 | --- | --- | :---: | --- |
@@ -303,7 +303,7 @@ Full-text search across indexed reference document titles, summaries, and tags. 
 
 ## list_scene_references
 
-List direct reference documents linked from a scene via metadata (for example, reference_ids). Returns only one-hop scene -> reference links and does not recursively traverse related references. If scene IDs are reused across projects, omitting project_id returns CONFLICT with candidate project_ids.
+List direct reference documents linked from a scene via metadata (for example, reference_ids). Returns only one-hop scene -> reference links and does not recursively traverse related references. If scene IDs are reused across projects, omitting project_id returns CONFLICT with candidate project_ids. Response shape note: returns a structured envelope (`results`, `total_count`) plus the resolved `scene_id` and `project_id` context.
 
 | Parameter | Type | Required | Description |
 | --- | --- | :---: | --- |
@@ -349,7 +349,7 @@ Get ordered scene metadata for all scenes belonging to a thread, including the p
 
 ## get_relationship_arc
 
-Show how the relationship between two characters evolves across scenes, in order. Uses explicitly recorded relationship entries — returns nothing if no entries exist yet. Use list_characters to get character_id values.
+Show how the relationship between two characters evolves across scenes, in order. Uses explicitly recorded relationship entries — returns nothing if no entries exist yet. Use list_characters to get character_id values. Response shape note: returns a structured envelope { results, total_count, from_character, to_character }.
 
 | Parameter | Type | Required | Description |
 | --- | --- | :---: | --- |

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -349,7 +349,7 @@ Get ordered scene metadata for all scenes belonging to a thread, including the p
 
 ## get_relationship_arc
 
-Show how the relationship between two characters evolves across scenes, in order. Uses explicitly recorded relationship entries — returns nothing if no entries exist yet. Use list_characters to get character_id values. Response shape note: returns a structured envelope { results, total_count, from_character, to_character }.
+Show how the relationship between two characters evolves across scenes, in order. Uses explicitly recorded relationship entries — returns a NO_RESULTS error if no entries exist yet. Use list_characters to get character_id values. Response shape note: returns a structured envelope { results, total_count, from_character, to_character }.
 
 | Parameter | Type | Required | Description |
 | --- | --- | :---: | --- |

--- a/src/test/integration/metadata.test.mjs
+++ b/src/test/integration/metadata.test.mjs
@@ -87,8 +87,9 @@ describe("update_place_sheet tool", () => {
 
     const sheet = await callWriteTool("get_place_sheet", { place_id: "harbor-district" });
     const parsed = JSON.parse(sheet);
-    assert.ok(parsed.associated_characters.includes("marcus"));
-    assert.ok(parsed.tags.includes("docks"));
+    assert.equal(parsed.total_count, 1);
+    assert.ok(parsed.results[0].associated_characters.includes("marcus"));
+    assert.ok(parsed.results[0].tags.includes("docks"));
   });
 
   test("returns error for unknown place", async () => {

--- a/src/test/integration/search.test.mjs
+++ b/src/test/integration/search.test.mjs
@@ -306,10 +306,14 @@ describe("get_character_sheet tool", () => {
   test("elena sheet includes traits", async () => {
     const text = await callTool("get_character_sheet", { character_id: "elena" });
     const parsed = JSON.parse(text);
+    const row = parsed.results[0];
     assert.ok((text.includes("driven") || text.includes("walls")),
       `Expected trait keywords for elena, got: ${text.slice(0, 200)}`);
+    assert.equal(parsed.total_count, 1);
+    assert.equal(Array.isArray(parsed.results), true);
     assert.equal(typeof parsed.next_step, "string");
     assert.ok(parsed.next_step.includes("get_arc"));
+    assert.equal(Array.isArray(row.traits), true);
   });
 
   test("marcus sheet includes arc_summary", async () => {
@@ -330,11 +334,13 @@ describe("get_character_sheet tool", () => {
 
     const text = await callWriteTool("get_character_sheet", { character_id: "alba" });
     const parsed = JSON.parse(text);
+    const row = parsed.results[0];
 
-    assert.equal(parsed.notes, "Canonical sheet content.");
-    assert.equal(parsed.supporting_notes.length, 1);
-    assert.equal(parsed.supporting_notes[0].file_name, "arc.md");
-    assert.equal(parsed.supporting_notes[0].content, "Alba support arc notes.");
+    assert.equal(parsed.total_count, 1);
+    assert.equal(row.notes, "Canonical sheet content.");
+    assert.equal(row.supporting_notes.length, 1);
+    assert.equal(row.supporting_notes[0].file_name, "arc.md");
+    assert.equal(row.supporting_notes[0].content, "Alba support arc notes.");
   });
 
   test("returns next_step guidance on unknown character", async () => {
@@ -362,10 +368,12 @@ describe("get_place_sheet tool", () => {
   test("harbor-district sheet includes associated_characters and tags", async () => {
     const text = await callTool("get_place_sheet", { place_id: "harbor-district" });
     const parsed = JSON.parse(text);
+    const row = parsed.results[0];
 
-    assert.ok(parsed.associated_characters.includes("elena"));
-    assert.ok(parsed.tags.includes("urban"));
-    assert.ok(parsed.notes.includes("brine and diesel"));
+    assert.equal(parsed.total_count, 1);
+    assert.ok(row.associated_characters.includes("elena"));
+    assert.ok(row.tags.includes("urban"));
+    assert.ok(row.notes.includes("brine and diesel"));
     assert.equal(typeof parsed.next_step, "string");
     assert.ok(parsed.next_step.includes("find_scenes"));
   });
@@ -382,13 +390,15 @@ describe("get_place_sheet tool", () => {
 
     const text = await callWriteTool("get_place_sheet", { place_id: "aevi-labs" });
     const parsed = JSON.parse(text);
+    const row = parsed.results[0];
 
-    assert.equal(parsed.notes, "Canonical place sheet content.");
-    assert.equal(parsed.associated_characters[0], "alba");
-    assert.equal(parsed.tags[0], "lab");
-    assert.equal(parsed.supporting_notes.length, 1);
-    assert.equal(parsed.supporting_notes[0].file_name, "history.md");
-    assert.equal(parsed.supporting_notes[0].content, "Aevi Labs support history notes.");
+    assert.equal(parsed.total_count, 1);
+    assert.equal(row.notes, "Canonical place sheet content.");
+    assert.equal(row.associated_characters[0], "alba");
+    assert.equal(row.tags[0], "lab");
+    assert.equal(row.supporting_notes.length, 1);
+    assert.equal(row.supporting_notes[0].file_name, "history.md");
+    assert.equal(row.supporting_notes[0].content, "Aevi Labs support history notes.");
   });
 
   test("returns next_step guidance on unknown place", async () => {
@@ -507,9 +517,10 @@ describe("reference link tools", () => {
 
     assert.equal(parsed.scene_id, "sc-ref-001");
     assert.equal(parsed.project_id, "test-novel");
-    assert.equal(parsed.references.length, 2);
-    assert.ok(parsed.references.some(row => row.doc_id === "ref-blood-rules"));
-    assert.ok(parsed.references.some(row => row.doc_id === "ref-sebastian-blood"));
+    assert.equal(parsed.total_count, 2);
+    assert.equal(parsed.results.length, 2);
+    assert.ok(parsed.results.some(row => row.doc_id === "ref-blood-rules"));
+    assert.ok(parsed.results.some(row => row.doc_id === "ref-sebastian-blood"));
   });
 
   test("list_scene_references returns CONFLICT for ambiguous scene_id without project_id", async () => {
@@ -615,7 +626,7 @@ describe("reference link tools", () => {
       project_id: "test-novel",
     });
     const listedParsed = JSON.parse(listedText);
-    assert.ok(listedParsed.references.some((row) => row.doc_id === "ref-apply-mode"));
+    assert.ok(listedParsed.results.some((row) => row.doc_id === "ref-apply-mode"));
   });
 
 });
@@ -831,9 +842,9 @@ describe("upsert_reference_link tool", () => {
       project_id: "test-novel",
     });
     const listedParsed = JSON.parse(listed);
-    assert.equal(listedParsed.references.length, 1);
-    assert.equal(listedParsed.references[0].doc_id, "ref-upsert-target");
-    assert.equal(listedParsed.references[0].relation, "see_also");
+    assert.equal(listedParsed.results.length, 1);
+    assert.equal(listedParsed.results[0].doc_id, "ref-upsert-target");
+    assert.equal(listedParsed.results[0].relation, "see_also");
 
     await callWriteTool("sync");
 
@@ -842,9 +853,9 @@ describe("upsert_reference_link tool", () => {
       project_id: "test-novel",
     });
     const listedAfterSyncParsed = JSON.parse(listedAfterSync);
-    assert.equal(listedAfterSyncParsed.references.length, 1);
-    assert.equal(listedAfterSyncParsed.references[0].doc_id, "ref-upsert-target");
-    assert.equal(listedAfterSyncParsed.references[0].relation, "see_also");
+    assert.equal(listedAfterSyncParsed.results.length, 1);
+    assert.equal(listedAfterSyncParsed.results[0].doc_id, "ref-upsert-target");
+    assert.equal(listedAfterSyncParsed.results[0].relation, "see_also");
   });
 
   test("returns conflict for ambiguous scene source without project scope", async () => {

--- a/src/test/unit/reference-tools.test.mjs
+++ b/src/test/unit/reference-tools.test.mjs
@@ -219,9 +219,10 @@ describe("reference link search tools", () => {
 
       assert.equal(parsed.scene_id, "sc-001");
       assert.equal(parsed.project_id, "test-novel");
-      assert.equal(parsed.references.length, 1);
-      assert.equal(parsed.references[0].doc_id, "ref-vampirism");
-      assert.deepEqual(parsed.references[0].tags, ["lore", "vampirism"]);
+      assert.equal(parsed.total_count, 1);
+      assert.equal(parsed.results.length, 1);
+      assert.equal(parsed.results[0].doc_id, "ref-vampirism");
+      assert.deepEqual(parsed.results[0].tags, ["lore", "vampirism"]);
     } finally {
       db.close();
     }

--- a/src/test/unit/reference-tools.test.mjs
+++ b/src/test/unit/reference-tools.test.mjs
@@ -885,3 +885,33 @@ describe("reference link search tools", () => {
     }
   });
 });
+
+  describe("get_relationship_arc tool", () => {
+    test("success path returns { results, total_count, from_character, to_character } envelope", async () => {
+      const db = openDb(":memory:");
+      try {
+        seedProject(db, "proj");
+        seedScene(db, { sceneId: "sc-001", projectId: "proj" });
+        db.prepare(`
+          INSERT INTO character_relationships
+            (from_character, to_character, relationship_type, strength, scene_id, note)
+          VALUES (?, ?, ?, ?, ?, ?)
+        `).run("char-elena", "char-marcus", "ally", "high", "sc-001", "Meet at harbor");
+
+        const harness = makeToolHarness(db);
+        const result = await harness.call("get_relationship_arc", {
+          from_character: "char-elena",
+          to_character: "char-marcus",
+        });
+
+        assert.equal(Array.isArray(result.results), true);
+        assert.equal(result.total_count, 1);
+        assert.equal(result.from_character, "char-elena");
+        assert.equal(result.to_character, "char-marcus");
+        assert.equal(result.results[0].relationship_type, "ally");
+        assert.equal(result.results[0].strength, "high");
+      } finally {
+        db.close();
+      }
+    });
+  });

--- a/src/tools/search.js
+++ b/src/tools/search.js
@@ -371,7 +371,7 @@ export function registerSearchTools(s, {
   // ---- get_character_sheet -------------------------------------------------
   s.tool(
     "get_character_sheet",
-    "Get full character details: role, arc_summary, traits, the canonical sheet content, and any adjacent support notes when the character uses a folder-based layout. Use this when the reasoning task needs the character's canonical profile rather than only their scene progression.",
+    "Get full character details: role, arc_summary, traits, the canonical sheet content, and any adjacent support notes when the character uses a folder-based layout. Use this when the reasoning task needs the character's canonical profile rather than only their scene progression. Response shape note: returns a structured envelope (`results`, `total_count`) with one result row.",
     {
       character_id: z.string().describe("The character_id to look up (e.g. 'char-sebastian'). Use list_characters to find valid IDs."),
     },
@@ -402,9 +402,17 @@ export function registerSearchTools(s, {
         traits,
         notes: notes || undefined,
         supporting_notes: supportingNotes.length ? supportingNotes : undefined,
-        next_step: "Use get_arc with this character_id to trace scene-level progression, then open specific scenes with get_scene_prose when prose evidence is needed.",
       };
-      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      return {
+        content: [{
+          type: "text",
+          text: JSON.stringify({
+            results: [result],
+            total_count: 1,
+            next_step: "Use get_arc with this character_id to trace scene-level progression, then open specific scenes with get_scene_prose when prose evidence is needed.",
+          }, null, 2),
+        }],
+      };
     }
   );
 
@@ -444,7 +452,7 @@ export function registerSearchTools(s, {
   // ---- get_place_sheet -----------------------------------------------------
   s.tool(
     "get_place_sheet",
-    "Get full place details: associated_characters, tags, the canonical sheet content, and any adjacent support notes when the place uses a folder-based layout. Use this when the current scene or question makes the place itself materially relevant.",
+    "Get full place details: associated_characters, tags, the canonical sheet content, and any adjacent support notes when the place uses a folder-based layout. Use this when the current scene or question makes the place itself materially relevant. Response shape note: returns a structured envelope (`results`, `total_count`) with one result row.",
     {
       place_id: z.string().describe("The place_id to look up (e.g. 'place-harbor-district'). Use list_places to find valid IDs."),
     },
@@ -480,9 +488,17 @@ export function registerSearchTools(s, {
         tags: tags.length ? tags : undefined,
         notes: notes || undefined,
         supporting_notes: supportingNotes.length ? supportingNotes : undefined,
-        next_step: "Use find_scenes with related filters to locate scenes where this place matters, then open targeted scenes with get_scene_prose when prose context is needed.",
       };
-      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      return {
+        content: [{
+          type: "text",
+          text: JSON.stringify({
+            results: [result],
+            total_count: 1,
+            next_step: "Use find_scenes with related filters to locate scenes where this place matters, then open targeted scenes with get_scene_prose when prose context is needed.",
+          }, null, 2),
+        }],
+      };
     }
   );
 
@@ -635,7 +651,7 @@ export function registerSearchTools(s, {
   // ---- list_scene_references -----------------------------------------------
   s.tool(
     "list_scene_references",
-    "List direct reference documents linked from a scene via metadata (for example, reference_ids). Returns only one-hop scene -> reference links and does not recursively traverse related references. If scene IDs are reused across projects, omitting project_id returns CONFLICT with candidate project_ids.",
+    "List direct reference documents linked from a scene via metadata (for example, reference_ids). Returns only one-hop scene -> reference links and does not recursively traverse related references. If scene IDs are reused across projects, omitting project_id returns CONFLICT with candidate project_ids. Response shape note: returns a structured envelope (`results`, `total_count`) plus the resolved `scene_id` and `project_id` context.",
     {
       scene_id: z.string().describe("Scene ID to inspect."),
       project_id: z.string().optional().describe("Optional project ID to disambiguate duplicate scene IDs across projects."),
@@ -714,9 +730,10 @@ export function registerSearchTools(s, {
         content: [{
           type: "text",
           text: JSON.stringify({
+            results: references,
+            total_count: references.length,
             scene_id: scene.scene_id,
             project_id: scene.project_id,
-            references,
           }, null, 2),
         }],
       };
@@ -869,7 +886,7 @@ export function registerSearchTools(s, {
   // ---- get_relationship_arc ------------------------------------------------
   s.tool(
     "get_relationship_arc",
-    "Show how the relationship between two characters evolves across scenes, in order. Uses explicitly recorded relationship entries — returns nothing if no entries exist yet. Use list_characters to get character_id values.",
+    "Show how the relationship between two characters evolves across scenes, in order. Uses explicitly recorded relationship entries — returns nothing if no entries exist yet. Use list_characters to get character_id values. Response shape note: returns a structured envelope { results, total_count, from_character, to_character }.",
     {
       from_character: z.string().describe("character_id of the first character (e.g. 'char-sebastian')."),
       to_character:   z.string().describe("character_id of the second character (e.g. 'char-mira-nystrom')."),
@@ -892,7 +909,7 @@ export function registerSearchTools(s, {
       if (rows.length === 0) {
         return errorResponse("NO_RESULTS", `No relationship data found between '${from_character}' and '${to_character}'.`);
       }
-      return { content: [{ type: "text", text: JSON.stringify(rows, null, 2) }] };
+      return { content: [{ type: "text", text: JSON.stringify({ results: rows, total_count: rows.length, from_character, to_character }, null, 2) }] };
     }
   );
 

--- a/src/tools/search.js
+++ b/src/tools/search.js
@@ -886,7 +886,7 @@ export function registerSearchTools(s, {
   // ---- get_relationship_arc ------------------------------------------------
   s.tool(
     "get_relationship_arc",
-    "Show how the relationship between two characters evolves across scenes, in order. Uses explicitly recorded relationship entries — returns nothing if no entries exist yet. Use list_characters to get character_id values. Response shape note: returns a structured envelope { results, total_count, from_character, to_character }.",
+    "Show how the relationship between two characters evolves across scenes, in order. Uses explicitly recorded relationship entries — returns a NO_RESULTS error if no entries exist yet. Use list_characters to get character_id values. Response shape note: returns a structured envelope { results, total_count, from_character, to_character }.",
     {
       from_character: z.string().describe("character_id of the first character (e.g. 'char-sebastian')."),
       to_character:   z.string().describe("character_id of the second character (e.g. 'char-mira-nystrom')."),


### PR DESCRIPTION
## Summary

- Normalizes four metadata-read tools to return structured envelopes `{ results, total_count, ... }` instead of flat objects or raw arrays.
- Tools affected: `get_character_sheet`, `get_place_sheet`, `list_scene_references`, `get_relationship_arc`.
- Updates integration and unit tests to assert envelope shapes.
- Regenerates `docs/tools.md` and adds README migration notes with safe parsing patterns.
- Adds release log entry in `docs/release-log.md`.

## Motivation

Prior to this change, metadata-read tools returned inconsistent shapes: some returned flat objects, others raw arrays, and others already used envelopes. This forced integrations and agents to maintain per-tool parsing logic. Standardizing on `{ results, total_count }` reduces cognitive overhead and makes downstream parsing more robust.

## Implementation

Shape changes only — no semantic, filtering, ranking, or ordering changes:

- `get_character_sheet`: `{ field: value, ... }` → `{ results: [row], total_count: 1, next_step }`
- `get_place_sheet`: same pattern as above
- `list_scene_references`: `{ references, scene_id, project_id }` → `{ results, total_count, scene_id, project_id }`
- `get_relationship_arc`: raw JSON array → `{ results, total_count, from_character, to_character }`

Tool descriptions updated to document the response envelope.

## Testing

- `npm test`: 204 pass, 0 fail
- Integration tests in `search.test.mjs` and `metadata.test.mjs` updated to assert envelope shape.
- Unit tests in `reference-tools.test.mjs` updated to assert envelope shape.

## Risks and tradeoffs

Breaking change for any integration that parses these four tools' raw output directly. Migration guidance and safe parsing patterns are documented in `README.md` under the Breaking changes section.

## Follow-up

- Consider adding explicit envelope shape assertions as a guardrail for future tools (Milestone D from roadmap).