### PR TITLE
feat(structure): add explicit scene chapter assignment

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -12,7 +12,7 @@ It supports metadata-first reasoning, explicit prose editing workflows, and revi
 Active initiative: [Target Architecture Migration](docs/initiatives/active/target-architecture-migration/prd.md).
 
 The active product focus is behavior-preserving design consolidation around structural manuscript state, especially the boundaries captured in [Managed Structure Contract](docs/foundations/managed-structure-contract.md).
-Current implementation focus: M5, adding the first explicit scene-to-chapter mutation workflow on top of the read-only diagnostics established in M4.
+Current implementation focus: M6, normalizing compatibility chapter resolution now that M5 introduced the first explicit scene-to-chapter mutation workflow.
 
 ---
 

--- a/docs/agents/tools.md
+++ b/docs/agents/tools.md
@@ -38,6 +38,7 @@
 - [`create_place_sheet`](#create_place_sheet)
 - [`upsert_thread_link`](#upsert_thread_link)
 - [`upsert_reference_link`](#upsert_reference_link)
+- [`assign_scene_to_chapter`](#assign_scene_to_chapter)
 - [`update_scene_metadata`](#update_scene_metadata)
 - [`update_character_sheet`](#update_character_sheet)
 - [`update_place_sheet`](#update_place_sheet)
@@ -465,6 +466,18 @@ Create or update an explicit reference link from a scene, character, place, or r
 | `source_project_id` | `string` | No | Optional project scope for the source. For scene/character/place sources, use this to disambiguate an ambiguous source_id across projects. For reference sources, when provided, it is treated as an ownership check and must match the source reference doc's project. |
 | `target_doc_id` | `string` | Yes | Target reference doc_id. |
 | `relation` | `string` | Yes | Relationship label (for example: 'informs', 'related', 'history_of'). The value is trimmed and lowercased before validation. |
+
+---
+
+## assign_scene_to_chapter
+
+Assign a scene to a canonical chapter through the explicit structure workflow. Writes chapter_id plus compatibility chapter/chapter_title fields to the scene sidecar and refreshes the index. Pass chapter_id=null to clear an explicit chapter link on an unchaptered scene. Use list_chapters first to choose a valid canonical chapter_id.
+
+| Parameter | Type | Required | Description |
+| --- | --- | :---: | --- |
+| `scene_id` | `string` | Yes | The scene_id to assign (e.g. 'sc-011-sebastian'). |
+| `project_id` | `string` | Yes | Project the scene belongs to (e.g. 'the-lamb'). |
+| `chapter_id` | `string` | Yes | Canonical chapter identifier. Use list_chapters to find valid values. Pass null to clear an explicit chapter link on an unchaptered scene. |
 
 ---
 

--- a/docs/initiatives/active/target-architecture-migration/milestones.md
+++ b/docs/initiatives/active/target-architecture-migration/milestones.md
@@ -1,7 +1,7 @@
 # Target Architecture Migration — Milestones
 
 Status: Active  
-Current milestone: M5 — Introduce Explicit Scene-to-Chapter Mutation  
+Current milestone: M6 — Normalize Compatibility Resolution  
 Owner: MCP Writing  
 Date: 2026-05-17
 
@@ -180,6 +180,8 @@ Out of scope:
 - Canonical storage redesign.
 
 ## M5 — Introduce Explicit Scene-to-Chapter Mutation
+
+Status: Complete.
 
 Goal: add the first sanctioned daily-work structural mutation path.
 

--- a/release-log.md
+++ b/release-log.md
@@ -6,6 +6,14 @@ This complements `CHANGELOG.md`:
 - `CHANGELOG.md` is technical and release-oriented.
 - This log is plain-language and outcome-oriented.
 
+### 2026-05-18 — Add explicit scene chapter assignment
+
+- What changed: Added an `assign_scene_to_chapter` workflow for assigning unchaptered scenes to canonical chapters or clearing explicit scene chapter links.
+- Why it matters: Authors and AI agents now have a named structural operation for chapter assignment instead of relying on generic metadata edits for structural intent.
+- Who is affected: Maintainers and contributors working on Target Architecture Migration M5, plus agents repairing scene-to-chapter links.
+- Action needed: Use `list_chapters` to choose a canonical `chapter_id`, then call `assign_scene_to_chapter` for structural assignment work.
+- PR: TBD
+
 ### 2026-05-18 — Add read-only structure diagnostics
 
 - What changed: Added a read-only `diagnose_structure` workflow for reporting chapter, epigraph, folder-derived, and compatibility-field drift before any repair work.

--- a/release-log.md
+++ b/release-log.md
@@ -12,7 +12,7 @@ This complements `CHANGELOG.md`:
 - Why it matters: Authors and AI agents now have a named structural operation for chapter assignment instead of relying on generic metadata edits for structural intent.
 - Who is affected: Maintainers and contributors working on Target Architecture Migration M5, plus agents repairing scene-to-chapter links.
 - Action needed: Use `list_chapters` to choose a canonical `chapter_id`, then call `assign_scene_to_chapter` for structural assignment work.
-- PR: TBD
+- PR: [#203](https://github.com/hannasdev/mcp-writing/pull/203)
 
 ### 2026-05-18 — Add read-only structure diagnostics
 

--- a/src/structure/scene-chapter-assignment.js
+++ b/src/structure/scene-chapter-assignment.js
@@ -45,7 +45,24 @@ export function buildSceneChapterAssignmentPlan(syncDir, filePath, meta = {}, { 
         message: "Cannot assign a scene to a different chapter while its file path implies another canonical chapter.",
         details: {
           requested_chapter_id: chapter.chapter_id,
+          requested_chapter: chapter.sort_index,
           path_chapter: pathChapter.chapter_id,
+          path_chapter_number: pathChapterNumber,
+        },
+      },
+    };
+  }
+
+  if (!pathChapter && pathChapterNumber !== null && pathChapterNumber !== chapter.sort_index) {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION_ERROR",
+        message: "Cannot assign a scene to a different chapter while its file path implies another compatibility chapter.",
+        details: {
+          requested_chapter_id: chapter.chapter_id,
+          requested_chapter: chapter.sort_index,
+          path_chapter: pathChapterNumber,
         },
       },
     };

--- a/src/structure/scene-chapter-assignment.js
+++ b/src/structure/scene-chapter-assignment.js
@@ -1,0 +1,60 @@
+import { applySceneStructurePatch } from "./structure-inference.js";
+
+export function buildSceneChapterAssignmentPlan(syncDir, filePath, meta = {}, { chapter } = {}) {
+  if (chapter === undefined) {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION_ERROR",
+        message: "Provide a canonical chapter or null to clear the scene chapter link.",
+      },
+    };
+  }
+
+  const currentStructure = applySceneStructurePatch(syncDir, filePath, meta);
+  const pathChapter = currentStructure.chapterStructure.chapter ?? null;
+  const pathChapterNumber = currentStructure.derived.chapter ?? null;
+
+  if (chapter === null) {
+    if (pathChapter || pathChapterNumber !== null) {
+      return {
+        ok: false,
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "chapter_id cannot be cleared for a scene whose file path implies a chapter.",
+          details: {
+            path_chapter: pathChapter?.chapter_id ?? pathChapterNumber,
+          },
+        },
+      };
+    }
+
+    return {
+      ok: true,
+      meta: applySceneStructurePatch(syncDir, filePath, meta, { chapter: null }).meta,
+      assignedChapter: null,
+      previousChapterId: meta.chapter_id ?? null,
+    };
+  }
+
+  if (pathChapter && pathChapter.chapter_id !== chapter.chapter_id) {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION_ERROR",
+        message: "Cannot assign a scene to a different chapter while its file path implies another canonical chapter.",
+        details: {
+          requested_chapter_id: chapter.chapter_id,
+          path_chapter: pathChapter.chapter_id,
+        },
+      },
+    };
+  }
+
+  return {
+    ok: true,
+    meta: applySceneStructurePatch(syncDir, filePath, meta, { chapter }).meta,
+    assignedChapter: chapter,
+    previousChapterId: meta.chapter_id ?? null,
+  };
+}

--- a/src/test/integration/metadata.test.mjs
+++ b/src/test/integration/metadata.test.mjs
@@ -219,6 +219,55 @@ describe("assign_scene_to_chapter tool", () => {
     assert.equal(findParsed.results.some((row) => row.scene_id === "sc-m5-clear"), false);
   });
 
+  test("reports previous chapter from sidecar when index is stale", async () => {
+    const sceneDir = path.join(writeSyncDir, "projects", "test-novel", "scenes");
+    fs.mkdirSync(sceneDir, { recursive: true });
+    const scenePath = path.join(sceneDir, "sc-m5-stale-index.md");
+    fs.writeFileSync(
+      scenePath,
+      "---\nscene_id: sc-m5-stale-index\ntitle: Stale Index Scene\n---\nM5 stale index prose.",
+      "utf8"
+    );
+
+    await callWriteTool("sync");
+
+    const chaptersText = await callWriteTool("list_chapters", { project_id: "test-novel" });
+    const chaptersParsed = JSON.parse(chaptersText);
+    const firstChapter = chaptersParsed.results.find((row) => row.sort_index === 1);
+    const secondChapter = chaptersParsed.results.find((row) => row.sort_index === 2);
+    assert.ok(firstChapter);
+    assert.ok(secondChapter);
+
+    await callWriteTool("assign_scene_to_chapter", {
+      scene_id: "sc-m5-stale-index",
+      project_id: "test-novel",
+      chapter_id: firstChapter.chapter_id,
+    });
+
+    const sidecarFile = path.join(sceneDir, "sc-m5-stale-index.meta.yaml");
+    const sidecar = yaml.load(fs.readFileSync(sidecarFile, "utf8"));
+    fs.writeFileSync(
+      sidecarFile,
+      yaml.dump({
+        ...sidecar,
+        chapter_id: secondChapter.chapter_id,
+        chapter: secondChapter.sort_index,
+        chapter_title: secondChapter.title,
+      }),
+      "utf8"
+    );
+
+    const clearText = await callWriteTool("assign_scene_to_chapter", {
+      scene_id: "sc-m5-stale-index",
+      project_id: "test-novel",
+      chapter_id: null,
+    });
+    const clearParsed = JSON.parse(clearText);
+
+    assert.equal(clearParsed.ok, true);
+    assert.equal(clearParsed.previous_chapter_id, secondChapter.chapter_id);
+  });
+
   test("rejects assignment when the scene path implies another chapter", async () => {
     const chaptersText = await callWriteTool("list_chapters", { project_id: "test-novel" });
     const chaptersParsed = JSON.parse(chaptersText);

--- a/src/test/integration/metadata.test.mjs
+++ b/src/test/integration/metadata.test.mjs
@@ -116,6 +116,130 @@ describe("update_scene_metadata tool", () => {
   });
 });
 
+describe("assign_scene_to_chapter tool", () => {
+  test("assigns an unchaptered scene and reflects it in chapter-aware reads", async () => {
+    const sceneDir = path.join(writeSyncDir, "projects", "test-novel", "scenes");
+    fs.mkdirSync(sceneDir, { recursive: true });
+    const scenePath = path.join(sceneDir, "sc-m5-assigned.md");
+    fs.writeFileSync(
+      scenePath,
+      "---\nscene_id: sc-m5-assigned\ntitle: Assigned M5 Scene\ntimeline_position: 42\n---\nM5 assignment prose.",
+      "utf8"
+    );
+
+    await callWriteTool("sync");
+
+    const chaptersText = await callWriteTool("list_chapters", { project_id: "test-novel" });
+    const chaptersParsed = JSON.parse(chaptersText);
+    const secondChapter = chaptersParsed.results.find((row) => row.sort_index === 2);
+    assert.ok(secondChapter);
+
+    const assignText = await callWriteTool("assign_scene_to_chapter", {
+      scene_id: "sc-m5-assigned",
+      project_id: "test-novel",
+      chapter_id: secondChapter.chapter_id,
+    });
+    const assignParsed = JSON.parse(assignText);
+    assert.equal(assignParsed.ok, true);
+    assert.equal(assignParsed.action, "assigned");
+    assert.equal(assignParsed.chapter.chapter_id, secondChapter.chapter_id);
+
+    const sidecarFile = path.join(sceneDir, "sc-m5-assigned.meta.yaml");
+    const sidecar = yaml.load(fs.readFileSync(sidecarFile, "utf8"));
+    assert.equal(sidecar.chapter_id, secondChapter.chapter_id);
+    assert.equal(sidecar.chapter, 2);
+    assert.equal(sidecar.chapter_title, secondChapter.title);
+
+    const findText = await callWriteTool("find_scenes", {
+      project_id: "test-novel",
+      chapter_id: secondChapter.chapter_id,
+    });
+    const findParsed = JSON.parse(findText);
+    assert.ok(findParsed.results.some((row) => row.scene_id === "sc-m5-assigned"));
+
+    const chapterProseText = await callWriteTool("get_chapter_prose", {
+      project_id: "test-novel",
+      chapter_id: secondChapter.chapter_id,
+    });
+    assert.ok(chapterProseText.includes("M5 assignment prose."));
+
+    const previewText = await callWriteTool("preview_review_bundle", {
+      project_id: "test-novel",
+      profile: "editor_detailed",
+      chapter_id: secondChapter.chapter_id,
+    });
+    const previewParsed = JSON.parse(previewText);
+    assert.ok(previewParsed.ordering.some((row) => row.scene_id === "sc-m5-assigned"));
+  });
+
+  test("clears an explicit chapter link for an unchaptered scene", async () => {
+    const sceneDir = path.join(writeSyncDir, "projects", "test-novel", "scenes");
+    fs.mkdirSync(sceneDir, { recursive: true });
+    const scenePath = path.join(sceneDir, "sc-m5-clear.md");
+    fs.writeFileSync(
+      scenePath,
+      "---\nscene_id: sc-m5-clear\ntitle: Clear M5 Scene\n---\nM5 clear prose.",
+      "utf8"
+    );
+
+    await callWriteTool("sync");
+
+    const chaptersText = await callWriteTool("list_chapters", { project_id: "test-novel" });
+    const chaptersParsed = JSON.parse(chaptersText);
+    const firstChapter = chaptersParsed.results.find((row) => row.sort_index === 1);
+    assert.ok(firstChapter);
+
+    await callWriteTool("assign_scene_to_chapter", {
+      scene_id: "sc-m5-clear",
+      project_id: "test-novel",
+      chapter_id: firstChapter.chapter_id,
+    });
+
+    const clearText = await callWriteTool("assign_scene_to_chapter", {
+      scene_id: "sc-m5-clear",
+      project_id: "test-novel",
+      chapter_id: null,
+    });
+    const clearParsed = JSON.parse(clearText);
+    assert.equal(clearParsed.ok, true);
+    assert.equal(clearParsed.action, "cleared");
+    assert.equal(clearParsed.chapter, null);
+
+    const sidecarFile = path.join(sceneDir, "sc-m5-clear.meta.yaml");
+    const sidecar = yaml.load(fs.readFileSync(sidecarFile, "utf8"));
+    assert.equal(sidecar.chapter_id, null);
+    assert.equal(sidecar.chapter, null);
+    assert.equal(sidecar.chapter_title, null);
+
+    const findText = await callWriteTool("find_scenes", {
+      project_id: "test-novel",
+      chapter_id: firstChapter.chapter_id,
+    });
+    const findParsed = JSON.parse(findText);
+    assert.equal(findParsed.results.some((row) => row.scene_id === "sc-m5-clear"), false);
+  });
+
+  test("rejects assignment when the scene path implies another chapter", async () => {
+    const chaptersText = await callWriteTool("list_chapters", { project_id: "test-novel" });
+    const chaptersParsed = JSON.parse(chaptersText);
+    const secondChapter = chaptersParsed.results.find((row) => row.sort_index === 2);
+    assert.ok(secondChapter);
+
+    const assignText = await callWriteTool("assign_scene_to_chapter", {
+      scene_id: "sc-001",
+      project_id: "test-novel",
+      chapter_id: secondChapter.chapter_id,
+    });
+    const assignParsed = JSON.parse(assignText);
+
+    assert.equal(assignParsed.ok, false);
+    assert.equal(assignParsed.error.code, "VALIDATION_ERROR");
+    assert.match(assignParsed.error.message, /file path implies another canonical chapter/);
+    assert.equal(assignParsed.error.details.requested_chapter_id, secondChapter.chapter_id);
+    assert.notEqual(assignParsed.error.details.path_chapter, null);
+  });
+});
+
 describe("update_character_sheet tool", () => {
   test("updates arc_summary and reflects in get_character_sheet", async () => {
     const text = await callWriteTool("update_character_sheet", {

--- a/src/test/unit/scene-chapter-assignment.test.mjs
+++ b/src/test/unit/scene-chapter-assignment.test.mjs
@@ -1,0 +1,74 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { buildSceneChapterAssignmentPlan } from "../../structure/scene-chapter-assignment.js";
+
+describe("buildSceneChapterAssignmentPlan", () => {
+  const chapter = {
+    chapter_id: "ch-02-second",
+    sort_index: 2,
+    title: "Second",
+  };
+
+  test("builds sidecar fields for a canonical assignment", () => {
+    const syncDir = "/sync";
+    const filePath = path.join(syncDir, "projects", "book", "scenes", "loose.md");
+
+    const plan = buildSceneChapterAssignmentPlan(syncDir, filePath, {
+      scene_id: "sc-loose",
+      title: "Loose",
+    }, { chapter });
+
+    assert.equal(plan.ok, true);
+    assert.equal(plan.meta.chapter_id, "ch-02-second");
+    assert.equal(plan.meta.chapter, 2);
+    assert.equal(plan.meta.chapter_title, "Second");
+    assert.deepEqual(plan.assignedChapter, chapter);
+  });
+
+  test("clears a chapter link for a scene without path-derived chapter structure", () => {
+    const syncDir = "/sync";
+    const filePath = path.join(syncDir, "projects", "book", "scenes", "loose.md");
+
+    const plan = buildSceneChapterAssignmentPlan(syncDir, filePath, {
+      scene_id: "sc-loose",
+      chapter_id: "ch-02-second",
+      chapter: 2,
+      chapter_title: "Second",
+    }, { chapter: null });
+
+    assert.equal(plan.ok, true);
+    assert.equal(plan.meta.chapter_id, null);
+    assert.equal(plan.meta.chapter, null);
+    assert.equal(plan.meta.chapter_title, null);
+    assert.equal(plan.assignedChapter, null);
+  });
+
+  test("rejects clearing a path-chaptered scene", () => {
+    const syncDir = "/sync";
+    const filePath = path.join(syncDir, "projects", "book", "part-1", "chapter-1", "sc-001.md");
+
+    const plan = buildSceneChapterAssignmentPlan(syncDir, filePath, {
+      scene_id: "sc-001",
+      chapter_id: "ch-01-first",
+    }, { chapter: null });
+
+    assert.equal(plan.ok, false);
+    assert.equal(plan.error.code, "VALIDATION_ERROR");
+    assert.match(plan.error.message, /file path implies a chapter/);
+  });
+
+  test("rejects assignment that conflicts with explicit folder-derived structure", () => {
+    const syncDir = "/sync";
+    const filePath = path.join(syncDir, "projects", "book", "Draft", "01-First", "sc-001.md");
+
+    const plan = buildSceneChapterAssignmentPlan(syncDir, filePath, {
+      scene_id: "sc-001",
+    }, { chapter });
+
+    assert.equal(plan.ok, false);
+    assert.equal(plan.error.code, "VALIDATION_ERROR");
+    assert.equal(plan.error.details.requested_chapter_id, "ch-02-second");
+    assert.equal(plan.error.details.path_chapter, "ch-01-first");
+  });
+});

--- a/src/test/unit/scene-chapter-assignment.test.mjs
+++ b/src/test/unit/scene-chapter-assignment.test.mjs
@@ -71,4 +71,20 @@ describe("buildSceneChapterAssignmentPlan", () => {
     assert.equal(plan.error.details.requested_chapter_id, "ch-02-second");
     assert.equal(plan.error.details.path_chapter, "ch-01-first");
   });
+
+  test("rejects assignment that conflicts with legacy path-derived chapter structure", () => {
+    const syncDir = "/sync";
+    const filePath = path.join(syncDir, "projects", "book", "part-1", "chapter-1", "sc-001.md");
+
+    const plan = buildSceneChapterAssignmentPlan(syncDir, filePath, {
+      scene_id: "sc-001",
+    }, { chapter });
+
+    assert.equal(plan.ok, false);
+    assert.equal(plan.error.code, "VALIDATION_ERROR");
+    assert.equal(plan.error.details.requested_chapter_id, "ch-02-second");
+    assert.equal(plan.error.details.requested_chapter, 2);
+    assert.equal(plan.error.details.path_chapter, "ch-01-chapter-1");
+    assert.equal(plan.error.details.path_chapter_number, 1);
+  });
 });

--- a/src/tools/metadata.js
+++ b/src/tools/metadata.js
@@ -585,7 +585,7 @@ export function registerMetadataTools(s, {
           action: chapter === null ? "cleared" : "assigned",
           scene_id,
           project_id,
-          previous_chapter_id: scene.chapter_id ?? plan.previousChapterId ?? null,
+          previous_chapter_id: plan.previousChapterId ?? scene.chapter_id ?? null,
           chapter: plan.assignedChapter,
         });
       } catch (err) {

--- a/src/tools/metadata.js
+++ b/src/tools/metadata.js
@@ -4,6 +4,7 @@ import matter from "gray-matter";
 import { readMeta, writeMeta, indexSceneFile, applySceneStructurePatch } from "../sync/sync.js";
 import { validateProjectId, validateUniverseId } from "../sync/importer.js";
 import { resolveValidatedChapterFilter } from "../core/chapter-resolution.js";
+import { buildSceneChapterAssignmentPlan } from "../structure/scene-chapter-assignment.js";
 import {
   persistSceneReferenceLink,
   upsertExplicitReferenceLinkRow,
@@ -507,6 +508,92 @@ export function registerMetadataTools(s, {
         action: "upserted",
         link,
       });
+    }
+  );
+
+  // ---- assign_scene_to_chapter --------------------------------------------
+  s.tool(
+    "assign_scene_to_chapter",
+    "Assign a scene to a canonical chapter through the explicit structure workflow. Writes chapter_id plus compatibility chapter/chapter_title fields to the scene sidecar and refreshes the index. Pass chapter_id=null to clear an explicit chapter link on an unchaptered scene. Use list_chapters first to choose a valid canonical chapter_id.",
+    {
+      scene_id: z.string().describe("The scene_id to assign (e.g. 'sc-011-sebastian')."),
+      project_id: z.string().describe("Project the scene belongs to (e.g. 'the-lamb')."),
+      chapter_id: z.string().nullable().describe("Canonical chapter identifier. Use list_chapters to find valid values. Pass null to clear an explicit chapter link on an unchaptered scene."),
+    },
+    async ({ scene_id, project_id, chapter_id }) => {
+      if (!SYNC_DIR_WRITABLE) {
+        return errorResponse("READ_ONLY", "Cannot assign scene to chapter: sync dir is read-only.");
+      }
+
+      const projectIdCheck = validateProjectId(project_id);
+      if (!projectIdCheck.ok) {
+        return errorResponse("INVALID_PROJECT_ID", projectIdCheck.reason, { project_id });
+      }
+
+      const scene = db.prepare(`
+        SELECT scene_id, project_id, chapter_id, file_path
+        FROM scenes
+        WHERE scene_id = ? AND project_id = ?
+      `).get(scene_id, project_id);
+      if (!scene) {
+        return errorResponse("NOT_FOUND", `Scene '${scene_id}' not found in project '${project_id}'.`);
+      }
+
+      let chapter = null;
+      if (chapter_id !== null) {
+        const resolvedChapterFilter = resolveValidatedChapterFilter(db, {
+          projectId: project_id,
+          chapterId: chapter_id,
+        });
+
+        if (resolvedChapterFilter.error) {
+          return errorResponse(
+            resolvedChapterFilter.error.code,
+            resolvedChapterFilter.error.message,
+            { project_id, chapter_id }
+          );
+        }
+
+        chapter = resolvedChapterFilter.chapter;
+        if (!chapter) {
+          return errorResponse("NOT_FOUND", "Chapter not found for the provided project and identifier.", {
+            project_id,
+            chapter_id,
+          });
+        }
+      }
+
+      try {
+        const { meta } = readMeta(scene.file_path, SYNC_DIR, { writable: true });
+        const plan = buildSceneChapterAssignmentPlan(SYNC_DIR, scene.file_path, meta, { chapter });
+        if (!plan.ok) {
+          return errorResponse(plan.error.code, plan.error.message, {
+            project_id,
+            scene_id,
+            chapter_id,
+            ...(plan.error.details ?? {}),
+          });
+        }
+
+        writeMeta(scene.file_path, plan.meta);
+
+        const { content: prose } = matter(fs.readFileSync(scene.file_path, "utf8"));
+        indexSceneFile(db, SYNC_DIR, scene.file_path, plan.meta, prose);
+
+        return jsonResponse({
+          ok: true,
+          action: chapter === null ? "cleared" : "assigned",
+          scene_id,
+          project_id,
+          previous_chapter_id: scene.chapter_id ?? plan.previousChapterId ?? null,
+          chapter: plan.assignedChapter,
+        });
+      } catch (err) {
+        if (err.code === "ENOENT") {
+          return errorResponse("STALE_PATH", `Prose file for scene '${scene_id}' not found at indexed path — the file may have moved. Run sync() to refresh.`, { indexed_path: scene.file_path });
+        }
+        return errorResponse("IO_ERROR", `Failed to assign scene '${scene_id}' to chapter: ${err.message}`);
+      }
     }
   );
 

--- a/src/workflows/workflow-catalogue.js
+++ b/src/workflows/workflow-catalogue.js
@@ -76,6 +76,17 @@ export const WORKFLOW_CATALOGUE = [
     ],
   },
   {
+    id: "structure_assignment",
+    label: "Assign a scene to a chapter",
+    use_when: "Use when the user wants to move an unchaptered scene into a canonical chapter, repair an explicit scene chapter link, or clear a scene's explicit chapter assignment.",
+    steps: [
+      { tool: "find_scenes", note: "Identify the target scene and confirm project_id if the user did not provide both." },
+      { tool: "list_chapters", note: "Choose the canonical chapter_id for the target project before assigning." },
+      { tool: "assign_scene_to_chapter", note: "Use this named structure workflow for chapter assignment or clearing instead of editing chapter fields through generic metadata updates." },
+      { tool: "diagnose_structure", note: "Run when the assignment is part of a drift repair workflow or when folder-derived structure may disagree with the requested link." },
+    ],
+  },
+  {
     id: "review_preparation",
     label: "Prepare material for human review",
     use_when: "Use when the task has shifted from reasoning or revising into packaging material for editors, collaborators, or beta readers.",


### PR DESCRIPTION
## Summary

- Adds `assign_scene_to_chapter` as the explicit M5 scene-to-chapter mutation workflow.
- Writes canonical `chapter_id` plus compatibility `chapter`/`chapter_title` fields through the shared structure patch path and refreshes the scene index immediately.
- Updates workflow/tool docs, release notes, and target-architecture milestone status to move active focus to M6.

## Motivation

M5 calls for the first sanctioned daily-work structural mutation path. This gives agents and maintainers a named operation for scene chapter assignment instead of relying on generic metadata edits for structural intent.

## Implementation

- Added a focused `buildSceneChapterAssignmentPlan` helper for assignment and clearing validation.
- Added the public `assign_scene_to_chapter` MCP tool in the metadata tool group.
- Allows clearing explicit chapter links for unchaptered scenes, while rejecting assignments that would conflict with folder-derived chapter authority.
- Kept existing `update_scene_metadata` compatibility behavior in place.

## Testing

- `node --experimental-sqlite --test src/test/unit/scene-chapter-assignment.test.mjs`
- `node --experimental-sqlite --test --test-concurrency=1 src/test/integration/metadata.test.mjs`
- `npm run lint`
- `npm run test:unit`
- `npm run test:integration`
- `npm run guard:legacy-root-imports`

## Risks and tradeoffs

- Folder-derived chapter structure remains authoritative for scenes whose paths imply a chapter. The new tool fails fast instead of writing a link that sync would immediately override.
- The generic metadata update compatibility path remains available until later migration milestones decide how to narrow it.

## Follow-up

- M6: normalize numeric compatibility chapter resolution across the remaining chapter-aware tools.
