### PR TITLE
refactor(structure): centralize scene structure patches

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -12,7 +12,7 @@ It supports metadata-first reasoning, explicit prose editing workflows, and revi
 Active initiative: [Target Architecture Migration](docs/initiatives/backlog/target-architecture-migration/prd.md).
 
 The active product focus is behavior-preserving design consolidation around structural manuscript state, especially the boundaries captured in [Managed Structure Contract](docs/foundations/managed-structure-contract.md).
-Current implementation focus: M1, naming current structure inference and canonical indexing boundaries without changing sync behavior.
+Current implementation focus: M2, centralizing structural sidecar writes without changing metadata update behavior.
 
 ---
 

--- a/src/structure/structure-inference.js
+++ b/src/structure/structure-inference.js
@@ -114,6 +114,16 @@ export function buildSceneStructurePatch(syncDir, filePath, meta = {}, { chapter
   const chapterStructure = inferChapterStructureFromPath(syncDir, filePath, meta);
   const patch = {};
 
+  if (derived.part !== null) patch.part = derived.part;
+  if (derived.chapter !== null) patch.chapter = derived.chapter;
+  if (chapterStructure.chapter?.chapter_id) {
+    patch.chapter_id = chapterStructure.chapter.chapter_id;
+    patch.chapter = chapterStructure.chapter.sort_index;
+    patch.chapter_title = chapterStructure.chapter.title;
+  }
+  if (chapterStructure.role) {
+    patch.scene_role = chapterStructure.role;
+  }
   if (chapter !== undefined) {
     if (chapter === null) {
       patch.chapter_id = null;
@@ -124,17 +134,6 @@ export function buildSceneStructurePatch(syncDir, filePath, meta = {}, { chapter
       patch.chapter = chapter.sort_index;
       patch.chapter_title = chapter.title ?? null;
     }
-  }
-
-  if (derived.part !== null) patch.part = derived.part;
-  if (derived.chapter !== null) patch.chapter = derived.chapter;
-  if (chapterStructure.chapter?.chapter_id) {
-    patch.chapter_id = chapterStructure.chapter.chapter_id;
-    patch.chapter = chapterStructure.chapter.sort_index;
-    patch.chapter_title = chapterStructure.chapter.title;
-  }
-  if (chapterStructure.role) {
-    patch.scene_role = chapterStructure.role;
   }
 
   return {

--- a/src/structure/structure-inference.js
+++ b/src/structure/structure-inference.js
@@ -109,24 +109,36 @@ export function inferChapterStructureFromPath(syncDir, filePath, meta = {}) {
   };
 }
 
-export function normalizeSceneMetaForPath(syncDir, filePath, meta = {}) {
+export function buildSceneStructurePatch(syncDir, filePath, meta = {}, { chapter } = {}) {
   const derived = inferScenePositionFromPath(syncDir, filePath);
   const chapterStructure = inferChapterStructureFromPath(syncDir, filePath, meta);
-  const normalized = { ...meta };
+  const patch = {};
 
-  if (derived.part !== null) normalized.part = derived.part;
-  if (derived.chapter !== null) normalized.chapter = derived.chapter;
+  if (chapter !== undefined) {
+    if (chapter === null) {
+      patch.chapter_id = null;
+      patch.chapter = null;
+      patch.chapter_title = null;
+    } else {
+      patch.chapter_id = chapter.chapter_id;
+      patch.chapter = chapter.sort_index;
+      patch.chapter_title = chapter.title ?? null;
+    }
+  }
+
+  if (derived.part !== null) patch.part = derived.part;
+  if (derived.chapter !== null) patch.chapter = derived.chapter;
   if (chapterStructure.chapter?.chapter_id) {
-    normalized.chapter_id = chapterStructure.chapter.chapter_id;
-    normalized.chapter = chapterStructure.chapter.sort_index;
-    normalized.chapter_title = chapterStructure.chapter.title;
+    patch.chapter_id = chapterStructure.chapter.chapter_id;
+    patch.chapter = chapterStructure.chapter.sort_index;
+    patch.chapter_title = chapterStructure.chapter.title;
   }
   if (chapterStructure.role) {
-    normalized.scene_role = chapterStructure.role;
+    patch.scene_role = chapterStructure.role;
   }
 
   return {
-    meta: normalized,
+    patch,
     derived,
     chapterStructure,
     mismatches: {
@@ -134,4 +146,16 @@ export function normalizeSceneMetaForPath(syncDir, filePath, meta = {}) {
       chapter: derived.chapter !== null && meta.chapter != null && meta.chapter !== derived.chapter,
     },
   };
+}
+
+export function applySceneStructurePatch(syncDir, filePath, meta = {}, options = {}) {
+  const plan = buildSceneStructurePatch(syncDir, filePath, meta, options);
+  return {
+    ...plan,
+    meta: { ...meta, ...plan.patch },
+  };
+}
+
+export function normalizeSceneMetaForPath(syncDir, filePath, meta = {}) {
+  return applySceneStructurePatch(syncDir, filePath, meta);
 }

--- a/src/sync/sync.js
+++ b/src/sync/sync.js
@@ -3,6 +3,8 @@ import path from "node:path";
 import matter from "gray-matter";
 import yaml from "js-yaml";
 import {
+  applySceneStructurePatch,
+  buildSceneStructurePatch,
   inferChapterStructureFromPath,
   inferScenePositionFromPath,
   normalizeSceneMetaForPath,
@@ -16,6 +18,8 @@ import { indexCanonicalEpigraph } from "../structure/epigraph-indexing.js";
 const { load: parseYaml, dump: stringifyYaml } = yaml;
 
 export {
+  applySceneStructurePatch,
+  buildSceneStructurePatch,
   inferChapterStructureFromPath,
   inferScenePositionFromPath,
   normalizeSceneMetaForPath,

--- a/src/test/integration/metadata.test.mjs
+++ b/src/test/integration/metadata.test.mjs
@@ -68,6 +68,7 @@ describe("update_scene_metadata tool", () => {
     const raw = fs.readFileSync(sidecarFile, "utf8");
     assert.ok(raw.includes(`chapter_id: ${firstChapter.chapter_id}`));
     assert.ok(raw.includes("chapter: 1"));
+    assert.ok(raw.includes(`chapter_title: ${firstChapter.title}`));
 
     const findText = await callWriteTool("find_scenes", {
       project_id: "test-novel",

--- a/src/test/integration/metadata.test.mjs
+++ b/src/test/integration/metadata.test.mjs
@@ -2,6 +2,7 @@ import { test, describe, before, after } from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
+import yaml from "js-yaml";
 import { createTestContext } from "../helpers/server.js";
 
 const ctx = createTestContext(3073, 3072);
@@ -65,10 +66,10 @@ describe("update_scene_metadata tool", () => {
     assert.ok(updateText.includes("Updated metadata"));
 
     const sidecarFile = path.join(sceneDir, "sc-unchaptered.meta.yaml");
-    const raw = fs.readFileSync(sidecarFile, "utf8");
-    assert.ok(raw.includes(`chapter_id: ${firstChapter.chapter_id}`));
-    assert.ok(raw.includes("chapter: 1"));
-    assert.ok(raw.includes(`chapter_title: ${firstChapter.title}`));
+    const sidecar = yaml.load(fs.readFileSync(sidecarFile, "utf8"));
+    assert.equal(sidecar.chapter_id, firstChapter.chapter_id);
+    assert.equal(sidecar.chapter, 1);
+    assert.equal(sidecar.chapter_title, firstChapter.title);
 
     const findText = await callWriteTool("find_scenes", {
       project_id: "test-novel",

--- a/src/test/integration/metadata.test.mjs
+++ b/src/test/integration/metadata.test.mjs
@@ -99,6 +99,21 @@ describe("update_scene_metadata tool", () => {
     assert.equal(parsed.error.code, "VALIDATION_ERROR");
     assert.match(parsed.error.message, /must refer to the same canonical chapter/);
   });
+
+  test("rejects clearing chapter_id for a path-chaptered scene", async () => {
+    const text = await callWriteTool("update_scene_metadata", {
+      scene_id: "sc-001",
+      project_id: "test-novel",
+      fields: { chapter_id: null },
+    });
+    const parsed = JSON.parse(text);
+
+    assert.equal(parsed.ok, false);
+    assert.equal(parsed.error.code, "VALIDATION_ERROR");
+    assert.match(parsed.error.message, /file path implies a chapter/);
+    assert.equal(parsed.error.details.scene_id, "sc-001");
+    assert.notEqual(parsed.error.details.path_chapter, null);
+  });
 });
 
 describe("update_character_sheet tool", () => {

--- a/src/test/unit/sync.test.mjs
+++ b/src/test/unit/sync.test.mjs
@@ -354,6 +354,28 @@ describe("inferChapterStructureFromPath", () => {
     });
   });
 
+  test("structure module lets explicit chapter patches override path-derived chapter fields", () => {
+    const result = buildSceneStructurePatch(
+      syncDir,
+      "/sync/projects/novel/scenes/part-1/chapter-1/sc-006.md",
+      { scene_id: "sc-006", chapter_title: "Path Chapter" },
+      {
+        chapter: {
+          chapter_id: "ch-02-explicit",
+          sort_index: 2,
+          title: "Explicit Chapter",
+        },
+      }
+    );
+
+    assert.deepEqual(result.patch, {
+      part: 1,
+      chapter_id: "ch-02-explicit",
+      chapter: 2,
+      chapter_title: "Explicit Chapter",
+    });
+  });
+
   test("structure module detects epigraphs from filename and metadata", () => {
     const byFilename = inferChapterStructureFromStructureModule(
       syncDir,

--- a/src/test/unit/sync.test.mjs
+++ b/src/test/unit/sync.test.mjs
@@ -14,6 +14,7 @@ import {
   walkFiles, walkSidecars, worldEntityFolderKey, worldEntityKindForPath,
 } from "../../sync/sync.js";
 import {
+  buildSceneStructurePatch,
   inferChapterStructureFromPath as inferChapterStructureFromStructureModule,
   normalizeSceneMetaForPath as normalizeSceneMetaForPathFromStructureModule,
 } from "../../structure/structure-inference.js";
@@ -315,6 +316,42 @@ describe("inferChapterStructureFromPath", () => {
     assert.equal(result.meta.chapter, 3);
     assert.equal(result.meta.chapter_title, "The Signal");
     assert.equal(result.mismatches.chapter, false);
+  });
+
+  test("structure module builds explicit chapter sidecar patches", () => {
+    const result = buildSceneStructurePatch(
+      syncDir,
+      "/sync/projects/novel/scenes/sc-004.md",
+      { scene_id: "sc-004" },
+      {
+        chapter: {
+          chapter_id: "ch-02-the-crossing",
+          sort_index: 2,
+          title: "The Crossing",
+        },
+      }
+    );
+
+    assert.deepEqual(result.patch, {
+      chapter_id: "ch-02-the-crossing",
+      chapter: 2,
+      chapter_title: "The Crossing",
+    });
+  });
+
+  test("structure module clears explicit chapter sidecar patches", () => {
+    const result = buildSceneStructurePatch(
+      syncDir,
+      "/sync/projects/novel/scenes/sc-005.md",
+      { scene_id: "sc-005", chapter_id: "ch-01-old", chapter: 1, chapter_title: "Old" },
+      { chapter: null }
+    );
+
+    assert.deepEqual(result.patch, {
+      chapter_id: null,
+      chapter: null,
+      chapter_title: null,
+    });
   });
 
   test("structure module detects epigraphs from filename and metadata", () => {

--- a/src/tools/metadata.js
+++ b/src/tools/metadata.js
@@ -560,6 +560,19 @@ export function registerMetadataTools(s, {
         }
 
         if (fields.chapter_id === null) {
+          const structurePlan = applySceneStructurePatch(SYNC_DIR, scene.file_path, meta);
+          if (structurePlan.derived.chapter !== null || structurePlan.chapterStructure.chapter?.chapter_id) {
+            return errorResponse(
+              "VALIDATION_ERROR",
+              "chapter_id cannot be cleared for a scene whose file path implies a chapter.",
+              {
+                project_id,
+                scene_id,
+                chapter_id: null,
+                path_chapter: structurePlan.chapterStructure.chapter?.chapter_id ?? structurePlan.derived.chapter,
+              }
+            );
+          }
           chapter = null;
         } else if (fields.chapter_id !== undefined || fields.chapter !== undefined) {
           const resolvedChapterFilter = resolveValidatedChapterFilter(db, {

--- a/src/tools/metadata.js
+++ b/src/tools/metadata.js
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import fs from "node:fs";
 import matter from "gray-matter";
-import { readMeta, writeMeta, indexSceneFile, normalizeSceneMetaForPath } from "../sync/sync.js";
+import { readMeta, writeMeta, indexSceneFile, applySceneStructurePatch } from "../sync/sync.js";
 import { validateProjectId, validateUniverseId } from "../sync/importer.js";
 import { resolveValidatedChapterFilter } from "../core/chapter-resolution.js";
 import {
@@ -545,6 +545,7 @@ export function registerMetadataTools(s, {
       try {
         const { meta } = readMeta(scene.file_path, SYNC_DIR, { writable: true });
         const nextFields = { ...fields };
+        let chapter = undefined;
 
         if (fields.chapter_id === null && fields.chapter !== undefined) {
           return errorResponse(
@@ -559,8 +560,7 @@ export function registerMetadataTools(s, {
         }
 
         if (fields.chapter_id === null) {
-          nextFields.chapter = null;
-          nextFields.chapter_title = null;
+          chapter = null;
         } else if (fields.chapter_id !== undefined || fields.chapter !== undefined) {
           const resolvedChapterFilter = resolveValidatedChapterFilter(db, {
             projectId: project_id,
@@ -594,12 +594,10 @@ export function registerMetadataTools(s, {
             );
           }
 
-          nextFields.chapter_id = resolvedChapter.chapter_id;
-          nextFields.chapter = resolvedChapter.sort_index;
-          nextFields.chapter_title = resolvedChapter.title ?? null;
+          chapter = resolvedChapter;
         }
 
-        const updated = normalizeSceneMetaForPath(SYNC_DIR, scene.file_path, { ...meta, ...nextFields }).meta;
+        const updated = applySceneStructurePatch(SYNC_DIR, scene.file_path, { ...meta, ...nextFields }, { chapter }).meta;
         writeMeta(scene.file_path, updated);
 
         const { content: prose } = matter(fs.readFileSync(scene.file_path, "utf8"));


### PR DESCRIPTION
## Summary

- Adds shared `buildSceneStructurePatch` and `applySceneStructurePatch` helpers for scene structure sidecar fields.
- Routes `update_scene_metadata` canonical chapter writes through the shared helper.
- Keeps existing normalization callers on `normalizeSceneMetaForPath`, now backed by the same structure patch helper.
- Updates the active initiative focus from M1 to M2 in `PRODUCT.md`.

## Motivation

M2 of the target architecture migration aims to stop structural sidecar writes from being spread through generic metadata update paths. Centralizing the patch shape makes future explicit structure commands easier to add without duplicating `chapter_id`, compatibility `chapter`, `chapter_title`, `part`, or `scene_role` handling.

## Implementation

- Extracted sidecar field construction from `normalizeSceneMetaForPath` into `buildSceneStructurePatch`.
- Added `applySceneStructurePatch` as the write-facing helper that merges the patch back into metadata.
- Preserved `normalizeSceneMetaForPath` as the compatibility wrapper used by sync, enrichment, and batch flows.
- Updated `update_scene_metadata` to resolve canonical chapters as before, then delegate sidecar field construction to the helper.

## Testing

- `node --test src/test/unit/sync.test.mjs`
- `node --test src/test/integration/metadata.test.mjs`
- `node --test src/test/integration/sync.test.mjs`
- `node --test src/test/unit/scene-character.test.mjs src/test/unit/metadata-tools.test.mjs`
- `npm run lint`
- `npm test`

## Risks and tradeoffs

- This is intended to be behavior-preserving; reviewers should focus on whether `update_scene_metadata` still writes the same chapter compatibility fields.
- Scrivener import/merge still owns its import-special-mode structure mapping logic; this PR does not move importer behavior into the new helper.
- No sidecar schema or public tool contract changes are intended.

## Follow-up

- M3: split sync observation from canonical mutation internals.