### PR TITLE
refactor(sync): complete target architecture M3

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -22,12 +22,6 @@ Track the remaining follow-up work around first-class chapters, deferred divisio
 
 **Status:** Deferred backlog (not active). Canonical chapters and epigraphs, `chapter_id` targeting, dedicated chapter/epigraph tools, and chapter-aware bundle rendering have already shipped; remaining follow-up work is paused pending structural design consolidation.
 
-### 🏗️ [Target Architecture Migration](docs/initiatives/backlog/target-architecture-migration/prd.md) 📋
-
-Preparatory refactoring and staged migration work that moves structural manuscript workflows toward the conceptual target architecture without committing too early to storage or public API changes.
-
-**Status:** Active. Early milestones focus on behavior-preserving refactors, characterization tests, and explicit structure boundaries before later compatibility tightening or storage-model decisions.
-
 ### 📊 [Embedding-Based Search](docs/initiatives/backlog/embeddings-search/prd.md) 📋
 
 Semantic search for queries that require understanding meaning, not just keywords.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -9,10 +9,10 @@ It supports metadata-first reasoning, explicit prose editing workflows, and revi
 
 ## Active Development
 
-Active initiative: [Target Architecture Migration](docs/initiatives/backlog/target-architecture-migration/prd.md).
+Active initiative: [Target Architecture Migration](docs/initiatives/active/target-architecture-migration/prd.md).
 
 The active product focus is behavior-preserving design consolidation around structural manuscript state, especially the boundaries captured in [Managed Structure Contract](docs/foundations/managed-structure-contract.md).
-Current implementation focus: M2, centralizing structural sidecar writes without changing metadata update behavior.
+Current implementation focus: M3, splitting sync observation from canonical mutation internals while preserving existing sync output and database effects.
 
 ---
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -12,7 +12,7 @@ It supports metadata-first reasoning, explicit prose editing workflows, and revi
 Active initiative: [Target Architecture Migration](docs/initiatives/active/target-architecture-migration/prd.md).
 
 The active product focus is behavior-preserving design consolidation around structural manuscript state, especially the boundaries captured in [Managed Structure Contract](docs/foundations/managed-structure-contract.md).
-Current implementation focus: M3, splitting sync observation from canonical mutation internals while preserving existing sync output and database effects.
+Current implementation focus: M4, adding read-only structure diagnostics on top of the sync observation seams established in M3.
 
 ---
 

--- a/docs/initiatives/active/target-architecture-migration/milestones.md
+++ b/docs/initiatives/active/target-architecture-migration/milestones.md
@@ -1,7 +1,7 @@
 # Target Architecture Migration — Milestones
 
 Status: Active  
-Current milestone: M3 — Split Sync Observation From Canonical Mutation Internals  
+Current milestone: M4 — Add Read-Only Structure Diagnostics  
 Owner: MCP Writing  
 Date: 2026-05-17
 
@@ -100,7 +100,7 @@ Out of scope:
 
 ## M3 — Split Sync Observation From Canonical Mutation Internals
 
-Status: Active.
+Status: Complete.
 
 Goal: create internal seams so sync can later observe broadly without always mutating canonical structure.
 

--- a/docs/initiatives/active/target-architecture-migration/milestones.md
+++ b/docs/initiatives/active/target-architecture-migration/milestones.md
@@ -1,6 +1,7 @@
 # Target Architecture Migration — Milestones
 
 Status: Active  
+Current milestone: M3 — Split Sync Observation From Canonical Mutation Internals  
 Owner: MCP Writing  
 Date: 2026-05-17
 
@@ -58,6 +59,8 @@ Out of scope:
 
 ## M2 — Centralize Structural Sidecar Writes
 
+Status: Complete.
+
 Goal: stop structural sidecar patches from being spread through generic metadata update paths.
 
 Deliverables:
@@ -96,6 +99,8 @@ Out of scope:
 - Changing sidecar schema.
 
 ## M3 — Split Sync Observation From Canonical Mutation Internals
+
+Status: Active.
 
 Goal: create internal seams so sync can later observe broadly without always mutating canonical structure.
 

--- a/docs/initiatives/active/target-architecture-migration/prd.md
+++ b/docs/initiatives/active/target-architecture-migration/prd.md
@@ -143,4 +143,4 @@ Manual verification:
 - [milestones.md](milestones.md)
 - [Conceptual Target Architecture](../../../foundations/target-architecture.md)
 - [Managed Structure Contract](../../../foundations/managed-structure-contract.md)
-- [Chapter Structure Follow-up](../chapter-structure/prd.md)
+- [Chapter Structure Follow-up](../../backlog/chapter-structure/prd.md)

--- a/release-log.md
+++ b/release-log.md
@@ -6,6 +6,14 @@ This complements `CHANGELOG.md`:
 - `CHANGELOG.md` is technical and release-oriented.
 - This log is plain-language and outcome-oriented.
 
+### 2026-05-18 — Complete target architecture migration M3
+
+- What changed: Marked the Target Architecture Migration through M3 as complete, moved the active focus to M4 read-only structure diagnostics, and split sync internals into clearer observation, indexing, regeneration, pruning, and diagnostics phases.
+- Why it matters: Maintainers now have safer seams for implementing structure diagnostics without silently changing canonical manuscript state or sync output behavior.
+- Who is affected: Maintainers and contributors working on sync, structure diagnostics, or future structural mutation workflows.
+- Action needed: None.
+- PR: [#201](https://github.com/hannasdev/mcp-writing/pull/201)
+
 ### 2026-05-17 — Move repo guidance away from local skills
 
 - What changed: Removed the repo-local maintainer skill files and helper scripts, updated agent guidance to treat `PRODUCT.md` as the product-work entry point, and clarified that general Codex skills now live outside this repository.

--- a/src/sync/sync.js
+++ b/src/sync/sync.js
@@ -986,7 +986,6 @@ export function pruneSyncDerivedIndexes(db, syncDir, {
 
 export function regenerateReferenceAndWorldIndexes(db, syncDir, files, { writable = false } = {}) {
   const indexedReferenceDocIds = new Set();
-  const diagnostics = [];
 
   for (const file of files) {
     if (isReferenceFile(syncDir, file)) {
@@ -995,12 +994,7 @@ export function regenerateReferenceAndWorldIndexes(db, syncDir, files, { writabl
         const docId = indexReferenceFile(db, syncDir, file, data, content);
         indexedReferenceDocIds.add(docId);
       } catch (err) {
-        const message = `[mcp-writing] Failed to index ${file}: ${err.message}`;
-        process.stderr.write(`${message}\n`);
-        diagnostics.push(buildSyncDiagnostic(message, {
-          type: "reference_index_failure",
-          file,
-        }));
+        process.stderr.write(`[mcp-writing] Failed to index ${file}: ${err.message}\n`);
       }
       continue;
     }
@@ -1015,12 +1009,7 @@ export function regenerateReferenceAndWorldIndexes(db, syncDir, files, { writabl
         indexWorldFile(db, syncDir, file, meta);
       }
     } catch (err) {
-      const message = `[mcp-writing] Failed to index ${file}: ${err.message}`;
-      process.stderr.write(`${message}\n`);
-      diagnostics.push(buildSyncDiagnostic(message, {
-        type: "world_index_failure",
-        file,
-      }));
+      process.stderr.write(`[mcp-writing] Failed to index ${file}: ${err.message}\n`);
     }
   }
 
@@ -1030,7 +1019,6 @@ export function regenerateReferenceAndWorldIndexes(db, syncDir, files, { writabl
 
   return {
     indexedReferenceDocIds,
-    diagnostics,
   };
 }
 
@@ -1445,8 +1433,6 @@ export function syncAll(db, syncDir, { quiet = false, writable = false } = {}) {
         continue;
       }
 
-      const { content: prose } = parseFile(file);
-
       // Duplicate scene_id detection
       const project_id = structureObservation.projectId;
       const key = `${meta.scene_id}::${project_id}`;
@@ -1475,6 +1461,8 @@ export function syncAll(db, syncDir, { quiet = false, writable = false } = {}) {
       for (const diagnostic of structureObservation.diagnostics) {
         warnings.push(diagnostic.message);
       }
+
+      const { content: prose } = parseFile(file);
 
       const result = indexSceneFile(db, syncDir, file, meta, prose, { observedStructure: structureObservation });
       const canonicalDiagnostics = result.canonicalIndexPlan?.diagnostics ?? [];

--- a/src/sync/sync.js
+++ b/src/sync/sync.js
@@ -946,9 +946,86 @@ function pruneMissingEpigraphs(db, seenEpigraphKeys, syncDir) {
   }
 }
 
-export function indexSceneFile(db, syncDir, file, meta, prose) {
+export function buildStructureDiagnostic(message, { type = "chapter_structure", ...details } = {}) {
+  return { type, message, ...details };
+}
+
+export function observeStructureForFile(syncDir, file, {
+  meta = {},
+  sourceMeta = {},
+  derived = {},
+  mismatches = {},
+} = {}) {
   const { universe_id, project_id } = inferProjectAndUniverse(syncDir, file);
+  const relativePath = path.relative(syncDir, file);
   const chapterStructure = inferChapterStructureFromPath(syncDir, file, meta);
+  const diagnostics = [];
+
+  if (mismatches.part || mismatches.chapter) {
+    const details = [];
+    if (mismatches.part) details.push(`part metadata ${sourceMeta.part} != path part ${derived.part}`);
+    if (mismatches.chapter) details.push(`chapter metadata ${sourceMeta.chapter} != path chapter ${derived.chapter}`);
+    diagnostics.push(buildStructureDiagnostic(
+      `Path/metadata mismatch for scene "${meta.scene_id}": ${relativePath} (${details.join(", ")}). Using path-derived values.`,
+      {
+        type: "path_metadata_mismatch",
+        sceneId: meta.scene_id ?? null,
+        relativePath,
+      }
+    ));
+  }
+
+  return {
+    universeId: universe_id,
+    projectId: project_id,
+    relativePath,
+    chapterStructure,
+    observedChapter: chapterStructure.chapter
+      ? {
+        chapterId: chapterStructure.chapter.chapter_id,
+        sortIndex: chapterStructure.chapter.sort_index,
+        title: chapterStructure.chapter.title,
+        folderKey: chapterStructure.chapter.folder_key,
+        sourceKind: chapterStructure.chapter.source_kind,
+      }
+      : null,
+    observedEpigraph: chapterStructure.isEpigraph
+      ? {
+        epigraphId: meta.epigraph_id ?? null,
+        chapterId: meta.chapter_id ?? chapterStructure.chapter?.chapter_id ?? null,
+        relativePath,
+      }
+      : null,
+    diagnostics,
+  };
+}
+
+export function buildCanonicalIndexPlan(db, syncDir, file, meta, observedStructure = observeStructureForFile(syncDir, file, { meta })) {
+  const chapterResolution = resolveIndexedChapterForFile(db, {
+    syncDir,
+    projectId: observedStructure.projectId,
+    filePath: file,
+    relativePath: observedStructure.relativePath,
+    meta,
+    chapterStructure: observedStructure.chapterStructure,
+  });
+
+  return {
+    universeId: observedStructure.universeId,
+    projectId: observedStructure.projectId,
+    observedStructure,
+    chapterResolution,
+    canonicalChapter: chapterResolution.upsertChapter,
+    diagnostics: chapterResolution.chapterWarning
+      ? [buildStructureDiagnostic(chapterResolution.chapterWarning)]
+      : [],
+  };
+}
+
+export function indexSceneFile(db, syncDir, file, meta, prose, { observedStructure } = {}) {
+  const canonicalIndexPlan = buildCanonicalIndexPlan(db, syncDir, file, meta, observedStructure);
+  const { universeId: universe_id, projectId: project_id } = canonicalIndexPlan;
+  const { chapterStructure } = canonicalIndexPlan.observedStructure;
   const referenceIds = normalizeReferenceIdList(meta.reference_ids ?? meta.references);
   const explicitSceneLinks = collectExplicitReferenceLinks(
     meta,
@@ -965,22 +1042,13 @@ export function indexSceneFile(db, syncDir, file, meta, prose) {
     project_id, universe_id ?? null, project_id
   );
 
-  const relativePath = path.relative(syncDir, file);
-  const chapterResolution = resolveIndexedChapterForFile(db, {
-    syncDir,
-    projectId: project_id,
-    filePath: file,
-    relativePath,
-    meta,
-    chapterStructure,
-  });
   const {
     chapterId,
     chapterSortIndex,
     chapterTitle,
     chapterWarning,
     upsertChapter,
-  } = chapterResolution;
+  } = canonicalIndexPlan.chapterResolution;
 
   if (upsertChapter) {
     upsertCanonicalChapterRecord(db, {
@@ -991,7 +1059,7 @@ export function indexSceneFile(db, syncDir, file, meta, prose) {
   }
 
   if (chapterStructure.isEpigraph) {
-    return indexCanonicalEpigraph(db, {
+    const result = indexCanonicalEpigraph(db, {
       projectId: project_id,
       chapterId,
       chapterSortIndex,
@@ -999,11 +1067,12 @@ export function indexSceneFile(db, syncDir, file, meta, prose) {
       meta,
       prose,
       file,
-      relativePath,
+      relativePath: canonicalIndexPlan.observedStructure.relativePath,
       chapterWarning,
       buildProseChecksum: checksumProse,
       buildDefaultEpigraphId: ({ projectId, chapterId }) => `epi-${slugifyChapterValue(`${projectId}-${chapterId}`)}`,
     });
+    return { ...result, canonicalIndexPlan };
   }
 
   const newChecksum = checksumProse(prose);
@@ -1141,7 +1210,7 @@ export function indexSceneFile(db, syncDir, file, meta, prose) {
     relation: "informs",
   });
 
-  return { isStale, chapterId, warning: chapterWarning };
+  return { isStale, chapterId, warning: chapterWarning, canonicalIndexPlan };
 }
 
 const WARNING_TYPE_LABELS = {
@@ -1251,16 +1320,22 @@ export function syncAll(db, syncDir, { quiet = false, writable = false } = {}) {
     try {
       const { meta, sourceMeta, sidecarGenerated, derived, mismatches } = readMeta(file, syncDir, { writable });
       if (sidecarGenerated) sidecarsMigrated++;
-      const chapterStructure = inferChapterStructureFromPath(syncDir, file, meta);
+      const structureObservation = observeStructureForFile(syncDir, file, {
+        meta,
+        sourceMeta,
+        derived,
+        mismatches,
+      });
+      const { chapterStructure } = structureObservation;
 
       if (!meta.scene_id && !chapterStructure.isEpigraph) {
         skipped++;
-        if (!quiet) warnings.push(`Skipped (no scene_id): ${path.relative(syncDir, file)}`);
+        if (!quiet) warnings.push(`Skipped (no scene_id): ${structureObservation.relativePath}`);
         continue;
       }
 
       // Duplicate scene_id detection
-      const { project_id } = inferProjectAndUniverse(syncDir, file);
+      const project_id = structureObservation.projectId;
       const key = `${meta.scene_id}::${project_id}`;
       if (meta.scene_id && seenSceneIds.has(key)) {
         warnings.push(
@@ -1284,18 +1359,16 @@ export function syncAll(db, syncDir, { quiet = false, writable = false } = {}) {
         }
       }
 
-      if (mismatches.part || mismatches.chapter) {
-        const details = [];
-        if (mismatches.part) details.push(`part metadata ${sourceMeta.part} != path part ${derived.part}`);
-        if (mismatches.chapter) details.push(`chapter metadata ${sourceMeta.chapter} != path chapter ${derived.chapter}`);
-        warnings.push(
-          `Path/metadata mismatch for scene "${meta.scene_id}": ${path.relative(syncDir, file)} (${details.join(", ")}). Using path-derived values.`
-        );
+      for (const diagnostic of structureObservation.diagnostics) {
+        warnings.push(diagnostic.message);
       }
 
       const { data: _frontmatter, content: prose } = parseFile(file);
-      const result = indexSceneFile(db, syncDir, file, meta, prose);
-      if (result.warning) {
+      const result = indexSceneFile(db, syncDir, file, meta, prose, { observedStructure: structureObservation });
+      const canonicalDiagnostics = result.canonicalIndexPlan?.diagnostics ?? [];
+      if (canonicalDiagnostics.length) {
+        for (const diagnostic of canonicalDiagnostics) warnings.push(diagnostic.message);
+      } else if (result.warning) {
         warnings.push(result.warning);
       }
       if (result.chapterId) {

--- a/src/sync/sync.js
+++ b/src/sync/sync.js
@@ -984,7 +984,10 @@ export function pruneSyncDerivedIndexes(db, syncDir, {
   return { pruned: true, reason: null };
 }
 
-export function regenerateReferenceAndWorldIndexes(db, syncDir, files, { writable = false } = {}) {
+export function regenerateReferenceAndWorldIndexes(db, syncDir, files, {
+  writable = false,
+  pruneReferenceDocs = false,
+} = {}) {
   const indexedReferenceDocIds = new Set();
 
   for (const file of files) {
@@ -1013,7 +1016,7 @@ export function regenerateReferenceAndWorldIndexes(db, syncDir, files, { writabl
     }
   }
 
-  if (canPruneReferenceDocs(syncDir)) {
+  if (pruneReferenceDocs && canPruneReferenceDocs(syncDir)) {
     pruneMissingReferenceDocs(db, indexedReferenceDocIds);
   }
 
@@ -1411,7 +1414,7 @@ export function syncAll(db, syncDir, { quiet = false, writable = false } = {}) {
 
   // --- Pass 1: world files and reference docs (characters/places must be indexed
   // before scenes so that character name -> ID resolution in scene_characters works) ---
-  regenerateReferenceAndWorldIndexes(db, syncDir, scanFiles, { writable });
+  regenerateReferenceAndWorldIndexes(db, syncDir, scanFiles, { writable, pruneReferenceDocs: true });
 
   // --- Pass 2: scene files ---
   for (const file of scanFiles) {

--- a/src/sync/sync.js
+++ b/src/sync/sync.js
@@ -836,8 +836,14 @@ export function indexReferenceFile(db, syncDir, file, meta = {}, content = "") {
   return docId;
 }
 
-function pruneMissingReferenceDocs(db, seenDocIds) {
-  const rows = db.prepare(`SELECT doc_id, project_id FROM reference_docs`).all();
+function pruneMissingReferenceDocs(db, seenDocIds, syncDir) {
+  const scope = inferReferenceScopeFromSyncDir(syncDir);
+  const rows = scope?.project_id
+    ? db.prepare(`SELECT doc_id, project_id FROM reference_docs WHERE project_id = ?`).all(scope.project_id)
+    : scope?.universe_id
+      ? db.prepare(`SELECT doc_id, project_id FROM reference_docs WHERE universe_id = ?`).all(scope.universe_id)
+      : db.prepare(`SELECT doc_id, project_id FROM reference_docs`).all();
+
   for (const row of rows) {
     if (seenDocIds.has(row.doc_id)) continue;
     db.prepare(`
@@ -1017,7 +1023,7 @@ export function regenerateReferenceAndWorldIndexes(db, syncDir, files, {
   }
 
   if (pruneReferenceDocs && canPruneReferenceDocs(syncDir)) {
-    pruneMissingReferenceDocs(db, indexedReferenceDocIds);
+    pruneMissingReferenceDocs(db, indexedReferenceDocIds, syncDir);
   }
 
   return {

--- a/src/sync/sync.js
+++ b/src/sync/sync.js
@@ -984,6 +984,56 @@ export function pruneSyncDerivedIndexes(db, syncDir, {
   return { pruned: true, reason: null };
 }
 
+export function regenerateReferenceAndWorldIndexes(db, syncDir, files, { writable = false } = {}) {
+  const indexedReferenceDocIds = new Set();
+  const diagnostics = [];
+
+  for (const file of files) {
+    if (isReferenceFile(syncDir, file)) {
+      try {
+        const { data, content } = parseFile(file);
+        const docId = indexReferenceFile(db, syncDir, file, data, content);
+        indexedReferenceDocIds.add(docId);
+      } catch (err) {
+        const message = `[mcp-writing] Failed to index ${file}: ${err.message}`;
+        process.stderr.write(`${message}\n`);
+        diagnostics.push(buildSyncDiagnostic(message, {
+          type: "reference_index_failure",
+          file,
+        }));
+      }
+      continue;
+    }
+
+    if (!isWorldFile(syncDir, file)) continue;
+    try {
+      const { meta } = readMeta(file, syncDir, { writable });
+      if (!Object.keys(meta).length) {
+        const { data } = parseFile(file);
+        indexWorldFile(db, syncDir, file, data);
+      } else {
+        indexWorldFile(db, syncDir, file, meta);
+      }
+    } catch (err) {
+      const message = `[mcp-writing] Failed to index ${file}: ${err.message}`;
+      process.stderr.write(`${message}\n`);
+      diagnostics.push(buildSyncDiagnostic(message, {
+        type: "world_index_failure",
+        file,
+      }));
+    }
+  }
+
+  if (canPruneReferenceDocs(syncDir)) {
+    pruneMissingReferenceDocs(db, indexedReferenceDocIds);
+  }
+
+  return {
+    indexedReferenceDocIds,
+    diagnostics,
+  };
+}
+
 export function buildStructureDiagnostic(message, { type = "chapter_structure", ...details } = {}) {
   return { type, message, ...details };
 }
@@ -1356,7 +1406,6 @@ export function syncAll(db, syncDir, { quiet = false, writable = false } = {}) {
   const indexedSceneIds = new Set(); // scene_id only — for orphaned sidecar move detection
   const seenChapterKeys = new Set();
   const seenEpigraphKeys = new Set();
-  const indexedReferenceDocIds = new Set();
   let sceneIndexFailures = 0;
   const warnings = [];
   const chapterFoldersByProject = new Map();
@@ -1370,35 +1419,7 @@ export function syncAll(db, syncDir, { quiet = false, writable = false } = {}) {
 
   // --- Pass 1: world files and reference docs (characters/places must be indexed
   // before scenes so that character name -> ID resolution in scene_characters works) ---
-  for (const file of scanFiles) {
-    if (isReferenceFile(syncDir, file)) {
-      try {
-        const { data, content } = parseFile(file);
-        const docId = indexReferenceFile(db, syncDir, file, data, content);
-        indexedReferenceDocIds.add(docId);
-      } catch (err) {
-        process.stderr.write(`[mcp-writing] Failed to index ${file}: ${err.message}\n`);
-      }
-      continue;
-    }
-
-    if (!isWorldFile(syncDir, file)) continue;
-    try {
-      const { meta } = readMeta(file, syncDir, { writable });
-      if (!Object.keys(meta).length) {
-        const { data } = parseFile(file);
-        indexWorldFile(db, syncDir, file, data);
-      } else {
-        indexWorldFile(db, syncDir, file, meta);
-      }
-    } catch (err) {
-      process.stderr.write(`[mcp-writing] Failed to index ${file}: ${err.message}\n`);
-    }
-  }
-
-  if (canPruneReferenceDocs(syncDir)) {
-    pruneMissingReferenceDocs(db, indexedReferenceDocIds);
-  }
+  regenerateReferenceAndWorldIndexes(db, syncDir, scanFiles, { writable });
 
   // --- Pass 2: scene files ---
   for (const file of scanFiles) {

--- a/src/sync/sync.js
+++ b/src/sync/sync.js
@@ -1110,8 +1110,12 @@ export function buildCanonicalIndexPlan(db, syncDir, file, meta, observedStructu
   };
 }
 
+export function readSceneMetadataForSync(syncDir, file, { writable = false } = {}) {
+  return readMeta(file, syncDir, { writable });
+}
+
 export function readSceneFileForSync(syncDir, file, { writable = false } = {}) {
-  const metadataRead = readMeta(file, syncDir, { writable });
+  const metadataRead = readSceneMetadataForSync(syncDir, file, { writable });
   const { data: frontmatter, content: prose } = parseFile(file);
 
   return {
@@ -1425,7 +1429,7 @@ export function syncAll(db, syncDir, { quiet = false, writable = false } = {}) {
   for (const file of scanFiles) {
     if (isWorldFile(syncDir, file) || isReferenceFile(syncDir, file)) continue;
     try {
-      const { meta, sourceMeta, sidecarGenerated, derived, mismatches, prose } = readSceneFileForSync(syncDir, file, { writable });
+      const { meta, sourceMeta, sidecarGenerated, derived, mismatches } = readSceneMetadataForSync(syncDir, file, { writable });
       if (sidecarGenerated) sidecarsMigrated++;
       const structureObservation = observeStructureForFile(syncDir, file, {
         meta,
@@ -1440,6 +1444,8 @@ export function syncAll(db, syncDir, { quiet = false, writable = false } = {}) {
         if (!quiet) warnings.push(`Skipped (no scene_id): ${structureObservation.relativePath}`);
         continue;
       }
+
+      const { content: prose } = parseFile(file);
 
       // Duplicate scene_id detection
       const project_id = structureObservation.projectId;

--- a/src/sync/sync.js
+++ b/src/sync/sync.js
@@ -74,9 +74,32 @@ export function walkSidecars(dir, fileList = []) {
   return fileList;
 }
 
+export function buildSyncDiagnostic(message, { type = null, ...details } = {}) {
+  return { type, message, ...details };
+}
+
 function isNestedMirrorPath(syncDir, filePath) {
   const rel = path.relative(syncDir, filePath).split(path.sep).join("/");
   return rel.includes("/scenes/projects/") || rel.includes("/scenes/universes/");
+}
+
+export function scanSyncFiles(syncDir) {
+  const files = [];
+  const diagnostics = [];
+
+  for (const file of walkFiles(syncDir)) {
+    if (isNestedMirrorPath(syncDir, file)) {
+      const relativePath = path.relative(syncDir, file);
+      diagnostics.push(buildSyncDiagnostic(`Ignored nested mirror path: ${relativePath}`, {
+        type: "nested_mirror",
+        relativePath,
+      }));
+      continue;
+    }
+    files.push(file);
+  }
+
+  return { files, diagnostics };
 }
 
 export function sidecarPath(filePath) {
@@ -946,6 +969,21 @@ function pruneMissingEpigraphs(db, seenEpigraphKeys, syncDir) {
   }
 }
 
+export function pruneSyncDerivedIndexes(db, syncDir, {
+  seenSceneKeys,
+  seenEpigraphKeys,
+  seenChapterKeys,
+  sceneIndexFailures,
+}) {
+  if (!canPruneScenes(syncDir)) return { pruned: false, reason: "scope_not_prunable" };
+  if (sceneIndexFailures !== 0) return { pruned: false, reason: "scene_index_failures" };
+
+  pruneMissingScenes(db, seenSceneKeys, syncDir);
+  pruneMissingEpigraphs(db, seenEpigraphKeys, syncDir);
+  pruneMissingChapters(db, seenChapterKeys, syncDir);
+  return { pruned: true, reason: null };
+}
+
 export function buildStructureDiagnostic(message, { type = "chapter_structure", ...details } = {}) {
   return { type, message, ...details };
 }
@@ -1019,6 +1057,17 @@ export function buildCanonicalIndexPlan(db, syncDir, file, meta, observedStructu
     diagnostics: chapterResolution.chapterWarning
       ? [buildStructureDiagnostic(chapterResolution.chapterWarning)]
       : [],
+  };
+}
+
+export function readSceneFileForSync(syncDir, file, { writable = false } = {}) {
+  const metadataRead = readMeta(file, syncDir, { writable });
+  const { data: frontmatter, content: prose } = parseFile(file);
+
+  return {
+    ...metadataRead,
+    frontmatter,
+    prose,
   };
 }
 
@@ -1213,6 +1262,47 @@ export function indexSceneFile(db, syncDir, file, meta, prose, { observedStructu
   return { isStale, chapterId, warning: chapterWarning, canonicalIndexPlan };
 }
 
+export function observeOrphanedSidecars(syncDir, { indexedSceneIds = new Set() } = {}) {
+  const diagnostics = [];
+  const sidecars = walkSidecars(syncDir).filter(sidecar => !isNestedMirrorPath(syncDir, sidecar));
+
+  for (const sidecar of sidecars) {
+    const prose = sidecar.replace(/\.meta\.yaml$/, ".md");
+    const proseTxt = sidecar.replace(/\.meta\.yaml$/, ".txt");
+    if (fs.existsSync(prose) || fs.existsSync(proseTxt)) continue;
+
+    let orphanedSceneId = null;
+    try {
+      const raw = fs.readFileSync(sidecar, "utf8");
+      orphanedSceneId = (parseYaml(raw) ?? {}).scene_id ?? null;
+    } catch { /* empty */ }
+
+    const relativePath = path.relative(syncDir, sidecar);
+    if (orphanedSceneId && indexedSceneIds.has(orphanedSceneId)) {
+      diagnostics.push(buildSyncDiagnostic(
+        `Moved scene detected: sidecar for "${orphanedSceneId}" is at stale path ${relativePath} — prose file has moved. Consider relocating the sidecar alongside the prose file.`,
+        {
+          type: "moved_scene",
+          sceneId: orphanedSceneId,
+          relativePath,
+        }
+      ));
+    } else {
+      const label = orphanedSceneId ? `scene "${orphanedSceneId}"` : "unknown scene";
+      diagnostics.push(buildSyncDiagnostic(
+        `Orphaned sidecar (${label}, no matching .md/.txt and not indexed): ${relativePath}`,
+        {
+          type: "orphaned_sidecar",
+          sceneId: orphanedSceneId,
+          relativePath,
+        }
+      ));
+    }
+  }
+
+  return diagnostics;
+}
+
 const WARNING_TYPE_LABELS = {
   no_scene_id: "Skipped (no scene_id)",
   duplicate_scene_id: "Duplicate scene_id",
@@ -1235,7 +1325,7 @@ const WARNING_PATTERNS = [
 
 const MAX_WARNING_EXAMPLES = 5;
 
-function buildWarningSummary(warnings) {
+export function buildWarningSummary(warnings) {
   const summary = {};
   for (const w of warnings) {
     const firstLine = w.split("\n")[0];
@@ -1255,7 +1345,6 @@ export function syncAll(db, syncDir, { quiet = false, writable = false } = {}) {
   // (for example after imports or path repairs) are reflected immediately.
   UNIVERSE_PROJECT_ROOT_CACHE.clear();
 
-  const files = walkFiles(syncDir);
   let indexed = 0;
   let staleMarked = 0;
   let epigraphsIndexed = 0;
@@ -1273,13 +1362,10 @@ export function syncAll(db, syncDir, { quiet = false, writable = false } = {}) {
   const chapterFoldersByProject = new Map();
   const roleFoldersByProject = new Map();
 
-  const scanFiles = [];
-  for (const file of files) {
-    if (isNestedMirrorPath(syncDir, file)) {
-      warnings.push(`Ignored nested mirror path: ${path.relative(syncDir, file)}`);
-      continue;
-    }
-    scanFiles.push(file);
+  const syncScan = scanSyncFiles(syncDir);
+  const scanFiles = syncScan.files;
+  for (const diagnostic of syncScan.diagnostics) {
+    warnings.push(diagnostic.message);
   }
 
   // --- Pass 1: world files and reference docs (characters/places must be indexed
@@ -1318,7 +1404,7 @@ export function syncAll(db, syncDir, { quiet = false, writable = false } = {}) {
   for (const file of scanFiles) {
     if (isWorldFile(syncDir, file) || isReferenceFile(syncDir, file)) continue;
     try {
-      const { meta, sourceMeta, sidecarGenerated, derived, mismatches } = readMeta(file, syncDir, { writable });
+      const { meta, sourceMeta, sidecarGenerated, derived, mismatches, prose } = readSceneFileForSync(syncDir, file, { writable });
       if (sidecarGenerated) sidecarsMigrated++;
       const structureObservation = observeStructureForFile(syncDir, file, {
         meta,
@@ -1363,7 +1449,6 @@ export function syncAll(db, syncDir, { quiet = false, writable = false } = {}) {
         warnings.push(diagnostic.message);
       }
 
-      const { data: _frontmatter, content: prose } = parseFile(file);
       const result = indexSceneFile(db, syncDir, file, meta, prose, { observedStructure: structureObservation });
       const canonicalDiagnostics = result.canonicalIndexPlan?.diagnostics ?? [];
       if (canonicalDiagnostics.length) {
@@ -1410,35 +1495,16 @@ export function syncAll(db, syncDir, { quiet = false, writable = false } = {}) {
     }
   }
 
-  if (canPruneScenes(syncDir) && sceneIndexFailures === 0) {
-    pruneMissingScenes(db, seenSceneKeys, syncDir);
-    pruneMissingEpigraphs(db, seenEpigraphKeys, syncDir);
-    pruneMissingChapters(db, seenChapterKeys, syncDir);
-  }
+  pruneSyncDerivedIndexes(db, syncDir, {
+    seenSceneKeys,
+    seenEpigraphKeys,
+    seenChapterKeys,
+    sceneIndexFailures,
+  });
 
   // --- Orphaned sidecar detection ---
-  const sidecars = walkSidecars(syncDir).filter(sidecar => !isNestedMirrorPath(syncDir, sidecar));
-  for (const sidecar of sidecars) {
-    const prose = sidecar.replace(/\.meta\.yaml$/, ".md");
-    const proseTxt = sidecar.replace(/\.meta\.yaml$/, ".txt");
-    if (!fs.existsSync(prose) && !fs.existsSync(proseTxt)) {
-      let orphanedSceneId = null;
-      try {
-        const raw = fs.readFileSync(sidecar, "utf8");
-        orphanedSceneId = (parseYaml(raw) ?? {}).scene_id ?? null;
-      } catch { /* empty */ }
-
-      if (orphanedSceneId && indexedSceneIds.has(orphanedSceneId)) {
-        warnings.push(
-          `Moved scene detected: sidecar for "${orphanedSceneId}" is at stale path ${path.relative(syncDir, sidecar)} — prose file has moved. Consider relocating the sidecar alongside the prose file.`
-        );
-      } else {
-        const label = orphanedSceneId ? `scene "${orphanedSceneId}"` : "unknown scene";
-        warnings.push(
-          `Orphaned sidecar (${label}, no matching .md/.txt and not indexed): ${path.relative(syncDir, sidecar)}`
-        );
-      }
-    }
+  for (const diagnostic of observeOrphanedSidecars(syncDir, { indexedSceneIds })) {
+    warnings.push(diagnostic.message);
   }
 
   const warningSummary = buildWarningSummary(warnings);

--- a/src/test/unit/sync.test.mjs
+++ b/src/test/unit/sync.test.mjs
@@ -12,6 +12,7 @@ import {
   isCanonicalWorldEntityFile, getSyncOwnershipDiagnostics, getFileWriteDiagnostics,
   isWorldFile, readMeta, isSyncDirWritable, sidecarPath, syncAll,
   walkFiles, walkSidecars, worldEntityFolderKey, worldEntityKindForPath,
+  buildCanonicalIndexPlan, observeStructureForFile,
 } from "../../sync/sync.js";
 import {
   buildSceneStructurePatch,
@@ -391,6 +392,61 @@ describe("inferChapterStructureFromPath", () => {
     assert.equal(byMetadata.isEpigraph, true);
     assert.equal(byFilename.chapter.chapter_id, "ch-01-arrival");
     assert.equal(byMetadata.chapter.chapter_id, "ch-01-arrival");
+  });
+});
+
+describe("structure observation", () => {
+  test("captures observed chapter state and path metadata diagnostics", () => {
+    const syncDir = "/tmp/sync";
+    const filePath = path.join(syncDir, "projects", "test-novel", "Draft", "01-Arrival", "sc-001.md");
+
+    const result = observeStructureForFile(syncDir, filePath, {
+      meta: { scene_id: "sc-001", part: 1, chapter: 1 },
+      sourceMeta: { part: 2, chapter: 9 },
+      derived: { part: 1, chapter: 1 },
+      mismatches: { part: true, chapter: true },
+    });
+
+    assert.equal(result.projectId, "test-novel");
+    assert.deepEqual(result.observedChapter, {
+      chapterId: "ch-01-arrival",
+      sortIndex: 1,
+      title: "Arrival",
+      folderKey: path.join("projects", "test-novel", "Draft", "01-Arrival"),
+      sourceKind: "chapter_folder",
+    });
+    assert.equal(result.diagnostics.length, 1);
+    assert.equal(result.diagnostics[0].type, "path_metadata_mismatch");
+    assert.equal(
+      result.diagnostics[0].message,
+      'Path/metadata mismatch for scene "sc-001": projects/test-novel/Draft/01-Arrival/sc-001.md (part metadata 2 != path part 1, chapter metadata 9 != path chapter 1). Using path-derived values.'
+    );
+  });
+
+  test("builds canonical indexing diagnostics without mutating canonical chapters", () => {
+    const syncDir = "/tmp/sync";
+    const filePath = path.join(syncDir, "projects", "test-novel", "scenes", "sc-001.md");
+    const db = openDb(":memory:");
+
+    const observation = observeStructureForFile(syncDir, filePath, {
+      meta: { scene_id: "sc-001", chapter_id: "ch-99-missing" },
+    });
+    const plan = buildCanonicalIndexPlan(db, syncDir, filePath, {
+      scene_id: "sc-001",
+      chapter_id: "ch-99-missing",
+    }, observation);
+
+    assert.equal(plan.projectId, "test-novel");
+    assert.equal(plan.observedStructure, observation);
+    assert.equal(plan.canonicalChapter, null);
+    assert.equal(plan.chapterResolution.chapterId, null);
+    assert.deepEqual(
+      plan.diagnostics.map((diagnostic) => diagnostic.message),
+      ["Scene references unknown chapter_id 'ch-99-missing': projects/test-novel/scenes/sc-001.md"]
+    );
+    assert.equal(db.prepare("SELECT count(*) AS count FROM chapters").get().count, 0);
+
+    db.close();
   });
 });
 

--- a/src/test/unit/sync.test.mjs
+++ b/src/test/unit/sync.test.mjs
@@ -635,6 +635,27 @@ describe("derived index regeneration", () => {
     db.close();
     fs.rmSync(dir, { recursive: true });
   });
+
+  test("does not prune reference docs for direct filtered helper calls unless requested", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "derived-index-filtered-"));
+    const indexedPath = path.join(dir, "projects", "test-novel", "world", "reference", "indexed.md");
+    const omittedPath = path.join(dir, "projects", "test-novel", "world", "reference", "omitted.md");
+    fs.mkdirSync(path.dirname(indexedPath), { recursive: true });
+    fs.writeFileSync(indexedPath, "---\ndoc_id: ref-indexed\ntitle: Indexed\n---\nIndexed reference.");
+    fs.writeFileSync(omittedPath, "---\ndoc_id: ref-omitted\ntitle: Omitted\n---\nOmitted reference.");
+    const db = openDb(":memory:");
+
+    regenerateReferenceAndWorldIndexes(db, dir, [indexedPath, omittedPath]);
+    regenerateReferenceAndWorldIndexes(db, dir, [indexedPath]);
+
+    assert.deepEqual(
+      db.prepare("SELECT doc_id FROM reference_docs ORDER BY doc_id").all().map((row) => row.doc_id),
+      ["ref-indexed", "ref-omitted"]
+    );
+
+    db.close();
+    fs.rmSync(dir, { recursive: true });
+  });
 });
 
 describe("resolveCanonicalChapterRecord", () => {

--- a/src/test/unit/sync.test.mjs
+++ b/src/test/unit/sync.test.mjs
@@ -1272,6 +1272,31 @@ describe("syncAll", () => {
     fs.rmSync(dir, { recursive: true });
   });
 
+  test("project-scoped reference pruning does not delete other project docs", () => {
+    const dir = makeTempSync();
+    const db = openDb(":memory:");
+    const alphaRoot = path.join(dir, "projects", "alpha-novel");
+    const betaRoot = path.join(dir, "projects", "beta-novel");
+    const alphaRefPath = path.join(alphaRoot, "world", "reference", "alpha.md");
+    const betaRefPath = path.join(betaRoot, "world", "reference", "beta.md");
+    fs.mkdirSync(path.dirname(alphaRefPath), { recursive: true });
+    fs.mkdirSync(path.dirname(betaRefPath), { recursive: true });
+    fs.writeFileSync(alphaRefPath, "---\ndoc_id: ref-alpha\ntitle: Alpha\n---\nAlpha reference.");
+    fs.writeFileSync(betaRefPath, "---\ndoc_id: ref-beta\ntitle: Beta\n---\nBeta reference.");
+
+    syncAll(db, dir, { quiet: true });
+    assert.equal(db.prepare(`SELECT COUNT(*) AS count FROM reference_docs`).get().count, 2);
+
+    fs.rmSync(alphaRefPath);
+    syncAll(db, alphaRoot, { quiet: true });
+
+    assert.equal(db.prepare(`SELECT COUNT(*) AS count FROM reference_docs WHERE doc_id = 'ref-alpha'`).get().count, 0);
+    assert.equal(db.prepare(`SELECT COUNT(*) AS count FROM reference_docs WHERE doc_id = 'ref-beta'`).get().count, 1);
+
+    db.close();
+    fs.rmSync(dir, { recursive: true });
+  });
+
   test("keeps scene->reference links isolated when the same scene_id exists in multiple projects", () => {
     const dir = makeTempSync();
     const db = openDb(":memory:");

--- a/src/test/unit/sync.test.mjs
+++ b/src/test/unit/sync.test.mjs
@@ -13,7 +13,7 @@ import {
   isWorldFile, readMeta, isSyncDirWritable, sidecarPath, syncAll,
   walkFiles, walkSidecars, worldEntityFolderKey, worldEntityKindForPath,
   buildCanonicalIndexPlan, buildWarningSummary, observeOrphanedSidecars,
-  observeStructureForFile, readSceneFileForSync, scanSyncFiles,
+  observeStructureForFile, readSceneFileForSync, regenerateReferenceAndWorldIndexes, scanSyncFiles,
 } from "../../sync/sync.js";
 import {
   buildSceneStructurePatch,
@@ -558,6 +558,50 @@ describe("orphaned sidecar observation", () => {
     assert.ok(diagnostics.find((diagnostic) => diagnostic.type === "orphaned_sidecar").message.includes("Orphaned sidecar"));
     assert.ok(diagnostics.find((diagnostic) => diagnostic.type === "moved_scene").message.includes("Moved scene detected"));
 
+    fs.rmSync(dir, { recursive: true });
+  });
+});
+
+describe("derived index regeneration", () => {
+  test("indexes reference docs and world entities before scene indexing", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "derived-index-"));
+    const referencePath = path.join(dir, "projects", "test-novel", "world", "reference", "lore.md");
+    const characterPath = path.join(dir, "projects", "test-novel", "world", "characters", "alex.md");
+    fs.mkdirSync(path.dirname(referencePath), { recursive: true });
+    fs.mkdirSync(path.dirname(characterPath), { recursive: true });
+    fs.writeFileSync(referencePath, [
+      "---",
+      "doc_id: ref-lore",
+      "title: Lore",
+      "tags: [continuity]",
+      "---",
+      "A compact lore note.",
+      "",
+    ].join("\n"));
+    fs.writeFileSync(characterPath, [
+      "---",
+      "character_id: char-alex",
+      "name: Alex",
+      "role: protagonist",
+      "---",
+      "",
+    ].join("\n"));
+    const db = openDb(":memory:");
+
+    const result = regenerateReferenceAndWorldIndexes(db, dir, [referencePath, characterPath]);
+
+    assert.deepEqual([...result.indexedReferenceDocIds], ["ref-lore"]);
+    assert.deepEqual(result.diagnostics, []);
+    assert.deepEqual(
+      db.prepare("SELECT doc_id, project_id, title FROM reference_docs").all().map((row) => ({ ...row })),
+      [{ doc_id: "ref-lore", project_id: "test-novel", title: "Lore" }]
+    );
+    assert.deepEqual(
+      db.prepare("SELECT character_id, project_id, name FROM characters").all().map((row) => ({ ...row })),
+      [{ character_id: "char-alex", project_id: "test-novel", name: "Alex" }]
+    );
+
+    db.close();
     fs.rmSync(dir, { recursive: true });
   });
 });

--- a/src/test/unit/sync.test.mjs
+++ b/src/test/unit/sync.test.mjs
@@ -607,7 +607,6 @@ describe("derived index regeneration", () => {
     const result = regenerateReferenceAndWorldIndexes(db, dir, [referencePath, characterPath]);
 
     assert.deepEqual([...result.indexedReferenceDocIds], ["ref-lore"]);
-    assert.deepEqual(result.diagnostics, []);
     assert.deepEqual(
       db.prepare("SELECT doc_id, project_id, title FROM reference_docs").all().map((row) => ({ ...row })),
       [{ doc_id: "ref-lore", project_id: "test-novel", title: "Lore" }]
@@ -616,6 +615,22 @@ describe("derived index regeneration", () => {
       db.prepare("SELECT character_id, project_id, name FROM characters").all().map((row) => ({ ...row })),
       [{ character_id: "char-alex", project_id: "test-novel", name: "Alex" }]
     );
+
+    db.close();
+    fs.rmSync(dir, { recursive: true });
+  });
+
+  test("keeps reference parse failures out of sync warning diagnostics", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "derived-index-failure-"));
+    const referencePath = path.join(dir, "projects", "test-novel", "world", "reference", "broken.md");
+    fs.mkdirSync(path.dirname(referencePath), { recursive: true });
+    fs.writeFileSync(referencePath, "---\ndoc_id: [invalid\n---\nBroken reference.");
+    const db = openDb(":memory:");
+
+    const result = regenerateReferenceAndWorldIndexes(db, dir, [referencePath]);
+
+    assert.deepEqual([...result.indexedReferenceDocIds], []);
+    assert.deepEqual(Object.keys(result), ["indexedReferenceDocIds"]);
 
     db.close();
     fs.rmSync(dir, { recursive: true });
@@ -1749,6 +1764,32 @@ describe("syncAll", () => {
 
     assert.equal(result.skipped, 1);
     assert.equal(db.prepare(`SELECT COUNT(*) AS count FROM scenes WHERE scene_id = 'sc-001'`).get().count, 0);
+
+    db.close();
+    fs.rmSync(dir, { recursive: true });
+  });
+
+  test("records pre-indexing diagnostics before malformed scene frontmatter fails", () => {
+    const dir = makeTempSync();
+    const db = openDb(":memory:");
+    const scenePath = path.join(dir, "projects", "test-novel", "scenes", "part-1", "chapter-1", "sc-001.md");
+    fs.mkdirSync(path.dirname(scenePath), { recursive: true });
+    fs.writeFileSync(scenePath, "---\ntitle: [invalid\n---\nScene prose.");
+    fs.writeFileSync(sidecarPath(scenePath), [
+      "scene_id: sc-001",
+      "part: 2",
+      "chapter: 9",
+      "",
+    ].join("\n"));
+
+    const result = syncAll(db, dir, { quiet: true });
+
+    assert.equal(result.indexed, 0);
+    assert.equal(result.warningSummary.path_metadata_mismatch.count, 1);
+    assert.equal(
+      result.warningSummary.path_metadata_mismatch.examples[0],
+      'Path/metadata mismatch for scene "sc-001": projects/test-novel/scenes/part-1/chapter-1/sc-001.md (part metadata 2 != path part 1, chapter metadata 9 != path chapter 1). Using path-derived values.'
+    );
 
     db.close();
     fs.rmSync(dir, { recursive: true });

--- a/src/test/unit/sync.test.mjs
+++ b/src/test/unit/sync.test.mjs
@@ -13,7 +13,8 @@ import {
   isWorldFile, readMeta, isSyncDirWritable, sidecarPath, syncAll,
   walkFiles, walkSidecars, worldEntityFolderKey, worldEntityKindForPath,
   buildCanonicalIndexPlan, buildWarningSummary, observeOrphanedSidecars,
-  observeStructureForFile, readSceneFileForSync, regenerateReferenceAndWorldIndexes, scanSyncFiles,
+  observeStructureForFile, readSceneFileForSync, readSceneMetadataForSync,
+  regenerateReferenceAndWorldIndexes, scanSyncFiles,
 } from "../../sync/sync.js";
 import {
   buildSceneStructurePatch,
@@ -188,6 +189,21 @@ describe("readSceneFileForSync", () => {
     assert.equal(result.prose, "Scene prose.");
     assert.equal(result.frontmatter.title, "Read Phase");
 
+    fs.rmSync(dir, { recursive: true });
+  });
+});
+
+describe("readSceneMetadataForSync", () => {
+  test("reads sidecar metadata without parsing manuscript frontmatter", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "scene-metadata-"));
+    const scenePath = path.join(dir, "projects", "test-novel", "scenes", "notes.md");
+    fs.mkdirSync(path.dirname(scenePath), { recursive: true });
+    fs.writeFileSync(scenePath, "---\ntitle: [invalid\n---\nSupport note.");
+    fs.writeFileSync(sidecarPath(scenePath), "title: Support note\n");
+
+    const result = readSceneMetadataForSync(dir, scenePath);
+
+    assert.equal(result.meta.title, "Support note");
     fs.rmSync(dir, { recursive: true });
   });
 });
@@ -1709,6 +1725,30 @@ describe("syncAll", () => {
     );
     const result = syncAll(db, dir, { quiet: true });
     assert.equal(result.indexed, 0);
+
+    db.close();
+    fs.rmSync(dir, { recursive: true });
+  });
+
+  test("skipped sidecar-only notes with malformed frontmatter do not block pruning", () => {
+    const dir = makeTempSync();
+    const db = openDb(":memory:");
+    const scenePath = path.join(dir, "projects", "test-novel", "scenes", "sc-001.md");
+    const notePath = path.join(dir, "projects", "test-novel", "scenes", "notes.md");
+
+    writeScene(dir, "sc-001");
+    syncAll(db, dir, { quiet: true });
+    assert.equal(db.prepare(`SELECT COUNT(*) AS count FROM scenes WHERE scene_id = 'sc-001'`).get().count, 1);
+
+    fs.rmSync(scenePath);
+    fs.rmSync(sidecarPath(scenePath), { force: true });
+    fs.writeFileSync(notePath, "---\ntitle: [invalid\n---\nSupport note.");
+    fs.writeFileSync(sidecarPath(notePath), "title: Support note\n");
+
+    const result = syncAll(db, dir, { quiet: true });
+
+    assert.equal(result.skipped, 1);
+    assert.equal(db.prepare(`SELECT COUNT(*) AS count FROM scenes WHERE scene_id = 'sc-001'`).get().count, 0);
 
     db.close();
     fs.rmSync(dir, { recursive: true });

--- a/src/test/unit/sync.test.mjs
+++ b/src/test/unit/sync.test.mjs
@@ -12,7 +12,8 @@ import {
   isCanonicalWorldEntityFile, getSyncOwnershipDiagnostics, getFileWriteDiagnostics,
   isWorldFile, readMeta, isSyncDirWritable, sidecarPath, syncAll,
   walkFiles, walkSidecars, worldEntityFolderKey, worldEntityKindForPath,
-  buildCanonicalIndexPlan, observeStructureForFile,
+  buildCanonicalIndexPlan, buildWarningSummary, observeOrphanedSidecars,
+  observeStructureForFile, readSceneFileForSync, scanSyncFiles,
 } from "../../sync/sync.js";
 import {
   buildSceneStructurePatch,
@@ -66,6 +67,31 @@ describe("walkFiles", () => {
     const files = walkFiles(dir);
     assert.equal(files.length, 1);
     assert.ok(files[0].endsWith("notes.txt"));
+    fs.rmSync(dir, { recursive: true });
+  });
+});
+
+describe("scanSyncFiles", () => {
+  test("returns scan files and diagnostics for ignored nested mirrors", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "scan-"));
+    const realScenePath = path.join(dir, "projects", "test-novel", "scenes", "sc-001.md");
+    const mirrorScenePath = path.join(dir, "projects", "test-novel", "scenes", "projects", "test-novel", "scenes", "sc-001.md");
+    fs.mkdirSync(path.dirname(realScenePath), { recursive: true });
+    fs.mkdirSync(path.dirname(mirrorScenePath), { recursive: true });
+    fs.writeFileSync(realScenePath, "");
+    fs.writeFileSync(mirrorScenePath, "");
+
+    const result = scanSyncFiles(dir);
+
+    assert.deepEqual(result.files.map((file) => path.relative(dir, file)), [
+      path.join("projects", "test-novel", "scenes", "sc-001.md"),
+    ]);
+    assert.deepEqual(result.diagnostics, [{
+      type: "nested_mirror",
+      message: `Ignored nested mirror path: ${path.join("projects", "test-novel", "scenes", "projects", "test-novel", "scenes", "sc-001.md")}`,
+      relativePath: path.join("projects", "test-novel", "scenes", "projects", "test-novel", "scenes", "sc-001.md"),
+    }]);
+
     fs.rmSync(dir, { recursive: true });
   });
 });
@@ -141,6 +167,27 @@ describe("readMeta", () => {
     fs.writeFileSync(path.join(dir, "sc-001.meta.yaml"), "scene_id: new-id\n");
     const { meta } = readMeta(path.join(dir, "sc-001.md"), dir);
     assert.equal(meta.scene_id, "new-id");
+    fs.rmSync(dir, { recursive: true });
+  });
+});
+
+describe("readSceneFileForSync", () => {
+  test("returns normalized metadata and prose for scene indexing", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "scene-read-"));
+    const scenePath = path.join(dir, "projects", "test-novel", "scenes", "part-1", "chapter-2", "sc-001.md");
+    fs.mkdirSync(path.dirname(scenePath), { recursive: true });
+    fs.writeFileSync(scenePath, "---\nscene_id: sc-001\ntitle: Read Phase\nchapter: 9\n---\nScene prose.");
+
+    const result = readSceneFileForSync(dir, scenePath);
+
+    assert.equal(result.meta.scene_id, "sc-001");
+    assert.equal(result.meta.chapter, 2);
+    assert.equal(result.sourceMeta.chapter, 9);
+    assert.equal(result.derived.chapter, 2);
+    assert.equal(result.mismatches.chapter, true);
+    assert.equal(result.prose, "Scene prose.");
+    assert.equal(result.frontmatter.title, "Read Phase");
+
     fs.rmSync(dir, { recursive: true });
   });
 });
@@ -447,6 +494,71 @@ describe("structure observation", () => {
     assert.equal(db.prepare("SELECT count(*) AS count FROM chapters").get().count, 0);
 
     db.close();
+  });
+});
+
+describe("warning summary", () => {
+  test("summarizes diagnostic warnings by taxonomy", () => {
+    const summary = buildWarningSummary([
+      "Ignored nested mirror path: projects/test-novel/scenes/projects/test-novel/scenes/sc-001.md",
+      "Scene references unknown chapter_id 'ch-99-missing': projects/test-novel/scenes/sc-001.md",
+      "Something uncategorized happened",
+    ]);
+
+    assert.deepEqual(summary, {
+      nested_mirror: {
+        count: 1,
+        examples: ["Ignored nested mirror path: projects/test-novel/scenes/projects/test-novel/scenes/sc-001.md"],
+      },
+      chapter_structure: {
+        count: 1,
+        examples: ["Scene references unknown chapter_id 'ch-99-missing': projects/test-novel/scenes/sc-001.md"],
+      },
+      other: {
+        count: 1,
+        examples: ["Something uncategorized happened"],
+      },
+    });
+  });
+});
+
+describe("orphaned sidecar observation", () => {
+  test("returns diagnostics for orphaned and moved sidecars", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "sidecar-observe-"));
+    const orphanedSidecar = path.join(dir, "projects", "test-novel", "scenes", "sc-deleted.meta.yaml");
+    const movedSidecar = path.join(dir, "projects", "test-novel", "scenes", "old", "sc-moved.meta.yaml");
+    fs.mkdirSync(path.dirname(orphanedSidecar), { recursive: true });
+    fs.mkdirSync(path.dirname(movedSidecar), { recursive: true });
+    fs.writeFileSync(orphanedSidecar, "scene_id: sc-deleted\n");
+    fs.writeFileSync(movedSidecar, "scene_id: sc-moved\n");
+
+    const diagnostics = observeOrphanedSidecars(dir, {
+      indexedSceneIds: new Set(["sc-moved"]),
+    });
+
+    assert.deepEqual(
+      diagnostics.map((diagnostic) => ({
+        type: diagnostic.type,
+        sceneId: diagnostic.sceneId,
+        relativePath: diagnostic.relativePath,
+      })).sort((a, b) => a.sceneId.localeCompare(b.sceneId)),
+      [
+        {
+          type: "orphaned_sidecar",
+          sceneId: "sc-deleted",
+          relativePath: path.join("projects", "test-novel", "scenes", "sc-deleted.meta.yaml"),
+        },
+        {
+          type: "moved_scene",
+          sceneId: "sc-moved",
+          relativePath: path.join("projects", "test-novel", "scenes", "old", "sc-moved.meta.yaml"),
+        },
+      ]
+    );
+    assert.ok(diagnostics.find((diagnostic) => diagnostic.type === "orphaned_sidecar").message.includes("Orphaned sidecar"));
+    assert.ok(diagnostics.find((diagnostic) => diagnostic.type === "moved_scene").message.includes("Moved scene detected"));
+
+    fs.rmSync(dir, { recursive: true });
   });
 });
 


### PR DESCRIPTION
## Summary

- Marks Target Architecture Migration M3 complete and advances the active focus to M4.
- Splits sync internals into named phases for file scanning, scene metadata reads, structure observation, canonical indexing plans, derived index regeneration, pruning, and warning summaries.
- Adds characterization coverage for the new sync observation and regeneration helpers while preserving existing sync output and database effects.

## Motivation

M3 is the behavior-preserving preparation step for read-only structure diagnostics. The sync path needed clearer internal boundaries so future diagnostics can distinguish observed structure drift from canonical mutation and derived index regeneration.

## Implementation

- Added explicit observation/result objects such as structure observations, canonical index plans, sync diagnostics, and derived regeneration results.
- Extracted world/reference derived index regeneration and scene pruning into named helpers used by `syncAll`.
- Updated the initiative docs after completing the M3 phase split.

## Testing

- `node --experimental-sqlite --test src/test/unit/sync.test.mjs`
- `node --experimental-sqlite --test src/test/integration/sync.test.mjs`
- `npm test`

## Risks and tradeoffs

- This is intended to be behavior-preserving; the main review risk is accidental warning or pruning drift in sync behavior.
- M4 read-only diagnostics are deliberately out of scope for this PR.

## Follow-up

- Implement M4 read-only structure diagnostics on top of these seams.