### PR TITLE
docs(prd): close out beta-reader accountability feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ sync/
 txt/
 my-project-sync/
 tmp/
+.vscode/settings.json

--- a/PRD.md
+++ b/PRD.md
@@ -21,11 +21,13 @@ The writing environment is a plain-text sync folder, integrated with Scrivener v
 Completed feature summaries now live in [docs/prd/completed-features.md](docs/prd/completed-features.md).
 
 Core completed areas:
+
 - [Metadata Architecture & Ownership](docs/prd/done/metadata.md)
 - [Import & Sync Operations](docs/prd/done/import-sync.md)
 - [Prose Editing & Version Control](docs/prd/done/editing.md)
 - [Search, Querying & Analysis](docs/prd/done/search-analysis.md)
 - [Review Bundles for Editorial Workflows](docs/prd/done/review-bundles.md)
+- [Beta Reader Accountability and Book-Like Layout](docs/prd/done/beta-reader-accountability-layout.md)
 - [Scrivener Direct Extraction](docs/prd/done/scrivener-direct-extraction-beta.md)
 - [Reference Document Querying](docs/prd/done/reference-docs.md)
 - [Guideline Generation](docs/prd/done/guideline-generation.md)
@@ -63,12 +65,14 @@ Semantic search for queries that require understanding meaning, not just keyword
 ## Open Questions & Ideas
 
 See [ideas-and-questions.md](docs/prd/inbox/ideas-and-questions.md) for:
+
 - Resolved design questions (enrichment model, sidecar files, database inclusion)
 - Deferred edge cases (mass reorders, circular relationships, multi-book arcs)
 - Feature ideas (tag enhancements, relationship graphs, continuity checker)
 - Operational improvements (first-time setup, permission warnings)
 
 Additional completed structural proposal:
+
 - [Root Structure Reorganization](docs/prd/done/root-structure-reorganization.md)
 
 ---
@@ -104,6 +108,7 @@ Writing MCP is now in continuous development rather than sequential phase delive
 ## For More Details
 
 - [Completed Features Index](docs/prd/completed-features.md) — shipped capability summaries and links
+- [Beta Reader Accountability and Book-Like Layout](docs/prd/done/beta-reader-accountability-layout.md) — chapter-scoped beta packets with per-page accountability and book-like PDF defaults
 - [OpenClaw Integration](docs/prd/in-progress/openclaw-integration.md) — deployment and runtime integration
 - [Client-Agnostic Setup Contract](docs/prd/in-progress/client-agnostic-setup.md) — shared setup contract and client-hosted setup UI direction
 - [Open Ideas](docs/prd/inbox/ideas-and-questions.md) — design questions, feature ideas

--- a/docs/prd/completed-features.md
+++ b/docs/prd/completed-features.md
@@ -11,6 +11,7 @@ Use this page when you want shipped capability summaries and links to the underl
 How metadata is stored, managed, and kept in sync with prose.
 
 Highlights:
+
 - Tier 1 (structural) and Tier 2 (editorial) metadata split
 - Sidecar-based storage with `.meta.yaml`
 - Auto-migration from legacy frontmatter
@@ -21,6 +22,7 @@ Highlights:
 How manuscripts are imported from Scrivener and synced into the indexed workspace.
 
 Highlights:
+
 - SQLite index with universe/project/scene/character/place/thread schema
 - Scrivener binder-ID based identity
 - World folder structure for characters, places, and reference docs
@@ -31,6 +33,7 @@ Highlights:
 Two-step editing workflow with git-backed history.
 
 Highlights:
+
 - `propose_edit` to `commit_edit` confirmation flow
 - Pre-edit snapshots before every commit
 - Manual snapshots for restore points
@@ -41,6 +44,7 @@ Highlights:
 Fast metadata-first discovery with prose loaded on demand.
 
 Highlights:
+
 - `find_scenes()` with metadata filters
 - `get_arc()` for ordered scene journeys
 - `search_metadata()` with FTS5
@@ -51,19 +55,29 @@ Highlights:
 Deterministic bundle generation for outline discussion, detailed editing, and beta reading.
 
 Highlights:
+
 - `preview_review_bundle` planning step
 - `create_review_bundle` artifact generation
 - PDF export with manifest and review companion files
 - Strictness modes for stale or incomplete metadata
 
-Known issue:
-- Logline currently renders in all bundle profiles and should be limited to `outline_discussion`.
+### 🔐 [Beta Reader Accountability and Book-Like Layout](done/beta-reader-accountability-layout.md)
+
+Chapter-scoped beta packets with per-page accountability and improved PDF reading ergonomics.
+
+Highlights:
+
+- `chapters` filter support for one/few chapter beta bundles
+- Per-page PDF footer accountability with recipient and fingerprint token
+- Manifest fingerprint metadata for provenance and traceability
+- 6x9 book-like PDF geometry for beta profile readability
 
 ### 🗂️ [Scrivener Direct Extraction](done/scrivener-direct-extraction-beta.md)
 
 Direct ingestion from `.scriv` and `.scrivx` internals for richer metadata extraction.
 
 Highlights:
+
 - Official direct binder ingestion path
 - Richer metadata than External Folder Sync alone
 - Safeguards to avoid schema-coupled regressions
@@ -73,6 +87,7 @@ Highlights:
 Reference note indexing and linkage for world-building, continuity, and research material.
 
 Highlights:
+
 - Query reference docs alongside manuscript metadata
 - Link reference docs to scenes
 - Support continuity and rules-of-the-world questions
@@ -84,6 +99,7 @@ Highlights:
 Reusable prose styleguide system with config resolution, skill generation, and edit-time enforcement behavior.
 
 Follow-up work:
+
 - [Client-Agnostic Setup Contract](in-progress/client-agnostic-setup.md)
 
 ## Additional Completed PRDs

--- a/docs/prd/done/beta-reader-accountability-layout.md
+++ b/docs/prd/done/beta-reader-accountability-layout.md
@@ -1,6 +1,16 @@
 # Beta Reader Accountability and Book-Like Layout
 
-**Status:** 📋 Proposed (inbox)
+**Status:** ✅ Done (shipped 2026-05-08)
+
+## Implementation Status
+
+Implemented across planner, renderer, writer, tool schemas, and tests.
+
+- Tool contract supports `chapters` and `beta_accountability` for beta bundles.
+- Beta PDF output includes per-page visible accountability footer and per-page fingerprint tokens.
+- Manifest includes fingerprint metadata for accountable beta PDF bundles.
+- Beta PDF layout uses book-like defaults (6x9 page geometry).
+- Release entry: [Release Log](../../release-log.md)
 
 ## Problem
 
@@ -99,11 +109,11 @@ These are defaults, not user-exposed publishing controls.
 2. Book-like smaller pages improve readability but increase total page count.
 3. Deterministic tokening improves traceability but requires careful input normalization to avoid accidental drift.
 
-## Open Decisions
+## Resolved Decisions
 
-1. Should footer appear on cover and notice pages, or prose pages only?
-2. Should the token include a human-recognizable recipient fragment (for example initials), or remain opaque?
-3. Should chapter selection add explicit `chapters: number[]` for review bundles, or rely on repeated existing filtering calls?
+1. Footer appears on all beta PDF pages (cover, notice, and prose pages).
+2. Token remains opaque and readable (`BR-...-P###`) without embedding recipient fragments.
+3. Chapter selection uses explicit `chapters: number[]` support, with deterministic normalization and validation.
 
 ## Acceptance Criteria
 
@@ -134,8 +144,8 @@ These are defaults, not user-exposed publishing controls.
 
 ## Related
 
-- [Review Bundles for Editorial Workflows](../done/review-bundles.md)
-- [Review Bundles — Implementation Checklist](../done/review-bundles-implementation.md)
+- [Review Bundles for Editorial Workflows](./review-bundles.md)
+- [Review Bundles — Implementation Checklist](./review-bundles-implementation.md)
 - [PRD Overview](../../../PRD.md)
 
 ## Implementation Plan

--- a/docs/prd/inbox/ideas-and-questions.md
+++ b/docs/prd/inbox/ideas-and-questions.md
@@ -12,7 +12,7 @@ Unresolved design questions, feature ideas, and edge cases that haven't yet been
 
 **Q:** Where do pending `propose_edit` proposals live? In-memory (lost on restart) or persisted in SQLite?
 
-**Status:** In-memory is simpler but means a restart between propose and commit loses the proposal. Acceptable for Phase 3.
+**Status:** In-memory is simpler but means a restart between propose and commit loses the proposal. Acceptable under current workflow assumptions.
 
 **Future:** Consider persistent proposal storage if users report frequent restarts losing work.
 
@@ -41,6 +41,7 @@ When a character appears across multiple books (series with shared universe), sh
 ### Tagging System Enhancement
 
 Current tags are free-form strings. Could benefit from:
+
 - Predefined tag categories (tone, pacing, theme, etc.)
 - Tag autocomplete during metadata edits
 - Tag migration/renaming tools
@@ -50,6 +51,7 @@ Current tags are free-form strings. Could benefit from:
 ### Relationship Strength Indicators
 
 Currently `character_relationships` stores strength as low/medium/high. Could be enhanced to:
+
 - Show strength trend over time (strengthening? weakening?)
 - Visualize relationship web as a graph
 - Query by relationship type
@@ -59,6 +61,7 @@ Currently `character_relationships` stores strength as low/medium/high. Could be
 ### Continuity Checker
 
 Tool to surface potential continuity issues:
+
 - Character appears in scene but not in character list
 - Place mentioned in prose but not in places list
 - Timeline gaps or inconsistencies
@@ -68,31 +71,34 @@ Tool to surface potential continuity issues:
 ### Comparative Scene Analysis
 
 Tool to compare two scenes:
+
 - Prose style similarity
 - Character behavior consistency
 - Setting/atmosphere contrast
 
-**Priority:** Low — deferred to Phase 4+ with embeddings.
+**Priority:** Low — deferred backlog item, likely revisited with embeddings work.
 
 ## Operational Notes
 
 ### First-Time Setup Friction
 
 Users report initial sync folder setup requires:
+
 1. Manual git init
 2. Manual folder structure creation
 3. Manual Scrivener External Folder Sync configuration
 
-**Potential improvement:** Add an `init_project` tool that scaffolds folder structure and guides Scrivener setup. (Phase 4A candidate)
+**Potential improvement:** Add an `init_project` tool that scaffolds folder structure and guides Scrivener setup (future backlog candidate).
 
 ### Permission Warnings
 
 Current behavior: `get_runtime_config` surfaces permission issues but doesn't help fix them. Could provide:
+
 - Suggested `chmod` commands
 - Volumes that need remounting
 - Folder initialization steps
 
-**Status:** Deferred to Phase 4A improvements.
+**Status:** Deferred backlog improvement.
 
 ## Related
 

--- a/src/test/integration/review-bundles.test.mjs
+++ b/src/test/integration/review-bundles.test.mjs
@@ -357,6 +357,35 @@ describe("create_review_bundle tool", () => {
       const inflatedStreamsText = extractPdfFlateText(pdfBytes);
       const decodedPdfText = decodePdfHexText(inflatedStreamsText);
       assert.match(decodedPdfText, /For: Jordan Example \| Fingerprint: BR-[A-Z0-9-]+-P\d{3}/);
+
+      const renderedFingerprints = decodedPdfText.match(/Fingerprint:\s*BR-[A-Z0-9-]+-P\d{3}/g) ?? [];
+      assert.equal(renderedFingerprints.length, manifest.fingerprint.page_tokens.length);
+      for (const entry of manifest.fingerprint.page_tokens) {
+        assert.match(decodedPdfText, new RegExp(`Fingerprint:\\s*${entry.token}`));
+      }
+    } finally {
+      fs.rmSync(outDir, { recursive: true, force: true });
+    }
+  });
+
+  test("beta PDF uses 6x9 page size media box", async () => {
+    const outDir = fs.mkdtempSync(path.join(writeSyncDir, "review-bundles-beta-pdf-layout-"));
+    try {
+      const text = await callWriteTool("create_review_bundle", {
+        project_id: "test-novel",
+        profile: "beta_reader_personalized",
+        recipient_name: "Jordan Example",
+        output_dir: outDir,
+        format: "pdf",
+      });
+      const parsed = JSON.parse(text);
+
+      assert.ok(parsed.ok, JSON.stringify(parsed));
+      assert.ok(parsed.output_paths?.bundle_pdf);
+
+      const pdfBytes = fs.readFileSync(parsed.output_paths.bundle_pdf);
+      const rawPdf = pdfBytes.toString("latin1");
+      assert.match(rawPdf, /\/MediaBox\s*\[\s*0\s+0\s+432(?:\.0+)?\s+648(?:\.0+)?\s*\]/);
     } finally {
       fs.rmSync(outDir, { recursive: true, force: true });
     }

--- a/src/test/unit/review-bundles.test.mjs
+++ b/src/test/unit/review-bundles.test.mjs
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import os from "node:os";
 import fs from "node:fs";
 import path from "node:path";
-import { buildReviewBundlePlan, renderReviewBundleMarkdown, renderReviewBundlePdf, ReviewBundlePlanError, buildPageFingerprintToken, buildFingerprintSeed, buildFingerprintSeedHash, extractSceneDateline } from "../../review-bundles/review-bundles.js";
+import { buildReviewBundlePlan, renderReviewBundleMarkdown, renderReviewBundlePdf, renderReviewBundlePdfWithMetadata, ReviewBundlePlanError, buildPageFingerprintToken, buildFingerprintSeed, buildFingerprintSeedHash, extractSceneDateline } from "../../review-bundles/review-bundles.js";
 import { insertTestScene, setupReviewBundleTestDb } from "../helpers/db.js";
 import { decodePdfHexText, extractPdfFlateText } from "../helpers/pdf.js";
 
@@ -797,6 +797,65 @@ describe("review-bundle fingerprint helpers", () => {
 
     assert.equal(token1a, token1b);
     assert.notEqual(token1a, token2);
+  });
+
+  test("renderReviewBundlePdfWithMetadata is reproducible for fixed inputs and varies by recipient", async () => {
+    const db = setupReviewBundleTestDb();
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "bundle-fingerprint-repro-"));
+    const scenePath = path.join(tempDir, "sc-001.md");
+    const longProse = Array.from(
+      { length: 140 },
+      (_, index) => `Paragraph ${index + 1}: The rain kept falling over the harbor while the ferry horn echoed.`
+    ).join("\n\n");
+    fs.writeFileSync(scenePath, longProse, "utf8");
+
+    try {
+      const now = new Date().toISOString();
+      db.prepare(`
+        INSERT INTO scenes (
+          scene_id, project_id, title, part, chapter, timeline_position, word_count,
+          file_path, prose_checksum, metadata_stale, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        "sc-001",
+        "test-novel",
+        "Fingerprint Repro Test",
+        1,
+        1,
+        1,
+        3000,
+        scenePath,
+        "deadbeef",
+        0,
+        now
+      );
+
+      const generatedAt = "2026-01-01T00:00:00.000Z";
+      const syncDir = fs.realpathSync.native(tempDir);
+      const planA = buildReviewBundlePlan(db, {
+        project_id: "test-novel",
+        profile: "beta_reader_personalized",
+        recipient_name: "Jordan Example",
+      });
+
+      const a1 = await renderReviewBundlePdfWithMetadata(db, planA, { generatedAt, syncDir });
+      const a2 = await renderReviewBundlePdfWithMetadata(db, planA, { generatedAt, syncDir });
+
+      assert.ok(Array.isArray(a1.fingerprint?.page_tokens));
+      assert.ok(a1.fingerprint.page_tokens.length >= 1);
+      assert.deepEqual(a1.fingerprint.page_tokens, a2.fingerprint.page_tokens);
+
+      const planB = buildReviewBundlePlan(db, {
+        project_id: "test-novel",
+        profile: "beta_reader_personalized",
+        recipient_name: "Taylor Example",
+      });
+      const b1 = await renderReviewBundlePdfWithMetadata(db, planB, { generatedAt, syncDir });
+      assert.notDeepEqual(a1.fingerprint.page_tokens, b1.fingerprint.page_tokens);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+      db.close();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

- Marks beta-reader accountability and book-like layout as shipped (2026-05-08) by moving the PRD from inbox to done.
- Resolves the three open decisions recorded in the PRD (footer page scope, token opacity, chapter selection approach).
- Adds an implementation status summary and fixes relative links after the file move.
- Updates `completed-features.md` to include the new feature and removes the stale logline known-issue note (fixed in shipping).
- Adds the feature to the `PRD.md` completed capabilities list.
- Replaces outdated phase-based wording in `ideas-and-questions.md` with current backlog language.
- Ignores `.vscode/settings.json` in `.gitignore`.

## Motivation

The feature shipped on 2026-05-08 but the PRD remained in inbox and the product docs (PRD, completed-features index, ideas doc) were not updated to reflect the delivered state. The logline known-issue note in completed-features was also stale — that behavior was fixed in the same delivery.

## Implementation

- `docs/prd/inbox/beta-reader-accountability-layout.md` → `docs/prd/done/` (rename + edits)
  - Status header updated to ✅ Done
  - Open Decisions section replaced with Resolved Decisions
  - Implementation Status summary block added
  - Related links corrected after move
- `docs/prd/completed-features.md`: new section for beta accountability; stale known-issue removed; list spacing fixed for lint.
- `PRD.md`: beta accountability added to core completed areas and For More Details links; list spacing fixed.
- `docs/prd/inbox/ideas-and-questions.md`: four phase references updated to backlog language; list spacing fixed.
- `src/test/integration/review-bundles.test.mjs`: added per-page token coverage assertion (every manifest token appears in PDF), added 6x9 MediaBox layout assertion.
- `src/test/unit/review-bundles.test.mjs`: added reproducibility + variation test using `renderReviewBundlePdfWithMetadata` with fixed `generatedAt`.

## Testing

- `npm test -- src/test/unit/review-bundles.test.mjs src/test/integration/review-bundles.test.mjs` — all tests passed.
- Editor diagnostics: no errors on any changed file.

## Risks and tradeoffs

- No behavior changes; docs and test-coverage only.
- The logline known-issue removal is justified: the guardrail was shipped and tested in the beta accountability release.

## Follow-up

- None.