### PR TITLE
docs: add target architecture migration snapshot

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -22,6 +22,12 @@ Track the remaining follow-up work around first-class chapters, deferred divisio
 
 **Status:** Deferred backlog (not active). Canonical chapters and epigraphs, `chapter_id` targeting, dedicated chapter/epigraph tools, and chapter-aware bundle rendering have already shipped; remaining follow-up work is paused pending structural design consolidation.
 
+### 🏗️ [Target Architecture Migration](docs/initiatives/backlog/target-architecture-migration/prd.md) 📋
+
+Preparatory refactoring and staged migration work that moves structural manuscript workflows toward the conceptual target architecture without committing too early to storage or public API changes.
+
+**Status:** Deferred backlog (not active). Early milestones focus on behavior-preserving refactors, characterization tests, and explicit structure boundaries before later compatibility tightening or storage-model decisions.
+
 ### 📊 [Embedding-Based Search](docs/initiatives/backlog/embeddings-search/prd.md) 📋
 
 Semantic search for queries that require understanding meaning, not just keywords.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -40,5 +40,6 @@ For structural manuscript state, use [Managed Structure Contract](docs/foundatio
 
 - [Features](FEATURES.md) — shipped product capabilities and links to completed initiative docs
 - [Backlog](BACKLOG.md) — deferred product work that is not currently active
+- [Conceptual Target Architecture](docs/foundations/target-architecture.md) — idealized architectural model for evaluating future structure, tooling, and workflow decisions
 - [Managed Structure Contract](docs/foundations/managed-structure-contract.md) — design boundaries for structural mutation, generated transparency, import, and maintenance workflows
 - [Agent Tool Reference](docs/agents/tools.md) — generated tool catalog including `describe_workflows`, the main AI navigation entry-point

--- a/docs/foundations/managed-structure-contract.md
+++ b/docs/foundations/managed-structure-contract.md
@@ -126,7 +126,8 @@ This contract refines existing ownership principles:
 ## Related
 
 - [Product Overview](../../PRODUCT.md)
-- [Historical Data Ownership Map](../history/data-ownership.md)
+- [Conceptual Target Architecture](./target-architecture.md)
+- [Data Ownership](./data-ownership.md)
 - [Chapter Structure Follow-up](../initiatives/backlog/chapter-structure/prd.md)
 - [Metadata Architecture & Ownership](../initiatives/done/metadata-architecture/prd.md)
 - [Import & Sync Operations](../initiatives/done/import-sync/prd.md)

--- a/docs/foundations/managed-structure-contract.md
+++ b/docs/foundations/managed-structure-contract.md
@@ -127,7 +127,7 @@ This contract refines existing ownership principles:
 
 - [Product Overview](../../PRODUCT.md)
 - [Conceptual Target Architecture](./target-architecture.md)
-- [Data Ownership](./data-ownership.md)
+- [Data Ownership](../history/data-ownership.md)
 - [Chapter Structure Follow-up](../initiatives/backlog/chapter-structure/prd.md)
 - [Metadata Architecture & Ownership](../initiatives/done/metadata-architecture/prd.md)
 - [Import & Sync Operations](../initiatives/done/import-sync/prd.md)

--- a/docs/foundations/target-architecture.md
+++ b/docs/foundations/target-architecture.md
@@ -252,5 +252,5 @@ In practical terms, it supports:
 
 - [Product Overview](../../PRODUCT.md)
 - [Managed Structure Contract](./managed-structure-contract.md)
-- [Data Ownership](./data-ownership.md)
+- [Data Ownership](../history/data-ownership.md)
 - [Chapter Structure Follow-up](../initiatives/backlog/chapter-structure/prd.md)

--- a/docs/foundations/target-architecture.md
+++ b/docs/foundations/target-architecture.md
@@ -1,0 +1,256 @@
+# Conceptual Target Architecture
+
+**Status:** Design reference
+
+This document captures the conceptual target architecture for Writing MCP based on the current design discussion.
+It is intentionally idealized.
+Use it to evaluate future initiatives, migration choices, and tooling boundaries without overfitting to the current filesystem layout or implementation constraints.
+
+## Core Idea
+
+The manuscript is a structured domain model with prose attachments, not a folder tree with metadata sprinkled around it.
+
+The filesystem still matters, but primarily as:
+- storage
+- audit trail
+- portability layer
+- generated transparency surface
+
+It should not be the primary control plane for structural manuscript state.
+
+## High-Level Shape
+
+```mermaid
+flowchart TB
+  Human["Human user"] --> AI["AI agent"]
+  AI --> MCP["MCP control plane"]
+
+  MCP --> Canonical["Canonical project model"]
+  MCP --> Prose["Authored prose store"]
+
+  Canonical --> Derived["Derived views and indexes"]
+  Prose --> Derived
+
+  Import["Import adapters<br/>Scrivener, legacy folders, markdown"] --> MCP
+  Canonical --> Export["Export adapters<br/>review bundles, markdown, sharing outputs"]
+
+  Human --> Read["Read surfaces<br/>reports, exports, generated views"]
+  AI --> Read
+  Derived --> Read
+  Export --> Read
+```
+
+## Architectural Layers
+
+### 1. MCP Control Plane
+
+All structural mutations should go through sanctioned MCP workflows.
+
+This includes:
+- chapter creation and rename
+- chapter order changes
+- scene-to-chapter assignment
+- epigraph attachment
+- division membership
+- metadata relationship changes
+- future structural entities
+
+This rule applies equally to human users and AI agents.
+The AI should not become a privileged second manual editor just because it is capable of touching raw files directly.
+
+### 2. Canonical Project Model
+
+The canonical project model is the real source of truth for structural state.
+
+It owns:
+- durable IDs
+- ordering
+- relationships
+- canonical metadata
+- structural invariants
+
+Representative entity classes include:
+- project
+- division
+- chapter
+- scene
+- epigraph
+- character
+- place
+- thread
+- style and configuration artifacts
+
+The key separation is:
+- identity is not title
+- order is not folder name
+- membership is not physical containment
+- readable representation is not authority
+
+### 3. Prose Store
+
+Prose is different from structure.
+
+It should remain:
+- human-meaningful
+- inspectable
+- editable in supported workflows
+
+But prose should be attached to stable structural IDs rather than acting as the structure model itself.
+That allows prose to stay plain-text and author-facing while structure remains validated and command-driven.
+
+### 4. Derived Views
+
+Derived views are generated transparency surfaces, not sources of truth.
+
+Examples:
+- chapter overview
+- outline and index views
+- diagnostics reports
+- search indexes
+- review bundles
+- generated agent-facing tool docs
+- release-oriented summaries
+
+They exist to make the project understandable and reviewable without promoting the visible representation into the domain model.
+
+Rule:
+- generated transparency is good
+- generated authority is not
+
+### 5. Import Adapters
+
+Import is a special mode.
+
+Import may cautiously infer structure from:
+- Scrivener sync output
+- legacy folder layouts
+- historical naming
+- metadata sidecars
+- existing prose
+
+But import should:
+- explain ambiguity
+- surface warnings
+- draft canonical state before blessing it
+- stop being authoritative once canonical state is established
+
+Import is a bridge from messy reality, not a permanent mutation model.
+
+### 6. Export Adapters
+
+Exports are projections for humans or external tools.
+
+Examples:
+- review bundle outputs
+- shareable manuscript exports
+- Scrivener-compatible outputs
+- generated summaries and reports
+
+Exports should read canonical state and prose, but they should not redefine either one.
+
+## Artifact Classes
+
+| Artifact class | Examples | Mutation rule |
+| --- | --- | --- |
+| Authored prose | Scene text, epigraph text | Editable in supported prose workflows |
+| Canonical structure | IDs, order, membership, links | MCP-only mutation |
+| Derived views | Reports, indexes, bundles, generated docs | Regenerated from canonical state |
+| Migration inputs | Scrivener output, legacy folders, old numbering | Interpreted during import only |
+
+## Workflow Zones
+
+### Setup and Import
+
+Setup and import are intentionally more permissive about interpretation.
+Their job is to create canonical state from a less controlled source.
+
+Allowed:
+- infer cautiously from source structure and legacy material
+- surface warnings and ambiguity
+- generate stable canonical identities
+- present a reviewable import result before commitment
+
+### Working on the Project
+
+Daily project work should be strict about structural mutation paths.
+The human expresses intent, the AI resolves targets when needed, and the MCP validates and writes canonical state.
+
+Allowed:
+- read canonical state, prose, and generated views
+- edit prose through supported prose workflows
+- mutate structure through named operations
+- generate diagnostics, bundles, and other read surfaces
+
+### Ongoing Maintenance
+
+Maintenance may inspect broadly, but canonical repair should remain deliberate.
+
+Allowed:
+- lint structure and metadata
+- detect stale or inconsistent derived state
+- regenerate indexes and generated views
+- propose or run explicit repair workflows
+
+Maintenance should not quietly fix canonical structure as a side effect of inspection.
+
+## Filesystem Role
+
+In the target architecture, the filesystem is a representation layer, not the primary structure UI.
+
+That means folder names should not be overloaded to carry:
+- durable identity
+- canonical title
+- canonical order
+- full structure semantics
+
+This is why opaque or semi-opaque storage becomes attractive over time.
+Opacity can be a feature when it signals that the area is managed system state rather than a casual editing surface.
+
+The lost readability should be replaced by:
+- MCP read tools
+- generated views
+- exports
+- diagnostics
+
+## AI Boundary
+
+The architecture must explicitly account for the AI as an actor.
+
+That means:
+- AI may read broadly
+- AI should use MCP workflows for structural writes
+- AI may edit prose where the workflow supports it
+- AI should not patch structural files directly when a sanctioned workflow exists
+- if no sanctioned workflow exists, the AI should expose the product gap rather than improvising
+
+Without this boundary, the system risks protecting itself from human direct editing while leaving the AI as an unsafe shortcut around the entire design.
+
+## Governing Rules
+
+1. The manuscript is a domain model, not a folder tree.
+2. Structure changes go through one trusted mutation path.
+3. Prose and structure have different editing rules.
+4. Filesystem representations are valuable, but not authoritative.
+5. Generated views explain state; they do not define it.
+6. Import may infer; daily work should be explicit.
+7. Maintenance may diagnose broadly; repair should be deliberate.
+8. Humans and AI follow the same structural guardrails.
+
+## What This Architecture Buys Us
+
+This architecture is intended to prevent a visible representation from hardening into the wrong schema.
+
+In practical terms, it supports:
+- title changes without identity drift
+- order changes without misleading path semantics
+- future divisions without repeating the same coupling mistake one level higher
+- generated transparency without split authority
+- AI assistance without AI bypassing structural invariants
+- long-term scaling as manuscript structure becomes richer
+
+## Related
+
+- [Product Overview](../../PRODUCT.md)
+- [Managed Structure Contract](./managed-structure-contract.md)
+- [Data Ownership](./data-ownership.md)
+- [Chapter Structure Follow-up](../initiatives/backlog/chapter-structure/prd.md)

--- a/docs/initiatives/backlog/target-architecture-migration/milestones.md
+++ b/docs/initiatives/backlog/target-architecture-migration/milestones.md
@@ -1,0 +1,285 @@
+# Target Architecture Migration — Milestones
+
+Status: Deferred backlog (not active)  
+Owner: MCP Writing  
+Date: 2026-05-17
+
+This milestone plan intentionally gives early refactoring milestones more detail than later migration work.
+The early milestones should preserve behavior while making the current structure-control boundaries explicit.
+Later milestones remain directional until the earlier seams and diagnostics teach us what needs to change.
+
+## Objective
+
+Stage preparatory refactoring that moves Writing MCP toward the target architecture without over-committing to storage, public API, or Scrivener workflow decisions too early.
+
+## Guardrails
+
+- Preserve existing behavior in M1-M3.
+- Keep refactor-only commits separate from behavior-changing commits where practical.
+- Add characterization tests before risky extractions.
+- Do not remove compatibility paths until explicit replacement workflows exist.
+- Keep the system passing and releasable after each milestone.
+
+## M1 — Name Current Structure Inference Boundaries
+
+Goal: make existing structure inference and indexing behavior easier to understand without changing it.
+
+Deliverables:
+
+- Extract chapter and epigraph inference helpers from generic sync code into a focused structure module.
+- Extract canonical chapter resolution/upsert logic from scene indexing into a focused helper or module.
+- Preserve all current warnings, derived IDs, database writes, and sync results.
+- Add characterization tests for the extracted behavior.
+
+Candidate module names:
+
+- `src/structure/structure-inference.js`
+- `src/structure/chapter-indexing.js`
+
+Acceptance criteria:
+
+- Existing sync behavior is unchanged for explicit chapter folders, legacy chapter paths, epigraph files, and ambiguous chapter order.
+- Tests cover current behavior before the extraction becomes a dependency for later work.
+- `src/sync/sync.js` has less direct responsibility for deciding what structural observations mean.
+
+Test strategy:
+
+- Unit tests for explicit chapter folder inference.
+- Unit tests for legacy path fallback inference.
+- Unit tests for epigraph detection from metadata and filename.
+- Unit tests for unknown or conflicting chapter linkage warnings.
+- Existing sync integration tests pass unchanged.
+
+Out of scope:
+
+- New public tools.
+- New strict mode.
+- Changing whether sync mutates canonical chapter rows.
+
+## M2 — Centralize Structural Sidecar Writes
+
+Goal: stop structural sidecar patches from being spread through generic metadata update paths.
+
+Deliverables:
+
+- Introduce a shared internal helper for scene structure sidecar patches.
+- Route existing writers through the helper where they touch fields such as:
+  - `chapter_id`
+  - `chapter`
+  - `chapter_title`
+  - `part`
+  - `scene_role`
+- Preserve current `update_scene_metadata` public behavior.
+- Preserve current enrichment and batch behavior where they normalize scene metadata.
+
+Candidate helper names:
+
+- `buildSceneStructurePatch`
+- `applySceneChapterFields`
+- `normalizeSceneStructureFields`
+
+Acceptance criteria:
+
+- Current metadata writes produce the same sidecar fields as before.
+- Chapter compatibility behavior remains available.
+- Future explicit structure commands have one obvious helper/service to call.
+
+Test strategy:
+
+- Unit tests for the helper using current sidecar inputs.
+- Integration test proving `update_scene_metadata` still persists canonical `chapter_id` and compatibility fields as today.
+- Existing metadata and styleguide tests pass unchanged.
+
+Out of scope:
+
+- Deprecating `chapter` or `chapter_id` fields on `update_scene_metadata`.
+- Changing sidecar schema.
+
+## M3 — Split Sync Observation From Canonical Mutation Internals
+
+Goal: create internal seams so sync can later observe broadly without always mutating canonical structure.
+
+Deliverables:
+
+- Refactor sync into clearer internal phases:
+  - file scan
+  - metadata/prose read
+  - structure observation
+  - canonical indexing
+  - derived index regeneration
+  - pruning
+  - diagnostics summary
+- Use explicit intermediate result objects for observed structure and diagnostics.
+- Preserve existing sync output and database effects.
+
+Suggested internal concepts:
+
+- `observedChapter`
+- `observedEpigraph`
+- `structureDiagnostic`
+- `canonicalIndexPlan`
+
+Acceptance criteria:
+
+- Sync results and warning summaries remain compatible.
+- Pruning behavior is unchanged.
+- The code can express "observed drift" separately from "mutated canonical state," even if both still happen in this milestone.
+
+Test strategy:
+
+- Characterization tests around sync warning summaries.
+- Integration parity tests for representative project fixtures.
+- Unit tests for diagnostic summary construction if extracted.
+
+Out of scope:
+
+- Read-only sync mode.
+- Strict sync mode.
+- Changing import behavior.
+
+## M4 — Add Read-Only Structure Diagnostics
+
+Goal: expose structure drift and ambiguity without repairing it.
+
+Deliverables:
+
+- Add an internal diagnostics layer, then expose it through a public read-only tool if appropriate.
+- Report categories such as:
+  - duplicate chapter sort indexes
+  - scenes linked to unknown chapters
+  - epigraphs linked to unknown or conflicting chapters
+  - multiple prologue or epilogue roles in one project
+  - folder-derived structure that disagrees with canonical records
+  - numeric compatibility fields that disagree with canonical chapter identity
+- Return actionable next steps without mutating files or database canonical state.
+
+Acceptance criteria:
+
+- Diagnostics can run independently from repair.
+- Diagnostics distinguish observation, derived-state regeneration, and canonical mutation.
+- Ambiguity is reported deterministically enough for an AI agent to explain to a user.
+
+Test strategy:
+
+- Unit tests for each diagnostic category.
+- Integration test on a mixed fixture containing clean structure, ambiguous structure, and stale compatibility fields.
+
+Out of scope:
+
+- Auto-repair.
+- Canonical storage redesign.
+
+## M5 — Introduce Explicit Scene-to-Chapter Mutation
+
+Goal: add the first sanctioned daily-work structural mutation path.
+
+Deliverables:
+
+- Add an explicit scene-to-chapter assignment workflow, likely `assign_scene_to_chapter`.
+- Support clearing a scene chapter link if product direction confirms this should be allowed.
+- Route the command through shared structure patching/indexing helpers.
+- Keep `update_scene_metadata` compatibility behavior working.
+- Update workflow/tool descriptions to steer AI agents toward the explicit operation.
+
+Acceptance criteria:
+
+- A scene can be assigned to a canonical chapter through a named MCP operation.
+- The command validates project scope and chapter identity.
+- The command updates sidecar state and index state consistently with current storage.
+- Existing compatibility paths are not removed in this milestone.
+
+Test strategy:
+
+- Unit tests for validation and patch generation.
+- Integration test for assignment followed by `find_scenes`.
+- Integration test for assignment followed by `get_chapter_prose`.
+- Review-bundle scope test if the affected scene participates in bundle planning.
+
+Out of scope:
+
+- Chapter rename or reorder commands.
+- Removing direct structural fields from generic metadata updates.
+
+## M6 — Normalize Compatibility Resolution
+
+Goal: reduce long-term reliance on numeric chapter fields as authority.
+
+Deliverables:
+
+- Resolve numeric `chapter` and `chapters` filters through canonical chapter identity where possible.
+- Align review-bundle planning with canonical chapter resolution.
+- Keep numeric chapter inputs as compatibility aliases.
+- Add clear errors or warnings when compatibility inputs cannot resolve safely.
+
+Acceptance criteria:
+
+- Numeric chapter targeting behaves consistently across search, prose retrieval, styleguide, batch enrichment, and review bundles.
+- Canonical `chapter_id` remains the preferred target in tool descriptions.
+- Ambiguous compatibility resolution does not silently select the wrong structure.
+
+Test strategy:
+
+- Unit tests for compatibility resolution.
+- Integration tests for all public tools that still accept numeric chapter filters.
+- Regression tests for no-result and ambiguous-result behavior.
+
+## M7 — Add Additional Explicit Structure Commands
+
+Goal: expand sanctioned structural mutation paths after the first command proves the pattern.
+
+Potential commands:
+
+- `create_chapter`
+- `rename_chapter`
+- `reorder_chapter`
+- `attach_epigraph`
+- `move_scene`
+
+Acceptance criteria:
+
+- Each command owns one structural intent.
+- Commands validate invariants before writing.
+- Commands produce clear diagnostics and next steps.
+
+Details intentionally deferred:
+
+- exact tool names
+- whether commands write sidecars, database rows, or both
+- how much Scrivener-compatible output is generated immediately
+
+## M8 — Decide Canonical Storage Direction
+
+Goal: make an evidence-based decision about whether sidecars remain canonical storage or become a representation layer.
+
+Questions to answer:
+
+- Is SQLite the durable canonical model, a derived index, or part of a hybrid model?
+- Which files remain author-editable?
+- Which files become managed system state?
+- How does Git-backed auditability work if managed state becomes opaque or semi-opaque?
+- How do import/export adapters preserve Scrivener interoperability?
+- What recovery story exists if database and files disagree?
+
+Acceptance criteria:
+
+- A decision record or follow-up PRD exists before implementation.
+- Migration strategy is explicit.
+- Rollback and recovery risks are documented.
+
+## Test Strategy Summary
+
+Early milestones:
+
+- prioritize characterization tests
+- run narrow unit tests around extracted helpers
+- run existing sync, metadata, search, and review-bundle integration tests
+
+Later milestones:
+
+- add command-level integration coverage
+- add compatibility resolution regression tests
+- add migration/recovery tests only after storage direction is chosen
+
+## Definition of Done
+
+This initiative is complete when Writing MCP has clear internal boundaries for structural observation, canonical mutation, diagnostics, and compatibility resolution, and the remaining storage-model migration can be planned from evidence rather than speculation.

--- a/docs/initiatives/backlog/target-architecture-migration/prd.md
+++ b/docs/initiatives/backlog/target-architecture-migration/prd.md
@@ -1,0 +1,146 @@
+# PRD: Target Architecture Migration
+
+**Status:** 📋 Deferred backlog (not active)
+
+This initiative captures preparatory refactoring and staged migration work needed to move Writing MCP toward the [Conceptual Target Architecture](../../../foundations/target-architecture.md) without forcing an early storage rewrite or behavior change.
+
+It should be treated as a staged convergence plan, not a commitment to implement the full target architecture in one branch.
+
+## Goal
+
+Prepare the codebase for a clearer separation between:
+
+- MCP control-plane workflows
+- canonical manuscript structure
+- authored prose
+- derived views and indexes
+- import/export adapters
+- maintenance diagnostics and repair
+
+The immediate goal is safer future migration, not a new user-facing workflow.
+
+## Problem
+
+The current implementation already has important target-architecture pieces:
+
+- canonical `chapters` and `epigraphs`
+- `chapter_id` scene links
+- chapter-aware search and prose retrieval
+- epigraph-aware review bundle rendering
+- sync/import warnings for ambiguous structure
+
+However, several implementation paths still blur architectural boundaries:
+
+- `sync` can infer structural state from folders and sidecars during ordinary indexing.
+- scene sidecars still carry compatibility fields such as `part`, `chapter`, and `chapter_title`.
+- generic metadata tools can still write structure-adjacent fields.
+- numeric chapter filters remain active in several workflows.
+- maintenance, observation, indexing, and canonical mutation are not always separated in code.
+
+These behaviors are valuable for compatibility, but they make it harder to enforce the target rule that canonical structure changes should go through sanctioned MCP workflows.
+
+## User Value
+
+This work does not primarily add new author-facing capability.
+It lowers the cost and risk of future author-facing work:
+
+- explicit chapter and scene-movement workflows
+- safer Scrivener and legacy imports
+- better structure diagnostics before repair
+- fewer accidental AI sidecar edits
+- future divisions without repeating folder/order coupling
+- clearer generated views that do not become authority
+
+## Product Boundary
+
+In scope:
+
+- behavior-preserving refactors that expose current structural boundaries
+- characterization tests around current sync, metadata, and chapter behavior
+- internal seams between observation, inference, canonical indexing, and mutation
+- read-only structure diagnostics
+- gradual introduction of explicit structural mutation workflows
+- compatibility cleanup after safer paths exist
+
+Out of scope for early milestones:
+
+- replacing the sidecar storage model
+- changing the public import contract
+- removing numeric chapter compatibility
+- introducing divisions
+- changing Scrivener workflow semantics
+- broad rewrite of sync or metadata tools
+
+## Design Principles
+
+1. **Preserve behavior before tightening it**
+   Early refactors should make the current behavior explicit and tested before changing contracts.
+
+2. **Separate structure from metadata plumbing**
+   Structural fields such as chapter membership and ordering need named pathways rather than being incidental metadata writes.
+
+3. **Split observation from mutation**
+   Maintenance and sync code should be able to observe drift without silently repairing canonical structure.
+
+4. **Keep compatibility visible**
+   Numeric chapter targeting and folder-derived structure should remain available during migration, but code should label them as compatibility paths.
+
+5. **Prefer small reviewable milestones**
+   Each milestone should leave the system releasable and should avoid committing later architectural details too early.
+
+## Migration Direction
+
+The migration should move in three broad phases:
+
+1. **Clarify current behavior**
+   Extract and test the existing inference, indexing, and sidecar-write behavior without changing outputs.
+
+2. **Introduce safe architecture seams**
+   Centralize structural writes, split sync observation from canonical mutation, and add diagnostics.
+
+3. **Tighten contracts gradually**
+   Add explicit structural commands, route callers through them, and later decide whether sidecars remain canonical storage or become a representation layer.
+
+## Acceptance Criteria
+
+This initiative is complete when:
+
+1. Structure inference and canonical indexing logic are isolated from generic sync mechanics.
+2. Structural sidecar writes are centralized behind named helpers or services.
+3. Sync internals distinguish observation, diagnostics, derived-index regeneration, and canonical mutation.
+4. A read-only structure diagnostic surface exists for canonical drift and ambiguous structure.
+5. At least one explicit structural mutation workflow exists for scene-to-chapter assignment.
+6. Numeric chapter compatibility paths are consistently resolved through canonical chapter identity where possible.
+7. Remaining storage-model questions are documented with enough evidence to decide a later migration.
+
+## Test Strategy
+
+Unit tests:
+
+- structure inference from explicit chapter folders
+- legacy path fallback behavior
+- epigraph detection and linkage requirements
+- canonical chapter resolution and compatibility aliases
+- structural sidecar patch helpers
+- structure diagnostics categories
+
+Integration tests:
+
+- `sync` parity before and after refactors
+- `update_scene_metadata` compatibility behavior until explicitly deprecated
+- chapter-aware search and prose retrieval
+- review bundle chapter and epigraph rendering
+- explicit structural command round trips once introduced
+
+Manual verification:
+
+- run sync on representative Scrivener-imported and direct-folder projects
+- inspect warning summaries for ambiguous structure
+- confirm existing AI-facing tool flows still work through `describe_workflows`
+
+## Related
+
+- [milestones.md](milestones.md)
+- [Conceptual Target Architecture](../../../foundations/target-architecture.md)
+- [Managed Structure Contract](../../../foundations/managed-structure-contract.md)
+- [Chapter Structure Follow-up](../chapter-structure/prd.md)


### PR DESCRIPTION
## Summary

- add a conceptual target architecture document as a design reference
- link the new architecture doc from the product overview and managed structure contract
- add a backlog initiative with staged migration milestones for preparatory refactoring work

## Motivation

We want a mergeable documentation snapshot that captures the current architectural direction before implementation work begins.

## Implementation

- added `docs/foundations/target-architecture.md`
- added `docs/initiatives/backlog/target-architecture-migration/` with `prd.md` and `milestones.md`
- updated core docs to cross-link the new architecture and migration planning docs

## Testing

- Not run: documentation-only change.

## Risks and tradeoffs

- Low risk: this change only affects documentation.
- The main tradeoff is that later implementation details may evolve, so the target architecture and later milestones should be kept updated as the codebase changes.

## Follow-up

- Use this PR as the documentation baseline before starting implementation refactors.