### PR TITLE
docs(skills): align release-log path guidance

### DIFF
--- a/release-log.md
+++ b/release-log.md
@@ -8,6 +8,14 @@ This complements `CHANGELOG.md`:
 
 ## Unreleased
 
+### 2026-05-16 — Align release-log skill guidance with the root log file
+
+- What changed: Updated the PR-description and release-log skills so maintainer-facing PR guidance points to `release-log.md` instead of the old `docs/release-log.md` path.
+- Why it matters: Future PRs and AI-assisted maintainer workflows now update the actual human release log instead of following stale instructions.
+- Who is affected: Maintainers and contributors preparing PR descriptions or release-log entries.
+- Action needed: None.
+- PR: TBD
+
 ### 2026-05-16 — Reorganize product docs around managed structure design
 
 - What changed: Reworked the product documentation set around `PRODUCT.md`, `FEATURES.md`, `BACKLOG.md`, and the new `docs/foundations/managed-structure-contract.md`; moved guides, agent docs, and initiative PRDs into clearer directories; and reclassified the old data-ownership writeup as historical context instead of an active design authority.

--- a/release-log.md
+++ b/release-log.md
@@ -14,7 +14,7 @@ This complements `CHANGELOG.md`:
 - Why it matters: Future PRs and AI-assisted maintainer workflows now update the actual human release log instead of following stale instructions.
 - Who is affected: Maintainers and contributors preparing PR descriptions or release-log entries.
 - Action needed: None.
-- PR: TBD
+- PR: [#195](https://github.com/hannasdev/mcp-writing/pull/195)
 
 ### 2026-05-16 — Reorganize product docs around managed structure design
 

--- a/release-log.md
+++ b/release-log.md
@@ -6,12 +6,10 @@ This complements `CHANGELOG.md`:
 - `CHANGELOG.md` is technical and release-oriented.
 - This log is plain-language and outcome-oriented.
 
-## Unreleased
+### 2026-05-16 — Align release-log guidance with PR-time updates
 
-### 2026-05-16 — Align release-log skill guidance with the root log file
-
-- What changed: Updated the PR-description and release-log skills so maintainer-facing PR guidance points to `release-log.md` instead of the old `docs/release-log.md` path.
-- Why it matters: Future PRs and AI-assisted maintainer workflows now update the actual human release log instead of following stale instructions.
+- What changed: Updated the PR-description and release-log skills so maintainer-facing PR guidance points to the root `release-log.md` file, and removed the stale staging section from the human release log.
+- Why it matters: Future PRs and AI-assisted maintainer workflows now update the actual human release log directly, matching the PR-time update model without implying a separate release-time cleanup step.
 - Who is affected: Maintainers and contributors preparing PR descriptions or release-log entries.
 - Action needed: None.
 - PR: [#195](https://github.com/hannasdev/mcp-writing/pull/195)

--- a/skills/pr-description/SKILL.md
+++ b/skills/pr-description/SKILL.md
@@ -19,7 +19,7 @@ Before writing the PR description:
 4. Identify test coverage and validation performed.
 5. Identify risks, tradeoffs, and follow-up work.
 6. Ensure the PR is scoped to one concern.
-7. If user-facing or maintainer-facing behavior changed, update `docs/release-log.md` using `skills/release-log/SKILL.md`.
+7. If user-facing or maintainer-facing behavior changed, update `release-log.md` using `skills/release-log/SKILL.md`.
 
 ## PR title
 

--- a/skills/release-log/SKILL.md
+++ b/skills/release-log/SKILL.md
@@ -28,7 +28,7 @@ Before writing the release log entry:
 2. Review the PR description (`Summary`, `Motivation`, `Implementation`, `Testing`, `Risks and tradeoffs`, `Follow-up`).
 3. Identify concrete user or maintainer value.
 4. Identify who is affected and whether any action is required.
-5. Add/update one entry in `release-log.md` under `## Unreleased`.
+5. Add/update one entry near the top of `release-log.md`.
 
 ## Entry format
 
@@ -45,7 +45,7 @@ Use this structure:
 ```
 
 Rules:
-- Newest entries first under `## Unreleased`.
+- Newest entries first, directly below the introductory note.
 - Use plain language; avoid internal implementation detail unless it changes behavior.
 - Keep bullets outcome-focused.
 - If no action is required, write `Action needed: None`.

--- a/skills/release-log/SKILL.md
+++ b/skills/release-log/SKILL.md
@@ -28,7 +28,7 @@ Before writing the release log entry:
 2. Review the PR description (`Summary`, `Motivation`, `Implementation`, `Testing`, `Risks and tradeoffs`, `Follow-up`).
 3. Identify concrete user or maintainer value.
 4. Identify who is affected and whether any action is required.
-5. Add/update one entry in `docs/release-log.md` under `## Unreleased`.
+5. Add/update one entry in `release-log.md` under `## Unreleased`.
 
 ## Entry format
 
@@ -64,7 +64,7 @@ Bad:
 
 ## Final response after updating release log
 
-After updating `docs/release-log.md`, summarize:
+After updating `release-log.md`, summarize:
 - the new release-log entry title/date;
 - intended audience;
 - any required user action (or `None`).


### PR DESCRIPTION
## Summary

- Updates the PR-description and release-log skills to point at the root `release-log.md` file.
- Removes the stale release-log staging section concept so entries are written directly in newest-first order.
- Adds a human release-log entry for the maintainer-facing workflow guidance change.

## Motivation

The human release log lives at the repository root and is updated together with relevant PRs. The previous skill guidance still pointed at an old docs path and treated the log as if entries lived in a separate staging bucket, which did not match the actual workflow.

## Implementation

- Replaced stale release-log path references in the PR-description and release-log skills.
- Removed staging-section language from the release-log skill.
- Removed the staging heading from `release-log.md` so entries begin directly below the introductory note.
- Updated the PR #195 release-log entry to describe the full workflow cleanup.

## Testing

- `rg -n 'Unreleased|unreleased|docs/release-log\\.md|PR: TBD' release-log.md skills AGENTS.md MAINTAINERS.md .github docs README.md -g '!node_modules/**'`
- `git diff --check`

## Risks and tradeoffs

Low risk; this is documentation and skill guidance only. Removing the staging heading means the human release log no longer visually distinguishes merged/unmerged PR entries, but that matches the current PR-time update model and avoids implying a release-time cleanup step.

## Follow-up

None.