### PR TITLE
feat(structure): add explicit M7 mutation commands

### DIFF
--- a/docs/agents/tools.md
+++ b/docs/agents/tools.md
@@ -39,6 +39,7 @@
 - [`upsert_thread_link`](#upsert_thread_link)
 - [`upsert_reference_link`](#upsert_reference_link)
 - [`create_chapter`](#create_chapter)
+- [`rename_chapter`](#rename_chapter)
 - [`assign_scene_to_chapter`](#assign_scene_to_chapter)
 - [`update_scene_metadata`](#update_scene_metadata)
 - [`update_character_sheet`](#update_character_sheet)
@@ -481,6 +482,18 @@ Create a canonical chapter record through the explicit structure workflow. Write
 | `sort_index` | `integer` | Yes | Canonical chapter order within the project. Must be unused. |
 | `chapter_id` | `string` | No | Optional canonical chapter identifier. If omitted, one is derived from sort_index and title. |
 | `logline` | `string` | No | Optional chapter-level logline. |
+
+---
+
+## rename_chapter
+
+Rename a canonical chapter through the explicit structure workflow. Updates canonical chapter state and explicit scene chapter_title compatibility fields; it does not rename scene files, sidecars by path-derived structure, or Scrivener-compatible folders.
+
+| Parameter | Type | Required | Description |
+| --- | --- | :---: | --- |
+| `project_id` | `string` | Yes | Project the chapter belongs to (e.g. 'the-lamb'). |
+| `chapter_id` | `string` | Yes | Canonical chapter identifier. Use list_chapters to find valid values. |
+| `title` | `string` | Yes | New human-readable chapter title. |
 
 ---
 

--- a/docs/agents/tools.md
+++ b/docs/agents/tools.md
@@ -40,6 +40,7 @@
 - [`upsert_reference_link`](#upsert_reference_link)
 - [`create_chapter`](#create_chapter)
 - [`rename_chapter`](#rename_chapter)
+- [`reorder_chapter`](#reorder_chapter)
 - [`assign_scene_to_chapter`](#assign_scene_to_chapter)
 - [`update_scene_metadata`](#update_scene_metadata)
 - [`update_character_sheet`](#update_character_sheet)
@@ -494,6 +495,18 @@ Rename a canonical chapter through the explicit structure workflow. Updates cano
 | `project_id` | `string` | Yes | Project the chapter belongs to (e.g. 'the-lamb'). |
 | `chapter_id` | `string` | Yes | Canonical chapter identifier. Use list_chapters to find valid values. |
 | `title` | `string` | Yes | New human-readable chapter title. |
+
+---
+
+## reorder_chapter
+
+Reorder a canonical chapter through the explicit structure workflow. Updates canonical chapter order and explicit scene chapter/chapter_title compatibility fields; it does not rename, move, or resequence scene files, sidecars by path-derived structure, or Scrivener-compatible folders.
+
+| Parameter | Type | Required | Description |
+| --- | --- | :---: | --- |
+| `project_id` | `string` | Yes | Project the chapter belongs to (e.g. 'the-lamb'). |
+| `chapter_id` | `string` | Yes | Canonical chapter identifier. Use list_chapters to find valid values. |
+| `sort_index` | `integer` | Yes | New canonical chapter order within the project. Must be unused. |
 
 ---
 

--- a/docs/agents/tools.md
+++ b/docs/agents/tools.md
@@ -41,6 +41,8 @@
 - [`create_chapter`](#create_chapter)
 - [`rename_chapter`](#rename_chapter)
 - [`reorder_chapter`](#reorder_chapter)
+- [`attach_epigraph`](#attach_epigraph)
+- [`move_scene`](#move_scene)
 - [`assign_scene_to_chapter`](#assign_scene_to_chapter)
 - [`update_scene_metadata`](#update_scene_metadata)
 - [`update_character_sheet`](#update_character_sheet)
@@ -507,6 +509,31 @@ Reorder a canonical chapter through the explicit structure workflow. Updates can
 | `project_id` | `string` | Yes | Project the chapter belongs to (e.g. 'the-lamb'). |
 | `chapter_id` | `string` | Yes | Canonical chapter identifier. Use list_chapters to find valid values. |
 | `sort_index` | `integer` | Yes | New canonical chapter order within the project. Must be unused. |
+
+---
+
+## attach_epigraph
+
+Attach an existing canonical epigraph to a canonical chapter through the explicit structure workflow. Updates canonical epigraph linkage and explicit epigraph sidecar fields; it does not move, rename, or create epigraph source files or Scrivener-compatible folders.
+
+| Parameter | Type | Required | Description |
+| --- | --- | :---: | --- |
+| `project_id` | `string` | Yes | Project the epigraph belongs to (e.g. 'the-lamb'). |
+| `epigraph_id` | `string` | Yes | Canonical epigraph identifier. Use find_epigraphs to find valid values. |
+| `chapter_id` | `string` | Yes | Canonical chapter identifier. Use list_chapters to find valid values. |
+
+---
+
+## move_scene
+
+Move a scene through the explicit structure workflow. Updates canonical chapter linkage and/or timeline_position in the scene sidecar and index; it does not move, rename, or resequence scene files or Scrivener-compatible folders.
+
+| Parameter | Type | Required | Description |
+| --- | --- | :---: | --- |
+| `scene_id` | `string` | Yes | The scene_id to move (e.g. 'sc-011-sebastian'). |
+| `project_id` | `string` | Yes | Project the scene belongs to (e.g. 'the-lamb'). |
+| `chapter_id` | `string` | No | Optional canonical chapter identifier. Use list_chapters to find valid values. Omit to keep the current chapter. |
+| `timeline_position` | `integer` | No | Optional new position within the target chapter. Must be unused. |
 
 ---
 

--- a/docs/agents/tools.md
+++ b/docs/agents/tools.md
@@ -38,6 +38,7 @@
 - [`create_place_sheet`](#create_place_sheet)
 - [`upsert_thread_link`](#upsert_thread_link)
 - [`upsert_reference_link`](#upsert_reference_link)
+- [`create_chapter`](#create_chapter)
 - [`assign_scene_to_chapter`](#assign_scene_to_chapter)
 - [`update_scene_metadata`](#update_scene_metadata)
 - [`update_character_sheet`](#update_character_sheet)
@@ -466,6 +467,20 @@ Create or update an explicit reference link from a scene, character, place, or r
 | `source_project_id` | `string` | No | Optional project scope for the source. For scene/character/place sources, use this to disambiguate an ambiguous source_id across projects. For reference sources, when provided, it is treated as an ownership check and must match the source reference doc's project. |
 | `target_doc_id` | `string` | Yes | Target reference doc_id. |
 | `relation` | `string` | Yes | Relationship label (for example: 'informs', 'related', 'history_of'). The value is trimmed and lowercased before validation. |
+
+---
+
+## create_chapter
+
+Create a canonical chapter record through the explicit structure workflow. Writes canonical chapter state only; it does not create scene files, sidecars, or Scrivener-compatible folders. Use assign_scene_to_chapter afterward to place unchaptered scenes in the new chapter.
+
+| Parameter | Type | Required | Description |
+| --- | --- | :---: | --- |
+| `project_id` | `string` | Yes | Project the chapter belongs to (e.g. 'the-lamb'). |
+| `title` | `string` | Yes | Human-readable chapter title. |
+| `sort_index` | `integer` | Yes | Canonical chapter order within the project. Must be unused. |
+| `chapter_id` | `string` | No | Optional canonical chapter identifier. If omitted, one is derived from sort_index and title. |
+| `logline` | `string` | No | Optional chapter-level logline. |
 
 ---
 

--- a/release-log.md
+++ b/release-log.md
@@ -12,7 +12,7 @@ This complements `CHANGELOG.md`:
 - Why it matters: Authors and AI agents can now express simple scene placement changes through a named structure operation, with validation for occupied positions and diagnostics when folder representation may need follow-up.
 - Who is affected: Authors, maintainers, and AI agents working on Target Architecture Migration M7 or explicit scene/chapter structure workflows.
 - Action needed: Use `list_chapters` to choose a canonical `chapter_id` when changing chapters, then call `move_scene` with a target chapter and/or `timeline_position`; run `diagnose_structure` if folder-derived structure may still reflect the old placement.
-- PR: TBD
+- PR: [#205](https://github.com/hannasdev/mcp-writing/pull/205)
 
 ### 2026-05-18 — Add explicit epigraph attachment
 
@@ -20,7 +20,7 @@ This complements `CHANGELOG.md`:
 - Why it matters: Authors and AI agents can now repair or adjust chapter-opening epigraph placement through a named structure operation, with clear diagnostics when the source-file representation may need follow-up.
 - Who is affected: Authors, maintainers, and AI agents working on Target Architecture Migration M7 or explicit chapter/epigraph structure workflows.
 - Action needed: Use `find_epigraphs` to choose an existing `epigraph_id` and `list_chapters` to choose a canonical `chapter_id`, then call `attach_epigraph`; run `diagnose_structure` if folder-derived structure may still reflect the old attachment.
-- PR: TBD
+- PR: [#205](https://github.com/hannasdev/mcp-writing/pull/205)
 
 ### 2026-05-18 — Add explicit chapter reorder
 
@@ -28,7 +28,7 @@ This complements `CHANGELOG.md`:
 - Why it matters: Authors and AI agents can now express simple chapter-order changes through a named structure operation, with clear diagnostics when folder representation may need follow-up.
 - Who is affected: Authors, maintainers, and AI agents working on Target Architecture Migration M7 or explicit chapter-structure workflows.
 - Action needed: Use `list_chapters` to choose a canonical `chapter_id` and an unused `sort_index`, then call `reorder_chapter`; run `diagnose_structure` if folder-derived structure may still reflect the old order.
-- PR: TBD
+- PR: [#205](https://github.com/hannasdev/mcp-writing/pull/205)
 
 ### 2026-05-18 — Add explicit chapter rename
 
@@ -36,7 +36,7 @@ This complements `CHANGELOG.md`:
 - Why it matters: Authors and AI agents can now express chapter-title changes through a named structure operation instead of generic metadata edits, while still seeing diagnostics when folder representation may need follow-up.
 - Who is affected: Authors, maintainers, and AI agents working on Target Architecture Migration M7 or explicit chapter-structure workflows.
 - Action needed: Use `list_chapters` to choose a canonical `chapter_id`, then call `rename_chapter`; run `diagnose_structure` if folder-derived structure may still reflect the old title.
-- PR: TBD
+- PR: [#205](https://github.com/hannasdev/mcp-writing/pull/205)
 
 ### 2026-05-18 — Add explicit chapter creation
 
@@ -44,7 +44,7 @@ This complements `CHANGELOG.md`:
 - Why it matters: Authors and AI agents now have a named structural operation for adding chapter state before assigning scenes, keeping chapter creation out of generic metadata edits.
 - Who is affected: Authors, maintainers, and AI agents working on Target Architecture Migration M7 or explicit chapter-structure workflows.
 - Action needed: Use `list_chapters` to inspect existing order, then call `create_chapter` for a new canonical chapter and `assign_scene_to_chapter` for scene placement.
-- PR: TBD
+- PR: [#205](https://github.com/hannasdev/mcp-writing/pull/205)
 
 ### 2026-05-18 — Normalize chapter compatibility targeting
 

--- a/release-log.md
+++ b/release-log.md
@@ -6,6 +6,14 @@ This complements `CHANGELOG.md`:
 - `CHANGELOG.md` is technical and release-oriented.
 - This log is plain-language and outcome-oriented.
 
+### 2026-05-18 — Add explicit chapter reorder
+
+- What changed: Added a `reorder_chapter` workflow for changing canonical chapter order and refreshing explicit scene `chapter` compatibility fields.
+- Why it matters: Authors and AI agents can now express simple chapter-order changes through a named structure operation, with clear diagnostics when folder representation may need follow-up.
+- Who is affected: Authors, maintainers, and AI agents working on Target Architecture Migration M7 or explicit chapter-structure workflows.
+- Action needed: Use `list_chapters` to choose a canonical `chapter_id` and an unused `sort_index`, then call `reorder_chapter`; run `diagnose_structure` if folder-derived structure may still reflect the old order.
+- PR: TBD
+
 ### 2026-05-18 — Add explicit chapter rename
 
 - What changed: Added a `rename_chapter` workflow for changing canonical chapter titles and refreshing explicit scene `chapter_title` compatibility fields.

--- a/release-log.md
+++ b/release-log.md
@@ -6,6 +6,22 @@ This complements `CHANGELOG.md`:
 - `CHANGELOG.md` is technical and release-oriented.
 - This log is plain-language and outcome-oriented.
 
+### 2026-05-19 — Add explicit scene move
+
+- What changed: Added a `move_scene` workflow for moving an existing scene to a canonical chapter and/or unused `timeline_position` without moving the source file.
+- Why it matters: Authors and AI agents can now express simple scene placement changes through a named structure operation, with validation for occupied positions and diagnostics when folder representation may need follow-up.
+- Who is affected: Authors, maintainers, and AI agents working on Target Architecture Migration M7 or explicit scene/chapter structure workflows.
+- Action needed: Use `list_chapters` to choose a canonical `chapter_id` when changing chapters, then call `move_scene` with a target chapter and/or `timeline_position`; run `diagnose_structure` if folder-derived structure may still reflect the old placement.
+- PR: TBD
+
+### 2026-05-18 — Add explicit epigraph attachment
+
+- What changed: Added an `attach_epigraph` workflow for moving an existing canonical epigraph relationship to another canonical chapter and refreshing explicit epigraph sidecar linkage.
+- Why it matters: Authors and AI agents can now repair or adjust chapter-opening epigraph placement through a named structure operation, with clear diagnostics when the source-file representation may need follow-up.
+- Who is affected: Authors, maintainers, and AI agents working on Target Architecture Migration M7 or explicit chapter/epigraph structure workflows.
+- Action needed: Use `find_epigraphs` to choose an existing `epigraph_id` and `list_chapters` to choose a canonical `chapter_id`, then call `attach_epigraph`; run `diagnose_structure` if folder-derived structure may still reflect the old attachment.
+- PR: TBD
+
 ### 2026-05-18 — Add explicit chapter reorder
 
 - What changed: Added a `reorder_chapter` workflow for changing canonical chapter order and refreshing explicit scene `chapter` compatibility fields.

--- a/release-log.md
+++ b/release-log.md
@@ -6,6 +6,14 @@ This complements `CHANGELOG.md`:
 - `CHANGELOG.md` is technical and release-oriented.
 - This log is plain-language and outcome-oriented.
 
+### 2026-05-18 — Add explicit chapter creation
+
+- What changed: Added a `create_chapter` workflow for creating canonical chapter records without generating scene files, sidecars, or Scrivener-compatible folders.
+- Why it matters: Authors and AI agents now have a named structural operation for adding chapter state before assigning scenes, keeping chapter creation out of generic metadata edits.
+- Who is affected: Authors, maintainers, and AI agents working on Target Architecture Migration M7 or explicit chapter-structure workflows.
+- Action needed: Use `list_chapters` to inspect existing order, then call `create_chapter` for a new canonical chapter and `assign_scene_to_chapter` for scene placement.
+- PR: TBD
+
 ### 2026-05-18 — Normalize chapter compatibility targeting
 
 - What changed: Numeric `chapter` and `chapters` filters now resolve through canonical chapter identity for search, prose retrieval, styleguide analysis, batch enrichment, and review-bundle planning.

--- a/release-log.md
+++ b/release-log.md
@@ -6,6 +6,14 @@ This complements `CHANGELOG.md`:
 - `CHANGELOG.md` is technical and release-oriented.
 - This log is plain-language and outcome-oriented.
 
+### 2026-05-18 — Add explicit chapter rename
+
+- What changed: Added a `rename_chapter` workflow for changing canonical chapter titles and refreshing explicit scene `chapter_title` compatibility fields.
+- Why it matters: Authors and AI agents can now express chapter-title changes through a named structure operation instead of generic metadata edits, while still seeing diagnostics when folder representation may need follow-up.
+- Who is affected: Authors, maintainers, and AI agents working on Target Architecture Migration M7 or explicit chapter-structure workflows.
+- Action needed: Use `list_chapters` to choose a canonical `chapter_id`, then call `rename_chapter`; run `diagnose_structure` if folder-derived structure may still reflect the old title.
+- PR: TBD
+
 ### 2026-05-18 — Add explicit chapter creation
 
 - What changed: Added a `create_chapter` workflow for creating canonical chapter records without generating scene files, sidecars, or Scrivener-compatible folders.

--- a/src/structure/chapter-commands.js
+++ b/src/structure/chapter-commands.js
@@ -310,6 +310,121 @@ export function buildReorderChapterPlan(db, {
   };
 }
 
+export function buildAttachEpigraphPlan(db, {
+  projectId,
+  epigraphId,
+  chapterId,
+  updatedAt = new Date().toISOString(),
+}) {
+  const normalizedEpigraphId = typeof epigraphId === "string" ? epigraphId.trim() : "";
+  const normalizedChapterId = typeof chapterId === "string" ? chapterId.trim() : "";
+
+  if (!normalizedEpigraphId) {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION_ERROR",
+        message: "Provide a non-empty epigraph_id.",
+      },
+    };
+  }
+
+  if (!normalizedChapterId) {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION_ERROR",
+        message: "Provide a non-empty chapter_id.",
+      },
+    };
+  }
+
+  const chapter = db.prepare(`
+    SELECT chapter_id, project_id, title, sort_index, logline, source_path, source_checksum, metadata_stale
+    FROM chapters
+    WHERE project_id = ? AND chapter_id = ?
+  `).get(projectId, normalizedChapterId);
+  if (!chapter) {
+    return {
+      ok: false,
+      error: {
+        code: "NOT_FOUND",
+        message: `Chapter '${normalizedChapterId}' not found in project '${projectId}'.`,
+        details: { project_id: projectId, chapter_id: normalizedChapterId },
+      },
+    };
+  }
+
+  const epigraph = db.prepare(`
+    SELECT epigraph_id, project_id, chapter_id, body, file_path, prose_checksum, metadata_stale
+    FROM epigraphs
+    WHERE project_id = ? AND epigraph_id = ?
+  `).get(projectId, normalizedEpigraphId);
+  if (!epigraph) {
+    return {
+      ok: false,
+      error: {
+        code: "NOT_FOUND",
+        message: `Epigraph '${normalizedEpigraphId}' not found in project '${projectId}'.`,
+        details: { project_id: projectId, epigraph_id: normalizedEpigraphId },
+      },
+    };
+  }
+
+  const existingForChapter = db.prepare(`
+    SELECT epigraph_id, chapter_id
+    FROM epigraphs
+    WHERE project_id = ? AND chapter_id = ? AND epigraph_id != ?
+  `).get(projectId, normalizedChapterId, normalizedEpigraphId);
+  if (existingForChapter) {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION_ERROR",
+        message: `Chapter '${normalizedChapterId}' already has epigraph '${existingForChapter.epigraph_id}'.`,
+        details: {
+          project_id: projectId,
+          chapter_id: normalizedChapterId,
+          epigraph_id: normalizedEpigraphId,
+          existing_epigraph_id: existingForChapter.epigraph_id,
+          next_step: "Use find_epigraphs to inspect the current chapter epigraph before reattaching another one.",
+        },
+      },
+    };
+  }
+
+  const previousChapter = db.prepare(`
+    SELECT chapter_id, title, sort_index
+    FROM chapters
+    WHERE project_id = ? AND chapter_id = ?
+  `).get(projectId, epigraph.chapter_id);
+
+  const diagnostics = [];
+  if (epigraph.file_path) {
+    diagnostics.push({
+      code: "REPRESENTATION_NOT_MOVED",
+      severity: "warning",
+      message: "Attached canonical epigraph state and explicit epigraph sidecar fields only; the existing epigraph source file was not moved.",
+      next_step: "Run diagnose_structure after sync if folder-derived structure still reports the previous chapter.",
+      details: {
+        file_path: epigraph.file_path,
+      },
+    });
+  }
+
+  return {
+    ok: true,
+    previousChapter,
+    chapter,
+    epigraph: {
+      ...epigraph,
+      chapter_id: normalizedChapterId,
+      updated_at: updatedAt,
+    },
+    diagnostics,
+  };
+}
+
 export function insertCanonicalChapter(db, chapter) {
   db.prepare(`
     INSERT INTO chapters (
@@ -351,6 +466,20 @@ export function renameCanonicalChapter(db, chapter) {
     chapter.updated_at,
     chapter.project_id,
     chapter.chapter_id
+  );
+}
+
+export function attachCanonicalEpigraph(db, epigraph) {
+  db.prepare(`
+    UPDATE epigraphs
+    SET chapter_id = ?,
+        updated_at = ?
+    WHERE project_id = ? AND epigraph_id = ?
+  `).run(
+    epigraph.chapter_id,
+    epigraph.updated_at,
+    epigraph.project_id,
+    epigraph.epigraph_id
   );
 }
 

--- a/src/structure/chapter-commands.js
+++ b/src/structure/chapter-commands.js
@@ -150,6 +150,86 @@ export function buildCreateChapterPlan(db, {
   };
 }
 
+export function buildRenameChapterPlan(db, {
+  projectId,
+  chapterId,
+  title,
+  updatedAt = new Date().toISOString(),
+}) {
+  const normalizedTitle = typeof title === "string" ? title.trim() : "";
+
+  if (!normalizedTitle) {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION_ERROR",
+        message: "Provide a non-empty chapter title.",
+      },
+    };
+  }
+
+  const chapter = db.prepare(`
+    SELECT chapter_id, project_id, title, sort_index, logline, source_path, source_checksum, metadata_stale
+    FROM chapters
+    WHERE project_id = ? AND chapter_id = ?
+  `).get(projectId, chapterId);
+  if (!chapter) {
+    return {
+      ok: false,
+      error: {
+        code: "NOT_FOUND",
+        message: `Chapter '${chapterId}' not found in project '${projectId}'.`,
+        details: { project_id: projectId, chapter_id: chapterId },
+      },
+    };
+  }
+
+  const existingByTitle = db.prepare(`
+    SELECT chapter_id, title, sort_index
+    FROM chapters
+    WHERE project_id = ? AND title = ? AND chapter_id != ?
+  `).get(projectId, normalizedTitle, chapterId);
+  if (existingByTitle) {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION_ERROR",
+        message: `Chapter title '${normalizedTitle}' is already used in project '${projectId}'.`,
+        details: {
+          project_id: projectId,
+          title: normalizedTitle,
+          existing_chapter_id: existingByTitle.chapter_id,
+          existing_sort_index: existingByTitle.sort_index,
+        },
+      },
+    };
+  }
+
+  const diagnostics = [];
+  if (chapter.source_path) {
+    diagnostics.push({
+      code: "REPRESENTATION_NOT_RENAMED",
+      severity: "warning",
+      message: "Renamed canonical chapter state and explicit scene compatibility fields only; the existing chapter source folder was not renamed.",
+      next_step: "Run diagnose_structure after sync if folder-derived structure still reports the old title.",
+      details: {
+        source_path: chapter.source_path,
+      },
+    });
+  }
+
+  return {
+    ok: true,
+    previousChapter: chapter,
+    chapter: {
+      ...chapter,
+      title: normalizedTitle,
+      updated_at: updatedAt,
+    },
+    diagnostics,
+  };
+}
+
 export function insertCanonicalChapter(db, chapter) {
   db.prepare(`
     INSERT INTO chapters (
@@ -165,5 +245,31 @@ export function insertCanonicalChapter(db, chapter) {
     chapter.source_checksum,
     chapter.metadata_stale,
     chapter.updated_at
+  );
+}
+
+export function renameCanonicalChapter(db, chapter) {
+  db.prepare(`
+    UPDATE chapters
+    SET title = ?,
+        updated_at = ?
+    WHERE project_id = ? AND chapter_id = ?
+  `).run(
+    chapter.title,
+    chapter.updated_at,
+    chapter.project_id,
+    chapter.chapter_id
+  );
+
+  db.prepare(`
+    UPDATE scenes
+    SET chapter_title = ?,
+        updated_at = ?
+    WHERE project_id = ? AND chapter_id = ?
+  `).run(
+    chapter.title,
+    chapter.updated_at,
+    chapter.project_id,
+    chapter.chapter_id
   );
 }

--- a/src/structure/chapter-commands.js
+++ b/src/structure/chapter-commands.js
@@ -230,6 +230,86 @@ export function buildRenameChapterPlan(db, {
   };
 }
 
+export function buildReorderChapterPlan(db, {
+  projectId,
+  chapterId,
+  sortIndex,
+  updatedAt = new Date().toISOString(),
+}) {
+  if (!Number.isInteger(sortIndex) || sortIndex < 1) {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION_ERROR",
+        message: "sort_index must be a positive integer.",
+        details: { sort_index: sortIndex },
+      },
+    };
+  }
+
+  const chapter = db.prepare(`
+    SELECT chapter_id, project_id, title, sort_index, logline, source_path, source_checksum, metadata_stale
+    FROM chapters
+    WHERE project_id = ? AND chapter_id = ?
+  `).get(projectId, chapterId);
+  if (!chapter) {
+    return {
+      ok: false,
+      error: {
+        code: "NOT_FOUND",
+        message: `Chapter '${chapterId}' not found in project '${projectId}'.`,
+        details: { project_id: projectId, chapter_id: chapterId },
+      },
+    };
+  }
+
+  const existingBySortIndex = db.prepare(`
+    SELECT chapter_id, title, sort_index
+    FROM chapters
+    WHERE project_id = ? AND sort_index = ? AND chapter_id != ?
+  `).get(projectId, sortIndex, chapterId);
+  if (existingBySortIndex) {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION_ERROR",
+        message: `Chapter sort_index ${sortIndex} is already used in project '${projectId}'.`,
+        details: {
+          project_id: projectId,
+          sort_index: sortIndex,
+          existing_chapter_id: existingBySortIndex.chapter_id,
+          existing_title: existingBySortIndex.title,
+          next_step: "Choose an unused sort_index. Automatic resequencing is not part of this command yet.",
+        },
+      },
+    };
+  }
+
+  const diagnostics = [];
+  if (chapter.source_path) {
+    diagnostics.push({
+      code: "REPRESENTATION_NOT_REORDERED",
+      severity: "warning",
+      message: "Reordered canonical chapter state and explicit scene compatibility fields only; the existing chapter source folder was not renamed or moved.",
+      next_step: "Run diagnose_structure after sync if folder-derived structure still reports the old order.",
+      details: {
+        source_path: chapter.source_path,
+      },
+    });
+  }
+
+  return {
+    ok: true,
+    previousChapter: chapter,
+    chapter: {
+      ...chapter,
+      sort_index: sortIndex,
+      updated_at: updatedAt,
+    },
+    diagnostics,
+  };
+}
+
 export function insertCanonicalChapter(db, chapter) {
   db.prepare(`
     INSERT INTO chapters (
@@ -267,6 +347,34 @@ export function renameCanonicalChapter(db, chapter) {
         updated_at = ?
     WHERE project_id = ? AND chapter_id = ?
   `).run(
+    chapter.title,
+    chapter.updated_at,
+    chapter.project_id,
+    chapter.chapter_id
+  );
+}
+
+export function reorderCanonicalChapter(db, chapter) {
+  db.prepare(`
+    UPDATE chapters
+    SET sort_index = ?,
+        updated_at = ?
+    WHERE project_id = ? AND chapter_id = ?
+  `).run(
+    chapter.sort_index,
+    chapter.updated_at,
+    chapter.project_id,
+    chapter.chapter_id
+  );
+
+  db.prepare(`
+    UPDATE scenes
+    SET chapter = ?,
+        chapter_title = ?,
+        updated_at = ?
+    WHERE project_id = ? AND chapter_id = ?
+  `).run(
+    chapter.sort_index,
     chapter.title,
     chapter.updated_at,
     chapter.project_id,

--- a/src/structure/chapter-commands.js
+++ b/src/structure/chapter-commands.js
@@ -1,0 +1,169 @@
+import { slugifyChapterValue } from "./structure-inference.js";
+
+export function deriveCanonicalChapterId({ chapterId, sortIndex, title }) {
+  if (chapterId) return chapterId;
+  const slug = slugifyChapterValue(title) || `chapter-${sortIndex}`;
+  return `ch-${String(sortIndex).padStart(2, "0")}-${slug}`;
+}
+
+export function buildCreateChapterPlan(db, {
+  projectId,
+  title,
+  sortIndex,
+  chapterId,
+  logline = null,
+  updatedAt = new Date().toISOString(),
+}) {
+  const normalizedTitle = typeof title === "string" ? title.trim() : "";
+  const normalizedChapterId = typeof chapterId === "string" ? chapterId.trim() : null;
+  const normalizedLogline = typeof logline === "string" && logline.trim() ? logline.trim() : null;
+
+  if (!normalizedTitle) {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION_ERROR",
+        message: "Provide a non-empty chapter title.",
+      },
+    };
+  }
+
+  if (!Number.isInteger(sortIndex) || sortIndex < 1) {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION_ERROR",
+        message: "sort_index must be a positive integer.",
+        details: { sort_index: sortIndex },
+      },
+    };
+  }
+
+  const project = db.prepare(`
+    SELECT project_id
+    FROM projects
+    WHERE project_id = ?
+  `).get(projectId);
+  if (!project) {
+    return {
+      ok: false,
+      error: {
+        code: "NOT_FOUND",
+        message: `Project '${projectId}' not found.`,
+        details: { project_id: projectId },
+      },
+    };
+  }
+
+  const resolvedChapterId = deriveCanonicalChapterId({
+    chapterId: normalizedChapterId,
+    sortIndex,
+    title: normalizedTitle,
+  });
+
+  const existingById = db.prepare(`
+    SELECT chapter_id, title, sort_index
+    FROM chapters
+    WHERE project_id = ? AND chapter_id = ?
+  `).get(projectId, resolvedChapterId);
+  if (existingById) {
+    return {
+      ok: false,
+      error: {
+        code: "ALREADY_EXISTS",
+        message: `Chapter '${resolvedChapterId}' already exists in project '${projectId}'.`,
+        details: {
+          project_id: projectId,
+          chapter_id: resolvedChapterId,
+          existing_title: existingById.title,
+          existing_sort_index: existingById.sort_index,
+        },
+      },
+    };
+  }
+
+  const existingBySortIndex = db.prepare(`
+    SELECT chapter_id, title, sort_index
+    FROM chapters
+    WHERE project_id = ? AND sort_index = ?
+  `).get(projectId, sortIndex);
+  if (existingBySortIndex) {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION_ERROR",
+        message: `Chapter sort_index ${sortIndex} is already used in project '${projectId}'.`,
+        details: {
+          project_id: projectId,
+          sort_index: sortIndex,
+          existing_chapter_id: existingBySortIndex.chapter_id,
+          existing_title: existingBySortIndex.title,
+          next_step: "Use list_chapters to choose an unused sort_index, or wait for reorder_chapter when changing existing order.",
+        },
+      },
+    };
+  }
+
+  const existingByTitle = db.prepare(`
+    SELECT chapter_id, title, sort_index
+    FROM chapters
+    WHERE project_id = ? AND title = ?
+  `).get(projectId, normalizedTitle);
+  if (existingByTitle) {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION_ERROR",
+        message: `Chapter title '${normalizedTitle}' is already used in project '${projectId}'.`,
+        details: {
+          project_id: projectId,
+          title: normalizedTitle,
+          existing_chapter_id: existingByTitle.chapter_id,
+          existing_sort_index: existingByTitle.sort_index,
+          next_step: "Use a distinct title, or wait for rename_chapter when changing an existing chapter title.",
+        },
+      },
+    };
+  }
+
+  return {
+    ok: true,
+    chapter: {
+      chapter_id: resolvedChapterId,
+      project_id: projectId,
+      title: normalizedTitle,
+      sort_index: sortIndex,
+      logline: normalizedLogline,
+      source_path: null,
+      source_checksum: null,
+      metadata_stale: 0,
+      updated_at: updatedAt,
+    },
+    diagnostics: [
+      {
+        code: "REPRESENTATION_DEFERRED",
+        severity: "info",
+        message: "Created canonical chapter state only; no scene files, sidecars, or Scrivener-compatible folders were generated.",
+        next_step: "Use assign_scene_to_chapter to place unchaptered scenes in this chapter, then run diagnose_structure if folder-derived structure may disagree.",
+      },
+    ],
+  };
+}
+
+export function insertCanonicalChapter(db, chapter) {
+  db.prepare(`
+    INSERT INTO chapters (
+      chapter_id, project_id, title, sort_index, logline, source_path, source_checksum, metadata_stale, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    chapter.chapter_id,
+    chapter.project_id,
+    chapter.title,
+    chapter.sort_index,
+    chapter.logline,
+    chapter.source_path,
+    chapter.source_checksum,
+    chapter.metadata_stale,
+    chapter.updated_at
+  );
+}

--- a/src/structure/scene-chapter-assignment.js
+++ b/src/structure/scene-chapter-assignment.js
@@ -75,3 +75,59 @@ export function buildSceneChapterAssignmentPlan(syncDir, filePath, meta = {}, { 
     previousChapterId: meta.chapter_id ?? null,
   };
 }
+
+export function buildMoveScenePlan(syncDir, filePath, meta = {}, {
+  currentScene,
+  chapter,
+  timelinePosition,
+} = {}) {
+  if (chapter === undefined && timelinePosition === undefined) {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION_ERROR",
+        message: "Provide chapter_id and/or timeline_position for move_scene.",
+      },
+    };
+  }
+
+  if (timelinePosition !== undefined && (!Number.isInteger(timelinePosition) || timelinePosition < 1)) {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION_ERROR",
+        message: "timeline_position must be a positive integer.",
+        details: { timeline_position: timelinePosition },
+      },
+    };
+  }
+
+  const assignmentPlan = chapter === undefined
+    ? {
+      ok: true,
+      meta,
+      assignedChapter: {
+        chapter_id: currentScene?.chapter_id ?? meta.chapter_id ?? null,
+        sort_index: currentScene?.chapter ?? meta.chapter ?? null,
+        title: currentScene?.chapter_title ?? meta.chapter_title ?? null,
+      },
+      previousChapterId: meta.chapter_id ?? currentScene?.chapter_id ?? null,
+    }
+    : buildSceneChapterAssignmentPlan(syncDir, filePath, meta, { chapter });
+
+  if (!assignmentPlan.ok) return assignmentPlan;
+
+  const movedMeta = {
+    ...assignmentPlan.meta,
+    ...(timelinePosition !== undefined ? { timeline_position: timelinePosition } : {}),
+  };
+
+  return {
+    ok: true,
+    meta: movedMeta,
+    assignedChapter: assignmentPlan.assignedChapter,
+    previousChapterId: assignmentPlan.previousChapterId ?? currentScene?.chapter_id ?? null,
+    previousTimelinePosition: meta.timeline_position ?? currentScene?.timeline_position ?? null,
+    timelinePosition: timelinePosition ?? meta.timeline_position ?? currentScene?.timeline_position ?? null,
+  };
+}

--- a/src/structure/scene-chapter-assignment.js
+++ b/src/structure/scene-chapter-assignment.js
@@ -107,9 +107,9 @@ export function buildMoveScenePlan(syncDir, filePath, meta = {}, {
       ok: true,
       meta,
       assignedChapter: {
-        chapter_id: currentScene?.chapter_id ?? meta.chapter_id ?? null,
-        sort_index: currentScene?.chapter ?? meta.chapter ?? null,
-        title: currentScene?.chapter_title ?? meta.chapter_title ?? null,
+        chapter_id: meta.chapter_id ?? currentScene?.chapter_id ?? null,
+        sort_index: meta.chapter ?? currentScene?.chapter ?? null,
+        title: meta.chapter_title ?? currentScene?.chapter_title ?? null,
       },
       previousChapterId: meta.chapter_id ?? currentScene?.chapter_id ?? null,
     }

--- a/src/structure/scene-chapter-assignment.js
+++ b/src/structure/scene-chapter-assignment.js
@@ -126,8 +126,13 @@ export function buildMoveScenePlan(syncDir, filePath, meta = {}, {
 
   if (!assignmentPlan.ok) return assignmentPlan;
 
+  const shouldCarryIndexedTimelinePosition = timelinePosition === undefined
+    && chapter !== undefined
+    && meta.timeline_position === undefined
+    && currentScene?.timeline_position != null;
   const movedMeta = {
     ...assignmentPlan.meta,
+    ...(shouldCarryIndexedTimelinePosition ? { timeline_position: currentScene.timeline_position } : {}),
     ...(timelinePosition !== undefined ? { timeline_position: timelinePosition } : {}),
   };
 
@@ -137,6 +142,6 @@ export function buildMoveScenePlan(syncDir, filePath, meta = {}, {
     assignedChapter: assignmentPlan.assignedChapter,
     previousChapterId: assignmentPlan.previousChapterId ?? currentScene?.chapter_id ?? null,
     previousTimelinePosition: meta.timeline_position ?? currentScene?.timeline_position ?? null,
-    timelinePosition: timelinePosition ?? meta.timeline_position ?? currentScene?.timeline_position ?? null,
+    timelinePosition: movedMeta.timeline_position ?? null,
   };
 }

--- a/src/structure/scene-chapter-assignment.js
+++ b/src/structure/scene-chapter-assignment.js
@@ -1,5 +1,14 @@
 import { applySceneStructurePatch } from "./structure-inference.js";
 
+function buildAssignedChapterPayload({ chapterId, sortIndex, title }) {
+  if (!chapterId) return null;
+  return {
+    chapter_id: chapterId,
+    sort_index: sortIndex ?? null,
+    title: title ?? null,
+  };
+}
+
 export function buildSceneChapterAssignmentPlan(syncDir, filePath, meta = {}, { chapter } = {}) {
   if (chapter === undefined) {
     return {
@@ -106,11 +115,11 @@ export function buildMoveScenePlan(syncDir, filePath, meta = {}, {
     ? {
       ok: true,
       meta,
-      assignedChapter: {
-        chapter_id: meta.chapter_id ?? currentScene?.chapter_id ?? null,
-        sort_index: meta.chapter ?? currentScene?.chapter ?? null,
+      assignedChapter: buildAssignedChapterPayload({
+        chapterId: meta.chapter_id ?? currentScene?.chapter_id ?? null,
+        sortIndex: meta.chapter ?? currentScene?.chapter ?? null,
         title: meta.chapter_title ?? currentScene?.chapter_title ?? null,
-      },
+      }),
       previousChapterId: meta.chapter_id ?? currentScene?.chapter_id ?? null,
     }
     : buildSceneChapterAssignmentPlan(syncDir, filePath, meta, { chapter });

--- a/src/test/integration/metadata.test.mjs
+++ b/src/test/integration/metadata.test.mjs
@@ -715,6 +715,65 @@ describe("move_scene tool", () => {
     assert.match(secondMoveParsed.error.details.next_step, /Automatic resequencing/);
   });
 
+  test("rejects moving chapters when existing timeline position is occupied in target", async () => {
+    const sceneDir = path.join(writeSyncDir, "projects", "test-novel", "scenes");
+    fs.mkdirSync(sceneDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(sceneDir, "sc-m7-move-carry-position.md"),
+      "---\nscene_id: sc-m7-move-carry-position\ntitle: Move Carry Position\ntimeline_position: 6\n---\nCarry position prose.",
+      "utf8"
+    );
+    fs.writeFileSync(
+      path.join(sceneDir, "sc-m7-move-carry-blocker.md"),
+      "---\nscene_id: sc-m7-move-carry-blocker\ntitle: Move Carry Blocker\n---\nCarry blocker prose.",
+      "utf8"
+    );
+
+    await callWriteTool("sync");
+
+    const sourceChapterText = await callWriteTool("create_chapter", {
+      project_id: "test-novel",
+      title: "M7 Move Carry Source",
+      sort_index: 81,
+    });
+    const sourceChapter = JSON.parse(sourceChapterText).chapter;
+
+    const targetChapterText = await callWriteTool("create_chapter", {
+      project_id: "test-novel",
+      title: "M7 Move Carry Target",
+      sort_index: 80,
+    });
+    const targetChapter = JSON.parse(targetChapterText).chapter;
+
+    const sourceMoveText = await callWriteTool("move_scene", {
+      scene_id: "sc-m7-move-carry-position",
+      project_id: "test-novel",
+      chapter_id: sourceChapter.chapter_id,
+    });
+    assert.equal(JSON.parse(sourceMoveText).ok, true);
+
+    const blockerMoveText = await callWriteTool("move_scene", {
+      scene_id: "sc-m7-move-carry-blocker",
+      project_id: "test-novel",
+      chapter_id: targetChapter.chapter_id,
+      timeline_position: 6,
+    });
+    assert.equal(JSON.parse(blockerMoveText).ok, true);
+
+    const moveText = await callWriteTool("move_scene", {
+      scene_id: "sc-m7-move-carry-position",
+      project_id: "test-novel",
+      chapter_id: targetChapter.chapter_id,
+    });
+    const moveParsed = JSON.parse(moveText);
+
+    assert.equal(moveParsed.ok, false);
+    assert.equal(moveParsed.error.code, "VALIDATION_ERROR");
+    assert.equal(moveParsed.error.details.chapter_id, targetChapter.chapter_id);
+    assert.equal(moveParsed.error.details.timeline_position, 6);
+    assert.equal(moveParsed.error.details.existing_scene_id, "sc-m7-move-carry-blocker");
+  });
+
   test("checks timeline conflicts against sidecar chapter when index is stale", async () => {
     const sceneDir = path.join(writeSyncDir, "projects", "test-novel", "scenes");
     fs.mkdirSync(sceneDir, { recursive: true });

--- a/src/test/integration/metadata.test.mjs
+++ b/src/test/integration/metadata.test.mjs
@@ -334,6 +334,94 @@ describe("create_chapter tool", () => {
   });
 });
 
+describe("rename_chapter tool", () => {
+  test("renames a canonical chapter and explicit scene compatibility fields", async () => {
+    const sceneDir = path.join(writeSyncDir, "projects", "test-novel", "scenes");
+    fs.mkdirSync(sceneDir, { recursive: true });
+    const scenePath = path.join(sceneDir, "sc-m7-rename.md");
+    fs.writeFileSync(
+      scenePath,
+      "---\nscene_id: sc-m7-rename\ntitle: Rename M7 Scene\n---\nM7 rename prose.",
+      "utf8"
+    );
+
+    await callWriteTool("sync");
+
+    const createText = await callWriteTool("create_chapter", {
+      project_id: "test-novel",
+      title: "M7 Before Rename",
+      sort_index: 98,
+    });
+    const createParsed = JSON.parse(createText);
+    assert.equal(createParsed.ok, true);
+
+    await callWriteTool("assign_scene_to_chapter", {
+      scene_id: "sc-m7-rename",
+      project_id: "test-novel",
+      chapter_id: createParsed.chapter.chapter_id,
+    });
+
+    const renameText = await callWriteTool("rename_chapter", {
+      project_id: "test-novel",
+      chapter_id: createParsed.chapter.chapter_id,
+      title: "M7 After Rename",
+    });
+    const renameParsed = JSON.parse(renameText);
+
+    assert.equal(renameParsed.ok, true);
+    assert.equal(renameParsed.action, "renamed");
+    assert.equal(renameParsed.previous_title, "M7 Before Rename");
+    assert.equal(renameParsed.chapter.title, "M7 After Rename");
+    assert.equal(renameParsed.updated_scene_count, 1);
+    assert.equal(renameParsed.updated_sidecar_count, 1);
+
+    const sidecarFile = path.join(sceneDir, "sc-m7-rename.meta.yaml");
+    const sidecar = yaml.load(fs.readFileSync(sidecarFile, "utf8"));
+    assert.equal(sidecar.chapter_id, createParsed.chapter.chapter_id);
+    assert.equal(sidecar.chapter_title, "M7 After Rename");
+
+    const chaptersText = await callWriteTool("list_chapters", { project_id: "test-novel" });
+    const chaptersParsed = JSON.parse(chaptersText);
+    const renamed = chaptersParsed.results.find((row) => row.chapter_id === createParsed.chapter.chapter_id);
+    assert.equal(renamed.title, "M7 After Rename");
+
+    const findText = await callWriteTool("find_scenes", {
+      project_id: "test-novel",
+      chapter_id: createParsed.chapter.chapter_id,
+    });
+    const findParsed = JSON.parse(findText);
+    const renamedScene = findParsed.results.find((row) => row.scene_id === "sc-m7-rename");
+    assert.equal(renamedScene.chapter_title, "M7 After Rename");
+  });
+
+  test("rejects renaming a chapter to an existing title", async () => {
+    const createText = await callWriteTool("create_chapter", {
+      project_id: "test-novel",
+      title: "M7 Rename Conflict Source",
+      sort_index: 97,
+    });
+    const createParsed = JSON.parse(createText);
+    assert.equal(createParsed.ok, true);
+
+    const chaptersText = await callWriteTool("list_chapters", { project_id: "test-novel" });
+    const chaptersParsed = JSON.parse(chaptersText);
+    const firstChapter = chaptersParsed.results.find((row) => row.sort_index === 1);
+    assert.ok(firstChapter);
+
+    const renameText = await callWriteTool("rename_chapter", {
+      project_id: "test-novel",
+      chapter_id: createParsed.chapter.chapter_id,
+      title: firstChapter.title,
+    });
+    const renameParsed = JSON.parse(renameText);
+
+    assert.equal(renameParsed.ok, false);
+    assert.equal(renameParsed.error.code, "VALIDATION_ERROR");
+    assert.match(renameParsed.error.message, /already used/);
+    assert.equal(renameParsed.error.details.existing_chapter_id, firstChapter.chapter_id);
+  });
+});
+
 describe("update_character_sheet tool", () => {
   test("updates arc_summary and reflects in get_character_sheet", async () => {
     const text = await callWriteTool("update_character_sheet", {

--- a/src/test/integration/metadata.test.mjs
+++ b/src/test/integration/metadata.test.mjs
@@ -422,6 +422,97 @@ describe("rename_chapter tool", () => {
   });
 });
 
+describe("reorder_chapter tool", () => {
+  test("reorders a canonical chapter and explicit scene compatibility fields", async () => {
+    const sceneDir = path.join(writeSyncDir, "projects", "test-novel", "scenes");
+    fs.mkdirSync(sceneDir, { recursive: true });
+    const scenePath = path.join(sceneDir, "sc-m7-reorder.md");
+    fs.writeFileSync(
+      scenePath,
+      "---\nscene_id: sc-m7-reorder\ntitle: Reorder M7 Scene\n---\nM7 reorder prose.",
+      "utf8"
+    );
+
+    await callWriteTool("sync");
+
+    const createText = await callWriteTool("create_chapter", {
+      project_id: "test-novel",
+      title: "M7 Before Reorder",
+      sort_index: 96,
+    });
+    const createParsed = JSON.parse(createText);
+    assert.equal(createParsed.ok, true);
+
+    await callWriteTool("assign_scene_to_chapter", {
+      scene_id: "sc-m7-reorder",
+      project_id: "test-novel",
+      chapter_id: createParsed.chapter.chapter_id,
+    });
+
+    const reorderText = await callWriteTool("reorder_chapter", {
+      project_id: "test-novel",
+      chapter_id: createParsed.chapter.chapter_id,
+      sort_index: 95,
+    });
+    const reorderParsed = JSON.parse(reorderText);
+
+    assert.equal(reorderParsed.ok, true);
+    assert.equal(reorderParsed.action, "reordered");
+    assert.equal(reorderParsed.previous_sort_index, 96);
+    assert.equal(reorderParsed.chapter.sort_index, 95);
+    assert.equal(reorderParsed.updated_scene_count, 1);
+    assert.equal(reorderParsed.updated_sidecar_count, 1);
+
+    const sidecarFile = path.join(sceneDir, "sc-m7-reorder.meta.yaml");
+    const sidecar = yaml.load(fs.readFileSync(sidecarFile, "utf8"));
+    assert.equal(sidecar.chapter_id, createParsed.chapter.chapter_id);
+    assert.equal(sidecar.chapter, 95);
+    assert.equal(sidecar.chapter_title, "M7 Before Reorder");
+
+    const chaptersText = await callWriteTool("list_chapters", { project_id: "test-novel" });
+    const chaptersParsed = JSON.parse(chaptersText);
+    const reordered = chaptersParsed.results.find((row) => row.chapter_id === createParsed.chapter.chapter_id);
+    assert.equal(reordered.sort_index, 95);
+
+    const findText = await callWriteTool("find_scenes", {
+      project_id: "test-novel",
+      chapter_id: createParsed.chapter.chapter_id,
+    });
+    const findParsed = JSON.parse(findText);
+    const reorderedScene = findParsed.results.find((row) => row.scene_id === "sc-m7-reorder");
+    assert.equal(reorderedScene.chapter, 95);
+    assert.equal(reorderedScene.chapter_title, "M7 Before Reorder");
+  });
+
+  test("rejects reordering a chapter to an occupied sort index", async () => {
+    const createText = await callWriteTool("create_chapter", {
+      project_id: "test-novel",
+      title: "M7 Reorder Conflict Source",
+      sort_index: 94,
+    });
+    const createParsed = JSON.parse(createText);
+    assert.equal(createParsed.ok, true);
+
+    const chaptersText = await callWriteTool("list_chapters", { project_id: "test-novel" });
+    const chaptersParsed = JSON.parse(chaptersText);
+    const firstChapter = chaptersParsed.results.find((row) => row.sort_index === 1);
+    assert.ok(firstChapter);
+
+    const reorderText = await callWriteTool("reorder_chapter", {
+      project_id: "test-novel",
+      chapter_id: createParsed.chapter.chapter_id,
+      sort_index: 1,
+    });
+    const reorderParsed = JSON.parse(reorderText);
+
+    assert.equal(reorderParsed.ok, false);
+    assert.equal(reorderParsed.error.code, "VALIDATION_ERROR");
+    assert.match(reorderParsed.error.message, /sort_index 1 is already used/);
+    assert.equal(reorderParsed.error.details.existing_chapter_id, firstChapter.chapter_id);
+    assert.match(reorderParsed.error.details.next_step, /Automatic resequencing/);
+  });
+});
+
 describe("update_character_sheet tool", () => {
   test("updates arc_summary and reflects in get_character_sheet", async () => {
     const text = await callWriteTool("update_character_sheet", {

--- a/src/test/integration/metadata.test.mjs
+++ b/src/test/integration/metadata.test.mjs
@@ -714,6 +714,78 @@ describe("move_scene tool", () => {
     assert.equal(secondMoveParsed.error.details.existing_scene_id, "sc-m7-move-occupied-a");
     assert.match(secondMoveParsed.error.details.next_step, /Automatic resequencing/);
   });
+
+  test("checks timeline conflicts against sidecar chapter when index is stale", async () => {
+    const sceneDir = path.join(writeSyncDir, "projects", "test-novel", "scenes");
+    fs.mkdirSync(sceneDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(sceneDir, "sc-m7-move-stale-subject.md"),
+      "---\nscene_id: sc-m7-move-stale-subject\ntitle: Move Stale Subject\n---\nStale subject prose.",
+      "utf8"
+    );
+    fs.writeFileSync(
+      path.join(sceneDir, "sc-m7-move-stale-blocker.md"),
+      "---\nscene_id: sc-m7-move-stale-blocker\ntitle: Move Stale Blocker\n---\nStale blocker prose.",
+      "utf8"
+    );
+
+    await callWriteTool("sync");
+
+    const sourceChapterText = await callWriteTool("create_chapter", {
+      project_id: "test-novel",
+      title: "M7 Move Stale Source",
+      sort_index: 83,
+    });
+    const sourceChapter = JSON.parse(sourceChapterText).chapter;
+
+    const targetChapterText = await callWriteTool("create_chapter", {
+      project_id: "test-novel",
+      title: "M7 Move Stale Target",
+      sort_index: 82,
+    });
+    const targetChapter = JSON.parse(targetChapterText).chapter;
+
+    const sourceMoveText = await callWriteTool("move_scene", {
+      scene_id: "sc-m7-move-stale-subject",
+      project_id: "test-novel",
+      chapter_id: sourceChapter.chapter_id,
+      timeline_position: 4,
+    });
+    assert.equal(JSON.parse(sourceMoveText).ok, true);
+
+    const blockerMoveText = await callWriteTool("move_scene", {
+      scene_id: "sc-m7-move-stale-blocker",
+      project_id: "test-novel",
+      chapter_id: targetChapter.chapter_id,
+      timeline_position: 8,
+    });
+    assert.equal(JSON.parse(blockerMoveText).ok, true);
+
+    const subjectSidecarFile = path.join(sceneDir, "sc-m7-move-stale-subject.meta.yaml");
+    const subjectSidecar = yaml.load(fs.readFileSync(subjectSidecarFile, "utf8"));
+    fs.writeFileSync(
+      subjectSidecarFile,
+      yaml.dump({
+        ...subjectSidecar,
+        chapter_id: targetChapter.chapter_id,
+        chapter: targetChapter.sort_index,
+        chapter_title: targetChapter.title,
+      }),
+      "utf8"
+    );
+
+    const moveText = await callWriteTool("move_scene", {
+      scene_id: "sc-m7-move-stale-subject",
+      project_id: "test-novel",
+      timeline_position: 8,
+    });
+    const moveParsed = JSON.parse(moveText);
+
+    assert.equal(moveParsed.ok, false);
+    assert.equal(moveParsed.error.code, "VALIDATION_ERROR");
+    assert.equal(moveParsed.error.details.chapter_id, targetChapter.chapter_id);
+    assert.equal(moveParsed.error.details.existing_scene_id, "sc-m7-move-stale-blocker");
+  });
 });
 
 describe("update_character_sheet tool", () => {

--- a/src/test/integration/metadata.test.mjs
+++ b/src/test/integration/metadata.test.mjs
@@ -752,6 +752,11 @@ describe("move_scene tool", () => {
     });
     assert.equal(JSON.parse(sourceMoveText).ok, true);
 
+    const subjectSidecarFile = path.join(sceneDir, "sc-m7-move-carry-position.meta.yaml");
+    const subjectSidecar = yaml.load(fs.readFileSync(subjectSidecarFile, "utf8"));
+    delete subjectSidecar.timeline_position;
+    fs.writeFileSync(subjectSidecarFile, yaml.dump(subjectSidecar), "utf8");
+
     const blockerMoveText = await callWriteTool("move_scene", {
       scene_id: "sc-m7-move-carry-blocker",
       project_id: "test-novel",

--- a/src/test/integration/metadata.test.mjs
+++ b/src/test/integration/metadata.test.mjs
@@ -513,6 +513,209 @@ describe("reorder_chapter tool", () => {
   });
 });
 
+describe("attach_epigraph tool", () => {
+  test("attaches an existing canonical epigraph to another chapter and updates explicit sidecar linkage", async () => {
+    const draftDir = path.join(writeSyncDir, "projects", "test-novel", "scenes", "Draft");
+    const sourceDir = path.join(draftDir, "89-M7 Epigraph Source");
+    fs.mkdirSync(sourceDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(sourceDir, "epigraph.md"),
+      "---\nepigraph_id: epi-m7-attach\n---\nM7 attach epigraph prose.",
+      "utf8"
+    );
+
+    await callWriteTool("sync");
+
+    const createText = await callWriteTool("create_chapter", {
+      project_id: "test-novel",
+      title: "M7 Epigraph Target",
+      sort_index: 88,
+    });
+    const createParsed = JSON.parse(createText);
+    assert.equal(createParsed.ok, true);
+
+    const sourceEpigraphsText = await callWriteTool("find_epigraphs", {
+      project_id: "test-novel",
+      chapter: 89,
+    });
+    const sourceEpigraphsParsed = JSON.parse(sourceEpigraphsText);
+    const sourceEpigraph = sourceEpigraphsParsed.results.find((row) => row.epigraph_id === "epi-m7-attach");
+    assert.ok(sourceEpigraph);
+
+    const attachText = await callWriteTool("attach_epigraph", {
+      project_id: "test-novel",
+      epigraph_id: "epi-m7-attach",
+      chapter_id: createParsed.chapter.chapter_id,
+    });
+    const attachParsed = JSON.parse(attachText);
+
+    assert.equal(attachParsed.ok, true);
+    assert.equal(attachParsed.action, "attached");
+    assert.equal(attachParsed.epigraph.epigraph_id, "epi-m7-attach");
+    assert.equal(attachParsed.epigraph.chapter_id, createParsed.chapter.chapter_id);
+    assert.equal(attachParsed.previous_chapter.chapter_id, sourceEpigraph.chapter_id);
+    assert.equal(attachParsed.updated_sidecar_count, 1);
+    assert.equal(attachParsed.diagnostics[0].code, "REPRESENTATION_NOT_MOVED");
+
+    const sidecarFile = path.join(sourceDir, "epigraph.meta.yaml");
+    const sidecar = yaml.load(fs.readFileSync(sidecarFile, "utf8"));
+    assert.equal(sidecar.kind, "epigraph");
+    assert.equal(sidecar.epigraph_id, "epi-m7-attach");
+    assert.equal(sidecar.chapter_id, createParsed.chapter.chapter_id);
+    assert.equal(sidecar.chapter, 88);
+    assert.equal(sidecar.chapter_title, "M7 Epigraph Target");
+
+    const targetEpigraphsText = await callWriteTool("find_epigraphs", {
+      project_id: "test-novel",
+      chapter_id: createParsed.chapter.chapter_id,
+    });
+    const targetEpigraphsParsed = JSON.parse(targetEpigraphsText);
+    assert.ok(targetEpigraphsParsed.results.some((row) => row.epigraph_id === "epi-m7-attach"));
+  });
+
+  test("rejects attaching an epigraph to a chapter that already has one", async () => {
+    const draftDir = path.join(writeSyncDir, "projects", "test-novel", "scenes", "Draft");
+    const sourceDir = path.join(draftDir, "87-M7 Attach Conflict Source");
+    const targetDir = path.join(draftDir, "86-M7 Attach Conflict Target");
+    fs.mkdirSync(sourceDir, { recursive: true });
+    fs.mkdirSync(targetDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(sourceDir, "epigraph.md"),
+      "---\nepigraph_id: epi-m7-conflict-source\n---\nSource conflict epigraph.",
+      "utf8"
+    );
+    fs.writeFileSync(
+      path.join(targetDir, "epigraph.md"),
+      "---\nepigraph_id: epi-m7-conflict-target\n---\nTarget conflict epigraph.",
+      "utf8"
+    );
+
+    await callWriteTool("sync");
+
+    const targetEpigraphsText = await callWriteTool("find_epigraphs", {
+      project_id: "test-novel",
+      chapter: 86,
+    });
+    const targetEpigraphsParsed = JSON.parse(targetEpigraphsText);
+    const targetEpigraph = targetEpigraphsParsed.results.find((row) => row.epigraph_id === "epi-m7-conflict-target");
+    assert.ok(targetEpigraph);
+
+    const attachText = await callWriteTool("attach_epigraph", {
+      project_id: "test-novel",
+      epigraph_id: "epi-m7-conflict-source",
+      chapter_id: targetEpigraph.chapter_id,
+    });
+    const attachParsed = JSON.parse(attachText);
+
+    assert.equal(attachParsed.ok, false);
+    assert.equal(attachParsed.error.code, "VALIDATION_ERROR");
+    assert.equal(attachParsed.error.details.existing_epigraph_id, "epi-m7-conflict-target");
+    assert.match(attachParsed.error.details.next_step, /find_epigraphs/);
+  });
+});
+
+describe("move_scene tool", () => {
+  test("moves a scene to a canonical chapter and timeline position", async () => {
+    const sceneDir = path.join(writeSyncDir, "projects", "test-novel", "scenes");
+    fs.mkdirSync(sceneDir, { recursive: true });
+    const scenePath = path.join(sceneDir, "sc-m7-move.md");
+    fs.writeFileSync(
+      scenePath,
+      "---\nscene_id: sc-m7-move\ntitle: Move M7 Scene\ntimeline_position: 3\n---\nM7 move prose.",
+      "utf8"
+    );
+
+    await callWriteTool("sync");
+
+    const createText = await callWriteTool("create_chapter", {
+      project_id: "test-novel",
+      title: "M7 Move Target",
+      sort_index: 85,
+    });
+    const createParsed = JSON.parse(createText);
+    assert.equal(createParsed.ok, true);
+
+    const moveText = await callWriteTool("move_scene", {
+      scene_id: "sc-m7-move",
+      project_id: "test-novel",
+      chapter_id: createParsed.chapter.chapter_id,
+      timeline_position: 12,
+    });
+    const moveParsed = JSON.parse(moveText);
+
+    assert.equal(moveParsed.ok, true);
+    assert.equal(moveParsed.action, "moved");
+    assert.equal(moveParsed.scene_id, "sc-m7-move");
+    assert.equal(moveParsed.chapter.chapter_id, createParsed.chapter.chapter_id);
+    assert.equal(moveParsed.timeline_position, 12);
+    assert.equal(moveParsed.previous_timeline_position, 3);
+    assert.equal(moveParsed.diagnostics[0].code, "REPRESENTATION_NOT_MOVED");
+
+    const sidecarFile = path.join(sceneDir, "sc-m7-move.meta.yaml");
+    const sidecar = yaml.load(fs.readFileSync(sidecarFile, "utf8"));
+    assert.equal(sidecar.chapter_id, createParsed.chapter.chapter_id);
+    assert.equal(sidecar.chapter, 85);
+    assert.equal(sidecar.chapter_title, "M7 Move Target");
+    assert.equal(sidecar.timeline_position, 12);
+
+    const findText = await callWriteTool("find_scenes", {
+      project_id: "test-novel",
+      chapter_id: createParsed.chapter.chapter_id,
+    });
+    const findParsed = JSON.parse(findText);
+    const movedScene = findParsed.results.find((row) => row.scene_id === "sc-m7-move");
+    assert.equal(movedScene.timeline_position, 12);
+    assert.equal(movedScene.chapter_id, createParsed.chapter.chapter_id);
+  });
+
+  test("rejects moving a scene to an occupied timeline position in the target chapter", async () => {
+    const sceneDir = path.join(writeSyncDir, "projects", "test-novel", "scenes");
+    fs.mkdirSync(sceneDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(sceneDir, "sc-m7-move-occupied-a.md"),
+      "---\nscene_id: sc-m7-move-occupied-a\ntitle: Move Occupied A\n---\nOccupied A prose.",
+      "utf8"
+    );
+    fs.writeFileSync(
+      path.join(sceneDir, "sc-m7-move-occupied-b.md"),
+      "---\nscene_id: sc-m7-move-occupied-b\ntitle: Move Occupied B\n---\nOccupied B prose.",
+      "utf8"
+    );
+
+    await callWriteTool("sync");
+
+    const createText = await callWriteTool("create_chapter", {
+      project_id: "test-novel",
+      title: "M7 Move Conflict Target",
+      sort_index: 84,
+    });
+    const createParsed = JSON.parse(createText);
+    assert.equal(createParsed.ok, true);
+
+    const firstMoveText = await callWriteTool("move_scene", {
+      scene_id: "sc-m7-move-occupied-a",
+      project_id: "test-novel",
+      chapter_id: createParsed.chapter.chapter_id,
+      timeline_position: 8,
+    });
+    const firstMoveParsed = JSON.parse(firstMoveText);
+    assert.equal(firstMoveParsed.ok, true);
+
+    const secondMoveText = await callWriteTool("move_scene", {
+      scene_id: "sc-m7-move-occupied-b",
+      project_id: "test-novel",
+      chapter_id: createParsed.chapter.chapter_id,
+      timeline_position: 8,
+    });
+    const secondMoveParsed = JSON.parse(secondMoveText);
+
+    assert.equal(secondMoveParsed.ok, false);
+    assert.equal(secondMoveParsed.error.code, "VALIDATION_ERROR");
+    assert.equal(secondMoveParsed.error.details.existing_scene_id, "sc-m7-move-occupied-a");
+    assert.match(secondMoveParsed.error.details.next_step, /Automatic resequencing/);
+  });
+});
+
 describe("update_character_sheet tool", () => {
   test("updates arc_summary and reflects in get_character_sheet", async () => {
     const text = await callWriteTool("update_character_sheet", {

--- a/src/test/integration/metadata.test.mjs
+++ b/src/test/integration/metadata.test.mjs
@@ -289,6 +289,51 @@ describe("assign_scene_to_chapter tool", () => {
   });
 });
 
+describe("create_chapter tool", () => {
+  test("creates a canonical chapter and returns follow-up guidance", async () => {
+    const createText = await callWriteTool("create_chapter", {
+      project_id: "test-novel",
+      title: "M7 New Crossing",
+      sort_index: 99,
+      logline: "A crossing appears at the edge of the map.",
+    });
+    const createParsed = JSON.parse(createText);
+
+    assert.equal(createParsed.ok, true);
+    assert.equal(createParsed.action, "created");
+    assert.equal(createParsed.chapter.chapter_id, "ch-99-m7-new-crossing");
+    assert.equal(createParsed.chapter.project_id, "test-novel");
+    assert.equal(createParsed.chapter.title, "M7 New Crossing");
+    assert.equal(createParsed.chapter.sort_index, 99);
+    assert.equal(createParsed.diagnostics[0].code, "REPRESENTATION_DEFERRED");
+    assert.ok(createParsed.next_steps.some((step) => step.includes("assign_scene_to_chapter")));
+
+    const chaptersText = await callWriteTool("list_chapters", { project_id: "test-novel" });
+    const chaptersParsed = JSON.parse(chaptersText);
+    assert.ok(chaptersParsed.results.some((row) => row.chapter_id === "ch-99-m7-new-crossing"));
+  });
+
+  test("rejects creating a chapter at an occupied sort index", async () => {
+    const chaptersText = await callWriteTool("list_chapters", { project_id: "test-novel" });
+    const chaptersParsed = JSON.parse(chaptersText);
+    const firstChapter = chaptersParsed.results.find((row) => row.sort_index === 1);
+    assert.ok(firstChapter);
+
+    const createText = await callWriteTool("create_chapter", {
+      project_id: "test-novel",
+      title: "M7 Conflicting Chapter",
+      sort_index: 1,
+    });
+    const createParsed = JSON.parse(createText);
+
+    assert.equal(createParsed.ok, false);
+    assert.equal(createParsed.error.code, "VALIDATION_ERROR");
+    assert.match(createParsed.error.message, /sort_index 1 is already used/);
+    assert.equal(createParsed.error.details.existing_chapter_id, firstChapter.chapter_id);
+    assert.match(createParsed.error.details.next_step, /reorder_chapter/);
+  });
+});
+
 describe("update_character_sheet tool", () => {
   test("updates arc_summary and reflects in get_character_sheet", async () => {
     const text = await callWriteTool("update_character_sheet", {

--- a/src/test/unit/chapter-commands.test.mjs
+++ b/src/test/unit/chapter-commands.test.mjs
@@ -3,8 +3,10 @@ import assert from "node:assert/strict";
 import {
   buildCreateChapterPlan,
   buildRenameChapterPlan,
+  buildReorderChapterPlan,
   insertCanonicalChapter,
   renameCanonicalChapter,
+  reorderCanonicalChapter,
 } from "../../structure/chapter-commands.js";
 import { setupReviewBundleTestDb } from "../helpers/db.js";
 
@@ -203,6 +205,130 @@ describe("buildRenameChapterPlan", () => {
 
     assert.equal(plan.ok, true);
     assert.equal(plan.diagnostics[0].code, "REPRESENTATION_NOT_RENAMED");
+    assert.equal(plan.diagnostics[0].details.source_path, "projects/test-novel/scenes/Draft/03-Existing");
+  });
+});
+
+describe("buildReorderChapterPlan", () => {
+  test("prepares a canonical order update and updates indexed scene compatibility", () => {
+    const db = setupReviewBundleTestDb();
+    insertCanonicalChapter(db, {
+      chapter_id: "ch-03-existing",
+      project_id: "test-novel",
+      title: "Existing",
+      sort_index: 3,
+      logline: null,
+      source_path: null,
+      source_checksum: null,
+      metadata_stale: 0,
+      updated_at: "2026-05-18T00:00:00.000Z",
+    });
+    db.prepare(`
+      INSERT INTO scenes (
+        scene_id, project_id, chapter_id, title, chapter, chapter_title, file_path, prose_checksum, metadata_stale, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      "sc-linked",
+      "test-novel",
+      "ch-03-existing",
+      "Linked",
+      3,
+      "Existing",
+      "/tmp/sc-linked.md",
+      "deadbeef",
+      0,
+      "2026-05-18T00:00:00.000Z"
+    );
+
+    const plan = buildReorderChapterPlan(db, {
+      projectId: "test-novel",
+      chapterId: "ch-03-existing",
+      sortIndex: 7,
+      updatedAt: "2026-05-18T01:00:00.000Z",
+    });
+
+    assert.equal(plan.ok, true);
+    assert.equal(plan.previousChapter.sort_index, 3);
+    assert.equal(plan.chapter.sort_index, 7);
+    assert.deepEqual(plan.diagnostics, []);
+
+    reorderCanonicalChapter(db, plan.chapter);
+
+    const chapter = db.prepare(`
+      SELECT sort_index
+      FROM chapters
+      WHERE project_id = ? AND chapter_id = ?
+    `).get("test-novel", "ch-03-existing");
+    const scene = db.prepare(`
+      SELECT chapter, chapter_title
+      FROM scenes
+      WHERE project_id = ? AND scene_id = ?
+    `).get("test-novel", "sc-linked");
+
+    assert.equal(chapter.sort_index, 7);
+    assert.equal(scene.chapter, 7);
+    assert.equal(scene.chapter_title, "Existing");
+  });
+
+  test("rejects a reorder to another chapter sort index", () => {
+    const db = setupReviewBundleTestDb();
+    insertCanonicalChapter(db, {
+      chapter_id: "ch-03-existing",
+      project_id: "test-novel",
+      title: "Existing",
+      sort_index: 3,
+      logline: null,
+      source_path: null,
+      source_checksum: null,
+      metadata_stale: 0,
+      updated_at: "2026-05-18T00:00:00.000Z",
+    });
+    insertCanonicalChapter(db, {
+      chapter_id: "ch-04-other",
+      project_id: "test-novel",
+      title: "Other",
+      sort_index: 4,
+      logline: null,
+      source_path: null,
+      source_checksum: null,
+      metadata_stale: 0,
+      updated_at: "2026-05-18T00:00:00.000Z",
+    });
+
+    const plan = buildReorderChapterPlan(db, {
+      projectId: "test-novel",
+      chapterId: "ch-03-existing",
+      sortIndex: 4,
+    });
+
+    assert.equal(plan.ok, false);
+    assert.equal(plan.error.code, "VALIDATION_ERROR");
+    assert.equal(plan.error.details.existing_chapter_id, "ch-04-other");
+    assert.match(plan.error.details.next_step, /Automatic resequencing/);
+  });
+
+  test("warns when reordering a chapter with a source folder representation", () => {
+    const db = setupReviewBundleTestDb();
+    insertCanonicalChapter(db, {
+      chapter_id: "ch-03-existing",
+      project_id: "test-novel",
+      title: "Existing",
+      sort_index: 3,
+      logline: null,
+      source_path: "projects/test-novel/scenes/Draft/03-Existing",
+      source_checksum: null,
+      metadata_stale: 0,
+      updated_at: "2026-05-18T00:00:00.000Z",
+    });
+
+    const plan = buildReorderChapterPlan(db, {
+      projectId: "test-novel",
+      chapterId: "ch-03-existing",
+      sortIndex: 7,
+    });
+
+    assert.equal(plan.ok, true);
+    assert.equal(plan.diagnostics[0].code, "REPRESENTATION_NOT_REORDERED");
     assert.equal(plan.diagnostics[0].details.source_path, "projects/test-novel/scenes/Draft/03-Existing");
   });
 });

--- a/src/test/unit/chapter-commands.test.mjs
+++ b/src/test/unit/chapter-commands.test.mjs
@@ -1,0 +1,81 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { buildCreateChapterPlan, insertCanonicalChapter } from "../../structure/chapter-commands.js";
+import { setupReviewBundleTestDb } from "../helpers/db.js";
+
+describe("buildCreateChapterPlan", () => {
+  test("derives a canonical chapter id and prepares a chapter insert", () => {
+    const db = setupReviewBundleTestDb();
+
+    const plan = buildCreateChapterPlan(db, {
+      projectId: "test-novel",
+      title: "The Silver Door",
+      sortIndex: 3,
+      logline: "A door appears where the wall should be.",
+      updatedAt: "2026-05-18T00:00:00.000Z",
+    });
+
+    assert.equal(plan.ok, true);
+    assert.equal(plan.chapter.chapter_id, "ch-03-the-silver-door");
+    assert.equal(plan.chapter.project_id, "test-novel");
+    assert.equal(plan.chapter.title, "The Silver Door");
+    assert.equal(plan.chapter.sort_index, 3);
+    assert.equal(plan.chapter.logline, "A door appears where the wall should be.");
+    assert.equal(plan.chapter.source_path, null);
+    assert.equal(plan.diagnostics[0].code, "REPRESENTATION_DEFERRED");
+  });
+
+  test("rejects a reused sort index before writing", () => {
+    const db = setupReviewBundleTestDb();
+    insertCanonicalChapter(db, {
+      chapter_id: "ch-03-existing",
+      project_id: "test-novel",
+      title: "Existing",
+      sort_index: 3,
+      logline: null,
+      source_path: null,
+      source_checksum: null,
+      metadata_stale: 0,
+      updated_at: "2026-05-18T00:00:00.000Z",
+    });
+
+    const plan = buildCreateChapterPlan(db, {
+      projectId: "test-novel",
+      title: "New Chapter",
+      sortIndex: 3,
+    });
+
+    assert.equal(plan.ok, false);
+    assert.equal(plan.error.code, "VALIDATION_ERROR");
+    assert.match(plan.error.message, /sort_index 3 is already used/);
+    assert.equal(plan.error.details.existing_chapter_id, "ch-03-existing");
+    assert.match(plan.error.details.next_step, /reorder_chapter/);
+  });
+
+  test("rejects duplicate chapter titles to avoid ambiguous title resolution", () => {
+    const db = setupReviewBundleTestDb();
+    insertCanonicalChapter(db, {
+      chapter_id: "ch-03-existing",
+      project_id: "test-novel",
+      title: "Existing",
+      sort_index: 3,
+      logline: null,
+      source_path: null,
+      source_checksum: null,
+      metadata_stale: 0,
+      updated_at: "2026-05-18T00:00:00.000Z",
+    });
+
+    const plan = buildCreateChapterPlan(db, {
+      projectId: "test-novel",
+      title: "Existing",
+      sortIndex: 4,
+    });
+
+    assert.equal(plan.ok, false);
+    assert.equal(plan.error.code, "VALIDATION_ERROR");
+    assert.match(plan.error.message, /title 'Existing' is already used/);
+    assert.equal(plan.error.details.existing_chapter_id, "ch-03-existing");
+    assert.match(plan.error.details.next_step, /rename_chapter/);
+  });
+});

--- a/src/test/unit/chapter-commands.test.mjs
+++ b/src/test/unit/chapter-commands.test.mjs
@@ -4,9 +4,11 @@ import {
   buildCreateChapterPlan,
   buildRenameChapterPlan,
   buildReorderChapterPlan,
+  buildAttachEpigraphPlan,
   insertCanonicalChapter,
   renameCanonicalChapter,
   reorderCanonicalChapter,
+  attachCanonicalEpigraph,
 } from "../../structure/chapter-commands.js";
 import { setupReviewBundleTestDb } from "../helpers/db.js";
 
@@ -330,5 +332,131 @@ describe("buildReorderChapterPlan", () => {
     assert.equal(plan.ok, true);
     assert.equal(plan.diagnostics[0].code, "REPRESENTATION_NOT_REORDERED");
     assert.equal(plan.diagnostics[0].details.source_path, "projects/test-novel/scenes/Draft/03-Existing");
+  });
+});
+
+describe("buildAttachEpigraphPlan", () => {
+  test("prepares an epigraph attachment to another canonical chapter", () => {
+    const db = setupReviewBundleTestDb();
+    insertCanonicalChapter(db, {
+      chapter_id: "ch-03-source",
+      project_id: "test-novel",
+      title: "Source",
+      sort_index: 3,
+      logline: null,
+      source_path: null,
+      source_checksum: null,
+      metadata_stale: 0,
+      updated_at: "2026-05-18T00:00:00.000Z",
+    });
+    insertCanonicalChapter(db, {
+      chapter_id: "ch-04-target",
+      project_id: "test-novel",
+      title: "Target",
+      sort_index: 4,
+      logline: null,
+      source_path: null,
+      source_checksum: null,
+      metadata_stale: 0,
+      updated_at: "2026-05-18T00:00:00.000Z",
+    });
+    db.prepare(`
+      INSERT INTO epigraphs (
+        epigraph_id, project_id, chapter_id, body, file_path, prose_checksum, metadata_stale, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      "epi-source",
+      "test-novel",
+      "ch-03-source",
+      "Opening line.",
+      "/tmp/epigraph.md",
+      "deadbeef",
+      0,
+      "2026-05-18T00:00:00.000Z"
+    );
+
+    const plan = buildAttachEpigraphPlan(db, {
+      projectId: "test-novel",
+      epigraphId: "epi-source",
+      chapterId: "ch-04-target",
+      updatedAt: "2026-05-18T01:00:00.000Z",
+    });
+
+    assert.equal(plan.ok, true);
+    assert.equal(plan.previousChapter.chapter_id, "ch-03-source");
+    assert.equal(plan.chapter.chapter_id, "ch-04-target");
+    assert.equal(plan.epigraph.chapter_id, "ch-04-target");
+    assert.equal(plan.diagnostics[0].code, "REPRESENTATION_NOT_MOVED");
+
+    attachCanonicalEpigraph(db, plan.epigraph);
+
+    const epigraph = db.prepare(`
+      SELECT chapter_id
+      FROM epigraphs
+      WHERE project_id = ? AND epigraph_id = ?
+    `).get("test-novel", "epi-source");
+    assert.equal(epigraph.chapter_id, "ch-04-target");
+  });
+
+  test("rejects attaching to a chapter that already has another epigraph", () => {
+    const db = setupReviewBundleTestDb();
+    insertCanonicalChapter(db, {
+      chapter_id: "ch-03-source",
+      project_id: "test-novel",
+      title: "Source",
+      sort_index: 3,
+      logline: null,
+      source_path: null,
+      source_checksum: null,
+      metadata_stale: 0,
+      updated_at: "2026-05-18T00:00:00.000Z",
+    });
+    insertCanonicalChapter(db, {
+      chapter_id: "ch-04-target",
+      project_id: "test-novel",
+      title: "Target",
+      sort_index: 4,
+      logline: null,
+      source_path: null,
+      source_checksum: null,
+      metadata_stale: 0,
+      updated_at: "2026-05-18T00:00:00.000Z",
+    });
+    const insertEpigraph = db.prepare(`
+      INSERT INTO epigraphs (
+        epigraph_id, project_id, chapter_id, body, file_path, prose_checksum, metadata_stale, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+    insertEpigraph.run(
+      "epi-source",
+      "test-novel",
+      "ch-03-source",
+      "Source line.",
+      "/tmp/source-epigraph.md",
+      "source",
+      0,
+      "2026-05-18T00:00:00.000Z"
+    );
+    insertEpigraph.run(
+      "epi-target",
+      "test-novel",
+      "ch-04-target",
+      "Target line.",
+      "/tmp/target-epigraph.md",
+      "target",
+      0,
+      "2026-05-18T00:00:00.000Z"
+    );
+
+    const plan = buildAttachEpigraphPlan(db, {
+      projectId: "test-novel",
+      epigraphId: "epi-source",
+      chapterId: "ch-04-target",
+    });
+
+    assert.equal(plan.ok, false);
+    assert.equal(plan.error.code, "VALIDATION_ERROR");
+    assert.equal(plan.error.details.existing_epigraph_id, "epi-target");
+    assert.match(plan.error.details.next_step, /find_epigraphs/);
   });
 });

--- a/src/test/unit/chapter-commands.test.mjs
+++ b/src/test/unit/chapter-commands.test.mjs
@@ -1,6 +1,11 @@
 import { test, describe } from "node:test";
 import assert from "node:assert/strict";
-import { buildCreateChapterPlan, insertCanonicalChapter } from "../../structure/chapter-commands.js";
+import {
+  buildCreateChapterPlan,
+  buildRenameChapterPlan,
+  insertCanonicalChapter,
+  renameCanonicalChapter,
+} from "../../structure/chapter-commands.js";
 import { setupReviewBundleTestDb } from "../helpers/db.js";
 
 describe("buildCreateChapterPlan", () => {
@@ -77,5 +82,127 @@ describe("buildCreateChapterPlan", () => {
     assert.match(plan.error.message, /title 'Existing' is already used/);
     assert.equal(plan.error.details.existing_chapter_id, "ch-03-existing");
     assert.match(plan.error.details.next_step, /rename_chapter/);
+  });
+});
+
+describe("buildRenameChapterPlan", () => {
+  test("prepares a canonical title update and updates indexed scene compatibility", () => {
+    const db = setupReviewBundleTestDb();
+    insertCanonicalChapter(db, {
+      chapter_id: "ch-03-existing",
+      project_id: "test-novel",
+      title: "Existing",
+      sort_index: 3,
+      logline: null,
+      source_path: null,
+      source_checksum: null,
+      metadata_stale: 0,
+      updated_at: "2026-05-18T00:00:00.000Z",
+    });
+    db.prepare(`
+      INSERT INTO scenes (
+        scene_id, project_id, chapter_id, title, chapter, chapter_title, file_path, prose_checksum, metadata_stale, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      "sc-linked",
+      "test-novel",
+      "ch-03-existing",
+      "Linked",
+      3,
+      "Existing",
+      "/tmp/sc-linked.md",
+      "deadbeef",
+      0,
+      "2026-05-18T00:00:00.000Z"
+    );
+
+    const plan = buildRenameChapterPlan(db, {
+      projectId: "test-novel",
+      chapterId: "ch-03-existing",
+      title: "Renamed",
+      updatedAt: "2026-05-18T01:00:00.000Z",
+    });
+
+    assert.equal(plan.ok, true);
+    assert.equal(plan.previousChapter.title, "Existing");
+    assert.equal(plan.chapter.title, "Renamed");
+    assert.deepEqual(plan.diagnostics, []);
+
+    renameCanonicalChapter(db, plan.chapter);
+
+    const chapter = db.prepare(`
+      SELECT title
+      FROM chapters
+      WHERE project_id = ? AND chapter_id = ?
+    `).get("test-novel", "ch-03-existing");
+    const scene = db.prepare(`
+      SELECT chapter_title
+      FROM scenes
+      WHERE project_id = ? AND scene_id = ?
+    `).get("test-novel", "sc-linked");
+
+    assert.equal(chapter.title, "Renamed");
+    assert.equal(scene.chapter_title, "Renamed");
+  });
+
+  test("rejects a rename to another chapter title", () => {
+    const db = setupReviewBundleTestDb();
+    insertCanonicalChapter(db, {
+      chapter_id: "ch-03-existing",
+      project_id: "test-novel",
+      title: "Existing",
+      sort_index: 3,
+      logline: null,
+      source_path: null,
+      source_checksum: null,
+      metadata_stale: 0,
+      updated_at: "2026-05-18T00:00:00.000Z",
+    });
+    insertCanonicalChapter(db, {
+      chapter_id: "ch-04-other",
+      project_id: "test-novel",
+      title: "Other",
+      sort_index: 4,
+      logline: null,
+      source_path: null,
+      source_checksum: null,
+      metadata_stale: 0,
+      updated_at: "2026-05-18T00:00:00.000Z",
+    });
+
+    const plan = buildRenameChapterPlan(db, {
+      projectId: "test-novel",
+      chapterId: "ch-03-existing",
+      title: "Other",
+    });
+
+    assert.equal(plan.ok, false);
+    assert.equal(plan.error.code, "VALIDATION_ERROR");
+    assert.equal(plan.error.details.existing_chapter_id, "ch-04-other");
+  });
+
+  test("warns when the chapter still has a source folder representation", () => {
+    const db = setupReviewBundleTestDb();
+    insertCanonicalChapter(db, {
+      chapter_id: "ch-03-existing",
+      project_id: "test-novel",
+      title: "Existing",
+      sort_index: 3,
+      logline: null,
+      source_path: "projects/test-novel/scenes/Draft/03-Existing",
+      source_checksum: null,
+      metadata_stale: 0,
+      updated_at: "2026-05-18T00:00:00.000Z",
+    });
+
+    const plan = buildRenameChapterPlan(db, {
+      projectId: "test-novel",
+      chapterId: "ch-03-existing",
+      title: "Renamed",
+    });
+
+    assert.equal(plan.ok, true);
+    assert.equal(plan.diagnostics[0].code, "REPRESENTATION_NOT_RENAMED");
+    assert.equal(plan.diagnostics[0].details.source_path, "projects/test-novel/scenes/Draft/03-Existing");
   });
 });

--- a/src/test/unit/scene-chapter-assignment.test.mjs
+++ b/src/test/unit/scene-chapter-assignment.test.mjs
@@ -172,6 +172,31 @@ describe("buildMoveScenePlan", () => {
     assert.equal(plan.timelinePosition, 4);
   });
 
+  test("carries indexed timeline position into sidecar metadata when changing chapters", () => {
+    const syncDir = "/sync";
+    const filePath = path.join(syncDir, "projects", "book", "scenes", "loose.md");
+
+    const plan = buildMoveScenePlan(syncDir, filePath, {
+      scene_id: "sc-loose",
+      chapter_id: "ch-01-first",
+      chapter: 1,
+      chapter_title: "First",
+    }, {
+      currentScene: {
+        chapter_id: "ch-01-first",
+        chapter: 1,
+        chapter_title: "First",
+        timeline_position: 6,
+      },
+      chapter,
+    });
+
+    assert.equal(plan.ok, true);
+    assert.equal(plan.meta.chapter_id, "ch-02-second");
+    assert.equal(plan.meta.timeline_position, 6);
+    assert.equal(plan.timelinePosition, 6);
+  });
+
   test("rejects a move with no target chapter or timeline position", () => {
     const syncDir = "/sync";
     const filePath = path.join(syncDir, "projects", "book", "scenes", "loose.md");

--- a/src/test/unit/scene-chapter-assignment.test.mjs
+++ b/src/test/unit/scene-chapter-assignment.test.mjs
@@ -1,7 +1,7 @@
 import { test, describe } from "node:test";
 import assert from "node:assert/strict";
 import path from "node:path";
-import { buildSceneChapterAssignmentPlan } from "../../structure/scene-chapter-assignment.js";
+import { buildMoveScenePlan, buildSceneChapterAssignmentPlan } from "../../structure/scene-chapter-assignment.js";
 
 describe("buildSceneChapterAssignmentPlan", () => {
   const chapter = {
@@ -86,5 +86,80 @@ describe("buildSceneChapterAssignmentPlan", () => {
     assert.equal(plan.error.details.requested_chapter, 2);
     assert.equal(plan.error.details.path_chapter, "ch-01-chapter-1");
     assert.equal(plan.error.details.path_chapter_number, 1);
+  });
+});
+
+describe("buildMoveScenePlan", () => {
+  const chapter = {
+    chapter_id: "ch-02-second",
+    sort_index: 2,
+    title: "Second",
+  };
+
+  test("moves a scene to a canonical chapter and timeline position", () => {
+    const syncDir = "/sync";
+    const filePath = path.join(syncDir, "projects", "book", "scenes", "loose.md");
+
+    const plan = buildMoveScenePlan(syncDir, filePath, {
+      scene_id: "sc-loose",
+      title: "Loose",
+      chapter_id: "ch-01-first",
+      chapter: 1,
+      chapter_title: "First",
+      timeline_position: 3,
+    }, {
+      chapter,
+      timelinePosition: 7,
+    });
+
+    assert.equal(plan.ok, true);
+    assert.equal(plan.meta.chapter_id, "ch-02-second");
+    assert.equal(plan.meta.chapter, 2);
+    assert.equal(plan.meta.chapter_title, "Second");
+    assert.equal(plan.meta.timeline_position, 7);
+    assert.equal(plan.previousChapterId, "ch-01-first");
+    assert.equal(plan.previousTimelinePosition, 3);
+    assert.deepEqual(plan.assignedChapter, chapter);
+  });
+
+  test("updates timeline position while preserving the current chapter", () => {
+    const syncDir = "/sync";
+    const filePath = path.join(syncDir, "projects", "book", "scenes", "loose.md");
+
+    const plan = buildMoveScenePlan(syncDir, filePath, {
+      scene_id: "sc-loose",
+      chapter_id: "ch-01-first",
+      chapter: 1,
+      chapter_title: "First",
+      timeline_position: 3,
+    }, {
+      currentScene: {
+        chapter_id: "ch-01-first",
+        chapter: 1,
+        chapter_title: "First",
+        timeline_position: 3,
+      },
+      timelinePosition: 4,
+    });
+
+    assert.equal(plan.ok, true);
+    assert.equal(plan.meta.chapter_id, "ch-01-first");
+    assert.equal(plan.meta.chapter, 1);
+    assert.equal(plan.meta.chapter_title, "First");
+    assert.equal(plan.meta.timeline_position, 4);
+    assert.equal(plan.previousTimelinePosition, 3);
+  });
+
+  test("rejects a move with no target chapter or timeline position", () => {
+    const syncDir = "/sync";
+    const filePath = path.join(syncDir, "projects", "book", "scenes", "loose.md");
+
+    const plan = buildMoveScenePlan(syncDir, filePath, {
+      scene_id: "sc-loose",
+    });
+
+    assert.equal(plan.ok, false);
+    assert.equal(plan.error.code, "VALIDATION_ERROR");
+    assert.match(plan.error.message, /Provide chapter_id/);
   });
 });

--- a/src/test/unit/scene-chapter-assignment.test.mjs
+++ b/src/test/unit/scene-chapter-assignment.test.mjs
@@ -150,6 +150,28 @@ describe("buildMoveScenePlan", () => {
     assert.equal(plan.previousTimelinePosition, 3);
   });
 
+  test("returns null chapter payload for timeline-only unchaptered moves", () => {
+    const syncDir = "/sync";
+    const filePath = path.join(syncDir, "projects", "book", "scenes", "loose.md");
+
+    const plan = buildMoveScenePlan(syncDir, filePath, {
+      scene_id: "sc-loose",
+      timeline_position: 3,
+    }, {
+      currentScene: {
+        chapter_id: null,
+        chapter: null,
+        chapter_title: null,
+        timeline_position: 3,
+      },
+      timelinePosition: 4,
+    });
+
+    assert.equal(plan.ok, true);
+    assert.equal(plan.assignedChapter, null);
+    assert.equal(plan.timelinePosition, 4);
+  });
+
   test("rejects a move with no target chapter or timeline position", () => {
     const syncDir = "/sync";
     const filePath = path.join(syncDir, "projects", "book", "scenes", "loose.md");

--- a/src/tools/metadata.js
+++ b/src/tools/metadata.js
@@ -8,8 +8,10 @@ import { buildSceneChapterAssignmentPlan } from "../structure/scene-chapter-assi
 import {
   buildCreateChapterPlan,
   buildRenameChapterPlan,
+  buildReorderChapterPlan,
   insertCanonicalChapter,
   renameCanonicalChapter,
+  reorderCanonicalChapter,
 } from "../structure/chapter-commands.js";
 import {
   persistSceneReferenceLink,
@@ -682,6 +684,106 @@ export function registerMetadataTools(s, {
         next_steps: [
           "Use list_chapters to confirm the canonical title.",
           "Run diagnose_structure if folder-derived structure may still use the previous chapter title.",
+        ],
+      });
+    }
+  );
+
+  // ---- reorder_chapter -----------------------------------------------------
+  s.tool(
+    "reorder_chapter",
+    "Reorder a canonical chapter through the explicit structure workflow. Updates canonical chapter order and explicit scene chapter/chapter_title compatibility fields; it does not rename, move, or resequence scene files, sidecars by path-derived structure, or Scrivener-compatible folders.",
+    {
+      project_id: z.string().describe("Project the chapter belongs to (e.g. 'the-lamb')."),
+      chapter_id: z.string().describe("Canonical chapter identifier. Use list_chapters to find valid values."),
+      sort_index: z.number().int().min(1).describe("New canonical chapter order within the project. Must be unused."),
+    },
+    async ({ project_id, chapter_id, sort_index }) => {
+      if (!SYNC_DIR_WRITABLE) {
+        return errorResponse("READ_ONLY", "Cannot reorder chapter: sync dir is read-only.");
+      }
+
+      const projectIdCheck = validateProjectId(project_id);
+      if (!projectIdCheck.ok) {
+        return errorResponse("INVALID_PROJECT_ID", projectIdCheck.reason, { project_id });
+      }
+
+      const plan = buildReorderChapterPlan(db, {
+        projectId: project_id,
+        chapterId: chapter_id,
+        sortIndex: sort_index,
+      });
+      if (!plan.ok) {
+        return errorResponse(plan.error.code, plan.error.message, {
+          project_id,
+          chapter_id,
+          sort_index,
+          ...(plan.error.details ?? {}),
+        });
+      }
+
+      const linkedScenes = db.prepare(`
+        SELECT scene_id, project_id, file_path
+        FROM scenes
+        WHERE project_id = ? AND chapter_id = ?
+        ORDER BY scene_id
+      `).all(project_id, chapter_id);
+
+      const sidecarUpdates = [];
+      try {
+        for (const scene of linkedScenes) {
+          const { meta } = readMeta(scene.file_path, SYNC_DIR, { writable: true });
+          if (meta.chapter_id === chapter_id) {
+            sidecarUpdates.push({
+              scene,
+              meta: {
+                ...meta,
+                chapter: plan.chapter.sort_index,
+                chapter_title: plan.chapter.title,
+              },
+            });
+          }
+        }
+
+        db.exec("BEGIN");
+        reorderCanonicalChapter(db, plan.chapter);
+        for (const update of sidecarUpdates) {
+          writeMeta(update.scene.file_path, update.meta);
+        }
+        db.exec("COMMIT");
+      } catch (err) {
+        try {
+          db.exec("ROLLBACK");
+        } catch (rollbackErr) {
+          void rollbackErr;
+        }
+        if (err.code === "ENOENT") {
+          return errorResponse("STALE_PATH", `Cannot reorder chapter '${chapter_id}': an indexed scene file is missing. Run sync() to refresh.`, {
+            project_id,
+            chapter_id,
+          });
+        }
+        return errorResponse("IO_ERROR", `Failed to reorder chapter '${chapter_id}': ${err.message}`);
+      }
+
+      return jsonResponse({
+        ok: true,
+        action: "reordered",
+        chapter: {
+          chapter_id: plan.chapter.chapter_id,
+          project_id: plan.chapter.project_id,
+          title: plan.chapter.title,
+          sort_index: plan.chapter.sort_index,
+          logline: plan.chapter.logline,
+          metadata_stale: plan.chapter.metadata_stale,
+        },
+        previous_sort_index: plan.previousChapter.sort_index,
+        updated_scene_count: linkedScenes.length,
+        updated_sidecar_count: sidecarUpdates.length,
+        diagnostics: plan.diagnostics,
+        next_steps: [
+          "Use list_chapters to confirm canonical order.",
+          "Run diagnose_structure if folder-derived structure may still use the previous order.",
         ],
       });
     }

--- a/src/tools/metadata.js
+++ b/src/tools/metadata.js
@@ -5,7 +5,12 @@ import { readMeta, writeMeta, indexSceneFile, applySceneStructurePatch } from ".
 import { validateProjectId, validateUniverseId } from "../sync/importer.js";
 import { resolveValidatedChapterFilter } from "../core/chapter-resolution.js";
 import { buildSceneChapterAssignmentPlan } from "../structure/scene-chapter-assignment.js";
-import { buildCreateChapterPlan, insertCanonicalChapter } from "../structure/chapter-commands.js";
+import {
+  buildCreateChapterPlan,
+  buildRenameChapterPlan,
+  insertCanonicalChapter,
+  renameCanonicalChapter,
+} from "../structure/chapter-commands.js";
 import {
   persistSceneReferenceLink,
   upsertExplicitReferenceLinkRow,
@@ -578,6 +583,105 @@ export function registerMetadataTools(s, {
         next_steps: [
           "Use assign_scene_to_chapter to place unchaptered scenes in this chapter.",
           "Run diagnose_structure if existing folders or sidecars may imply conflicting structure.",
+        ],
+      });
+    }
+  );
+
+  // ---- rename_chapter ------------------------------------------------------
+  s.tool(
+    "rename_chapter",
+    "Rename a canonical chapter through the explicit structure workflow. Updates canonical chapter state and explicit scene chapter_title compatibility fields; it does not rename scene files, sidecars by path-derived structure, or Scrivener-compatible folders.",
+    {
+      project_id: z.string().describe("Project the chapter belongs to (e.g. 'the-lamb')."),
+      chapter_id: z.string().describe("Canonical chapter identifier. Use list_chapters to find valid values."),
+      title: z.string().describe("New human-readable chapter title."),
+    },
+    async ({ project_id, chapter_id, title }) => {
+      if (!SYNC_DIR_WRITABLE) {
+        return errorResponse("READ_ONLY", "Cannot rename chapter: sync dir is read-only.");
+      }
+
+      const projectIdCheck = validateProjectId(project_id);
+      if (!projectIdCheck.ok) {
+        return errorResponse("INVALID_PROJECT_ID", projectIdCheck.reason, { project_id });
+      }
+
+      const plan = buildRenameChapterPlan(db, {
+        projectId: project_id,
+        chapterId: chapter_id,
+        title,
+      });
+      if (!plan.ok) {
+        return errorResponse(plan.error.code, plan.error.message, {
+          project_id,
+          chapter_id,
+          title,
+          ...(plan.error.details ?? {}),
+        });
+      }
+
+      const linkedScenes = db.prepare(`
+        SELECT scene_id, project_id, file_path
+        FROM scenes
+        WHERE project_id = ? AND chapter_id = ?
+        ORDER BY scene_id
+      `).all(project_id, chapter_id);
+
+      const sidecarUpdates = [];
+      try {
+        for (const scene of linkedScenes) {
+          const { meta } = readMeta(scene.file_path, SYNC_DIR, { writable: true });
+          if (meta.chapter_id === chapter_id) {
+            sidecarUpdates.push({
+              scene,
+              meta: {
+                ...meta,
+                chapter_title: plan.chapter.title,
+              },
+            });
+          }
+        }
+
+        db.exec("BEGIN");
+        renameCanonicalChapter(db, plan.chapter);
+        for (const update of sidecarUpdates) {
+          writeMeta(update.scene.file_path, update.meta);
+        }
+        db.exec("COMMIT");
+      } catch (err) {
+        try {
+          db.exec("ROLLBACK");
+        } catch (rollbackErr) {
+          void rollbackErr;
+        }
+        if (err.code === "ENOENT") {
+          return errorResponse("STALE_PATH", `Cannot rename chapter '${chapter_id}': an indexed scene file is missing. Run sync() to refresh.`, {
+            project_id,
+            chapter_id,
+          });
+        }
+        return errorResponse("IO_ERROR", `Failed to rename chapter '${chapter_id}': ${err.message}`);
+      }
+
+      return jsonResponse({
+        ok: true,
+        action: "renamed",
+        chapter: {
+          chapter_id: plan.chapter.chapter_id,
+          project_id: plan.chapter.project_id,
+          title: plan.chapter.title,
+          sort_index: plan.chapter.sort_index,
+          logline: plan.chapter.logline,
+          metadata_stale: plan.chapter.metadata_stale,
+        },
+        previous_title: plan.previousChapter.title,
+        updated_scene_count: linkedScenes.length,
+        updated_sidecar_count: sidecarUpdates.length,
+        diagnostics: plan.diagnostics,
+        next_steps: [
+          "Use list_chapters to confirm the canonical title.",
+          "Run diagnose_structure if folder-derived structure may still use the previous chapter title.",
         ],
       });
     }

--- a/src/tools/metadata.js
+++ b/src/tools/metadata.js
@@ -4,14 +4,16 @@ import matter from "gray-matter";
 import { readMeta, writeMeta, indexSceneFile, applySceneStructurePatch } from "../sync/sync.js";
 import { validateProjectId, validateUniverseId } from "../sync/importer.js";
 import { resolveValidatedChapterFilter } from "../core/chapter-resolution.js";
-import { buildSceneChapterAssignmentPlan } from "../structure/scene-chapter-assignment.js";
+import { buildMoveScenePlan, buildSceneChapterAssignmentPlan } from "../structure/scene-chapter-assignment.js";
 import {
   buildCreateChapterPlan,
   buildRenameChapterPlan,
   buildReorderChapterPlan,
+  buildAttachEpigraphPlan,
   insertCanonicalChapter,
   renameCanonicalChapter,
   reorderCanonicalChapter,
+  attachCanonicalEpigraph,
 } from "../structure/chapter-commands.js";
 import {
   persistSceneReferenceLink,
@@ -786,6 +788,249 @@ export function registerMetadataTools(s, {
           "Run diagnose_structure if folder-derived structure may still use the previous order.",
         ],
       });
+    }
+  );
+
+  // ---- attach_epigraph -----------------------------------------------------
+  s.tool(
+    "attach_epigraph",
+    "Attach an existing canonical epigraph to a canonical chapter through the explicit structure workflow. Updates canonical epigraph linkage and explicit epigraph sidecar fields; it does not move, rename, or create epigraph source files or Scrivener-compatible folders.",
+    {
+      project_id: z.string().describe("Project the epigraph belongs to (e.g. 'the-lamb')."),
+      epigraph_id: z.string().describe("Canonical epigraph identifier. Use find_epigraphs to find valid values."),
+      chapter_id: z.string().describe("Canonical chapter identifier. Use list_chapters to find valid values."),
+    },
+    async ({ project_id, epigraph_id, chapter_id }) => {
+      if (!SYNC_DIR_WRITABLE) {
+        return errorResponse("READ_ONLY", "Cannot attach epigraph: sync dir is read-only.");
+      }
+
+      const projectIdCheck = validateProjectId(project_id);
+      if (!projectIdCheck.ok) {
+        return errorResponse("INVALID_PROJECT_ID", projectIdCheck.reason, { project_id });
+      }
+
+      const plan = buildAttachEpigraphPlan(db, {
+        projectId: project_id,
+        epigraphId: epigraph_id,
+        chapterId: chapter_id,
+      });
+      if (!plan.ok) {
+        return errorResponse(plan.error.code, plan.error.message, {
+          project_id,
+          epigraph_id,
+          chapter_id,
+          ...(plan.error.details ?? {}),
+        });
+      }
+
+      try {
+        const { meta } = readMeta(plan.epigraph.file_path, SYNC_DIR, { writable: true });
+        const sidecarUpdate = {
+          ...meta,
+          kind: meta.kind ?? "epigraph",
+          epigraph_id: plan.epigraph.epigraph_id,
+          chapter_id: plan.chapter.chapter_id,
+          chapter: plan.chapter.sort_index,
+          chapter_title: plan.chapter.title,
+        };
+
+        db.exec("BEGIN");
+        attachCanonicalEpigraph(db, plan.epigraph);
+        writeMeta(plan.epigraph.file_path, sidecarUpdate);
+        db.exec("COMMIT");
+      } catch (err) {
+        try {
+          db.exec("ROLLBACK");
+        } catch (rollbackErr) {
+          void rollbackErr;
+        }
+        if (err.code === "ENOENT") {
+          return errorResponse("STALE_PATH", `Cannot attach epigraph '${epigraph_id}': the indexed epigraph file is missing. Run sync() to refresh.`, {
+            project_id,
+            epigraph_id,
+            chapter_id,
+          });
+        }
+        return errorResponse("IO_ERROR", `Failed to attach epigraph '${epigraph_id}': ${err.message}`);
+      }
+
+      return jsonResponse({
+        ok: true,
+        action: "attached",
+        epigraph: {
+          epigraph_id: plan.epigraph.epigraph_id,
+          project_id: plan.epigraph.project_id,
+          chapter_id: plan.epigraph.chapter_id,
+          metadata_stale: plan.epigraph.metadata_stale,
+        },
+        chapter: {
+          chapter_id: plan.chapter.chapter_id,
+          title: plan.chapter.title,
+          sort_index: plan.chapter.sort_index,
+        },
+        previous_chapter: plan.previousChapter
+          ? {
+            chapter_id: plan.previousChapter.chapter_id,
+            title: plan.previousChapter.title,
+            sort_index: plan.previousChapter.sort_index,
+          }
+          : null,
+        updated_sidecar_count: 1,
+        diagnostics: plan.diagnostics,
+        next_steps: [
+          "Use find_epigraphs to confirm the canonical epigraph attachment.",
+          "Run diagnose_structure if folder-derived structure may still imply the previous chapter.",
+        ],
+      });
+    }
+  );
+
+  // ---- move_scene ----------------------------------------------------------
+  s.tool(
+    "move_scene",
+    "Move a scene through the explicit structure workflow. Updates canonical chapter linkage and/or timeline_position in the scene sidecar and index; it does not move, rename, or resequence scene files or Scrivener-compatible folders.",
+    {
+      scene_id: z.string().describe("The scene_id to move (e.g. 'sc-011-sebastian')."),
+      project_id: z.string().describe("Project the scene belongs to (e.g. 'the-lamb')."),
+      chapter_id: z.string().optional().describe("Optional canonical chapter identifier. Use list_chapters to find valid values. Omit to keep the current chapter."),
+      timeline_position: z.number().int().min(1).optional().describe("Optional new position within the target chapter. Must be unused."),
+    },
+    async ({ scene_id, project_id, chapter_id, timeline_position }) => {
+      if (!SYNC_DIR_WRITABLE) {
+        return errorResponse("READ_ONLY", "Cannot move scene: sync dir is read-only.");
+      }
+
+      const projectIdCheck = validateProjectId(project_id);
+      if (!projectIdCheck.ok) {
+        return errorResponse("INVALID_PROJECT_ID", projectIdCheck.reason, { project_id });
+      }
+
+      if (chapter_id === undefined && timeline_position === undefined) {
+        return errorResponse("VALIDATION_ERROR", "Provide chapter_id and/or timeline_position for move_scene.", {
+          project_id,
+          scene_id,
+        });
+      }
+
+      const scene = db.prepare(`
+        SELECT scene_id, project_id, chapter_id, chapter, chapter_title, timeline_position, file_path
+        FROM scenes
+        WHERE scene_id = ? AND project_id = ?
+      `).get(scene_id, project_id);
+      if (!scene) {
+        return errorResponse("NOT_FOUND", `Scene '${scene_id}' not found in project '${project_id}'.`);
+      }
+
+      let chapter = undefined;
+      if (chapter_id !== undefined) {
+        const resolvedChapterFilter = resolveValidatedChapterFilter(db, {
+          projectId: project_id,
+          chapterId: chapter_id,
+        });
+
+        if (resolvedChapterFilter.error) {
+          return errorResponse(
+            resolvedChapterFilter.error.code,
+            resolvedChapterFilter.error.message,
+            { project_id, chapter_id }
+          );
+        }
+
+        chapter = resolvedChapterFilter.chapter;
+        if (!chapter) {
+          return errorResponse("NOT_FOUND", "Chapter not found for the provided project and identifier.", {
+            project_id,
+            chapter_id,
+          });
+        }
+      }
+
+      const targetChapterId = chapter?.chapter_id ?? scene.chapter_id ?? null;
+      if (timeline_position !== undefined) {
+        const positionConflict = targetChapterId === null
+          ? db.prepare(`
+            SELECT scene_id
+            FROM scenes
+            WHERE project_id = ? AND chapter_id IS NULL AND timeline_position = ? AND scene_id != ?
+            ORDER BY scene_id
+            LIMIT 1
+          `).get(project_id, timeline_position, scene_id)
+          : db.prepare(`
+            SELECT scene_id
+            FROM scenes
+            WHERE project_id = ? AND chapter_id = ? AND timeline_position = ? AND scene_id != ?
+            ORDER BY scene_id
+            LIMIT 1
+          `).get(project_id, targetChapterId, timeline_position, scene_id);
+
+        if (positionConflict) {
+          return errorResponse("VALIDATION_ERROR", `timeline_position ${timeline_position} is already used in the target chapter.`, {
+            project_id,
+            scene_id,
+            chapter_id: targetChapterId,
+            timeline_position,
+            existing_scene_id: positionConflict.scene_id,
+            next_step: "Choose an unused timeline_position. Automatic resequencing is not part of this command yet.",
+          });
+        }
+      }
+
+      try {
+        const { meta } = readMeta(scene.file_path, SYNC_DIR, { writable: true });
+        const plan = buildMoveScenePlan(SYNC_DIR, scene.file_path, meta, {
+          currentScene: scene,
+          chapter,
+          timelinePosition: timeline_position,
+        });
+        if (!plan.ok) {
+          return errorResponse(plan.error.code, plan.error.message, {
+            project_id,
+            scene_id,
+            chapter_id: chapter_id ?? null,
+            timeline_position: timeline_position ?? null,
+            ...(plan.error.details ?? {}),
+          });
+        }
+
+        writeMeta(scene.file_path, plan.meta);
+
+        const { content: prose } = matter(fs.readFileSync(scene.file_path, "utf8"));
+        indexSceneFile(db, SYNC_DIR, scene.file_path, plan.meta, prose);
+
+        return jsonResponse({
+          ok: true,
+          action: "moved",
+          scene_id,
+          project_id,
+          previous_chapter_id: plan.previousChapterId,
+          previous_timeline_position: plan.previousTimelinePosition,
+          chapter: plan.assignedChapter,
+          timeline_position: plan.timelinePosition,
+          diagnostics: [
+            {
+              code: "REPRESENTATION_NOT_MOVED",
+              severity: "warning",
+              message: "Moved canonical scene structure fields only; the existing scene source file was not moved or renamed.",
+              next_step: "Run diagnose_structure if folder-derived structure may still imply the previous placement.",
+              details: {
+                file_path: scene.file_path,
+              },
+            },
+          ],
+          next_steps: [
+            "Use find_scenes to confirm the scene's canonical chapter and timeline_position.",
+            "Run diagnose_structure if folder-derived structure may still imply the previous placement.",
+          ],
+        });
+      } catch (err) {
+        if (err.code === "ENOENT") {
+          return errorResponse("STALE_PATH", `Prose file for scene '${scene_id}' not found at indexed path. Run sync() to refresh.`, {
+            indexed_path: scene.file_path,
+          });
+        }
+        return errorResponse("IO_ERROR", `Failed to move scene '${scene_id}': ${err.message}`);
+      }
     }
   );
 

--- a/src/tools/metadata.js
+++ b/src/tools/metadata.js
@@ -874,12 +874,12 @@ export function registerMetadataTools(s, {
         const sidecarUpdate = {
           filePath: plan.epigraph.file_path,
           meta: {
-          ...meta,
-          kind: meta.kind ?? "epigraph",
-          epigraph_id: plan.epigraph.epigraph_id,
-          chapter_id: plan.chapter.chapter_id,
-          chapter: plan.chapter.sort_index,
-          chapter_title: plan.chapter.title,
+            ...meta,
+            kind: meta.kind ?? "epigraph",
+            epigraph_id: plan.epigraph.epigraph_id,
+            chapter_id: plan.chapter.chapter_id,
+            chapter: plan.chapter.sort_index,
+            chapter_title: plan.chapter.title,
           },
         };
 

--- a/src/tools/metadata.js
+++ b/src/tools/metadata.js
@@ -5,6 +5,7 @@ import { readMeta, writeMeta, indexSceneFile, applySceneStructurePatch } from ".
 import { validateProjectId, validateUniverseId } from "../sync/importer.js";
 import { resolveValidatedChapterFilter } from "../core/chapter-resolution.js";
 import { buildSceneChapterAssignmentPlan } from "../structure/scene-chapter-assignment.js";
+import { buildCreateChapterPlan, insertCanonicalChapter } from "../structure/chapter-commands.js";
 import {
   persistSceneReferenceLink,
   upsertExplicitReferenceLinkRow,
@@ -507,6 +508,77 @@ export function registerMetadataTools(s, {
         ok: true,
         action: "upserted",
         link,
+      });
+    }
+  );
+
+  // ---- create_chapter ------------------------------------------------------
+  s.tool(
+    "create_chapter",
+    "Create a canonical chapter record through the explicit structure workflow. Writes canonical chapter state only; it does not create scene files, sidecars, or Scrivener-compatible folders. Use assign_scene_to_chapter afterward to place unchaptered scenes in the new chapter.",
+    {
+      project_id: z.string().describe("Project the chapter belongs to (e.g. 'the-lamb')."),
+      title: z.string().describe("Human-readable chapter title."),
+      sort_index: z.number().int().min(1).describe("Canonical chapter order within the project. Must be unused."),
+      chapter_id: z.string().optional().describe("Optional canonical chapter identifier. If omitted, one is derived from sort_index and title."),
+      logline: z.string().optional().describe("Optional chapter-level logline."),
+    },
+    async ({ project_id, title, sort_index, chapter_id, logline }) => {
+      if (!SYNC_DIR_WRITABLE) {
+        return errorResponse("READ_ONLY", "Cannot create chapter: sync dir is read-only.");
+      }
+
+      const projectIdCheck = validateProjectId(project_id);
+      if (!projectIdCheck.ok) {
+        return errorResponse("INVALID_PROJECT_ID", projectIdCheck.reason, { project_id });
+      }
+
+      const plan = buildCreateChapterPlan(db, {
+        projectId: project_id,
+        title,
+        sortIndex: sort_index,
+        chapterId: chapter_id,
+        logline,
+      });
+      if (!plan.ok) {
+        return errorResponse(plan.error.code, plan.error.message, {
+          project_id,
+          title,
+          sort_index,
+          chapter_id: chapter_id ?? null,
+          ...(plan.error.details ?? {}),
+        });
+      }
+
+      try {
+        db.exec("BEGIN");
+        insertCanonicalChapter(db, plan.chapter);
+        db.exec("COMMIT");
+      } catch (err) {
+        try {
+          db.exec("ROLLBACK");
+        } catch (rollbackErr) {
+          void rollbackErr;
+        }
+        return errorResponse("IO_ERROR", `Failed to create chapter '${plan.chapter.chapter_id}': ${err.message}`);
+      }
+
+      return jsonResponse({
+        ok: true,
+        action: "created",
+        chapter: {
+          chapter_id: plan.chapter.chapter_id,
+          project_id: plan.chapter.project_id,
+          title: plan.chapter.title,
+          sort_index: plan.chapter.sort_index,
+          logline: plan.chapter.logline,
+          metadata_stale: plan.chapter.metadata_stale,
+        },
+        diagnostics: plan.diagnostics,
+        next_steps: [
+          "Use assign_scene_to_chapter to place unchaptered scenes in this chapter.",
+          "Run diagnose_structure if existing folders or sidecars may imply conflicting structure.",
+        ],
       });
     }
   );

--- a/src/tools/metadata.js
+++ b/src/tools/metadata.js
@@ -946,36 +946,6 @@ export function registerMetadataTools(s, {
         }
       }
 
-      const targetChapterId = chapter?.chapter_id ?? scene.chapter_id ?? null;
-      if (timeline_position !== undefined) {
-        const positionConflict = targetChapterId === null
-          ? db.prepare(`
-            SELECT scene_id
-            FROM scenes
-            WHERE project_id = ? AND chapter_id IS NULL AND timeline_position = ? AND scene_id != ?
-            ORDER BY scene_id
-            LIMIT 1
-          `).get(project_id, timeline_position, scene_id)
-          : db.prepare(`
-            SELECT scene_id
-            FROM scenes
-            WHERE project_id = ? AND chapter_id = ? AND timeline_position = ? AND scene_id != ?
-            ORDER BY scene_id
-            LIMIT 1
-          `).get(project_id, targetChapterId, timeline_position, scene_id);
-
-        if (positionConflict) {
-          return errorResponse("VALIDATION_ERROR", `timeline_position ${timeline_position} is already used in the target chapter.`, {
-            project_id,
-            scene_id,
-            chapter_id: targetChapterId,
-            timeline_position,
-            existing_scene_id: positionConflict.scene_id,
-            next_step: "Choose an unused timeline_position. Automatic resequencing is not part of this command yet.",
-          });
-        }
-      }
-
       try {
         const { meta } = readMeta(scene.file_path, SYNC_DIR, { writable: true });
         const plan = buildMoveScenePlan(SYNC_DIR, scene.file_path, meta, {
@@ -991,6 +961,36 @@ export function registerMetadataTools(s, {
             timeline_position: timeline_position ?? null,
             ...(plan.error.details ?? {}),
           });
+        }
+
+        const targetChapterId = plan.meta.chapter_id ?? null;
+        if (timeline_position !== undefined) {
+          const positionConflict = targetChapterId === null
+            ? db.prepare(`
+              SELECT scene_id
+              FROM scenes
+              WHERE project_id = ? AND chapter_id IS NULL AND timeline_position = ? AND scene_id != ?
+              ORDER BY scene_id
+              LIMIT 1
+            `).get(project_id, timeline_position, scene_id)
+            : db.prepare(`
+              SELECT scene_id
+              FROM scenes
+              WHERE project_id = ? AND chapter_id = ? AND timeline_position = ? AND scene_id != ?
+              ORDER BY scene_id
+              LIMIT 1
+            `).get(project_id, targetChapterId, timeline_position, scene_id);
+
+          if (positionConflict) {
+            return errorResponse("VALIDATION_ERROR", `timeline_position ${timeline_position} is already used in the target chapter.`, {
+              project_id,
+              scene_id,
+              chapter_id: targetChapterId,
+              timeline_position,
+              existing_scene_id: positionConflict.scene_id,
+              next_step: "Choose an unused timeline_position. Automatic resequencing is not part of this command yet.",
+            });
+          }
         }
 
         writeMeta(scene.file_path, plan.meta);

--- a/src/tools/metadata.js
+++ b/src/tools/metadata.js
@@ -91,6 +91,41 @@ function persistPlaceReferenceLink({ placePath, syncDir, targetDocId, relation }
   writeMeta(placePath, nextMeta);
 }
 
+function writeStructureSidecarUpdates(updates, { failureCode }) {
+  const failures = [];
+  let updatedCount = 0;
+
+  for (const update of updates) {
+    try {
+      writeMeta(update.filePath, update.meta);
+      updatedCount += 1;
+    } catch (err) {
+      failures.push({
+        file_path: update.filePath,
+        message: err.message,
+      });
+    }
+  }
+
+  return {
+    updatedCount,
+    diagnostics: failures.length
+      ? [
+        {
+          code: failureCode,
+          severity: "warning",
+          message: "Canonical structure was updated, but one or more explicit sidecar compatibility updates failed.",
+          next_step: "Inspect the failed sidecar paths, then run sync and diagnose_structure before making more structure changes.",
+          details: {
+            failed_sidecar_count: failures.length,
+            failures,
+          },
+        },
+      ]
+      : [],
+  };
+}
+
 function resolveProjectScopedSource({
   db,
   errorResponse,
@@ -639,6 +674,7 @@ export function registerMetadataTools(s, {
           if (meta.chapter_id === chapter_id) {
             sidecarUpdates.push({
               scene,
+              filePath: scene.file_path,
               meta: {
                 ...meta,
                 chapter_title: plan.chapter.title,
@@ -649,9 +685,6 @@ export function registerMetadataTools(s, {
 
         db.exec("BEGIN");
         renameCanonicalChapter(db, plan.chapter);
-        for (const update of sidecarUpdates) {
-          writeMeta(update.scene.file_path, update.meta);
-        }
         db.exec("COMMIT");
       } catch (err) {
         try {
@@ -668,6 +701,10 @@ export function registerMetadataTools(s, {
         return errorResponse("IO_ERROR", `Failed to rename chapter '${chapter_id}': ${err.message}`);
       }
 
+      const sidecarWriteResult = writeStructureSidecarUpdates(sidecarUpdates, {
+        failureCode: "SCENE_SIDECAR_UPDATE_FAILED",
+      });
+
       return jsonResponse({
         ok: true,
         action: "renamed",
@@ -681,8 +718,11 @@ export function registerMetadataTools(s, {
         },
         previous_title: plan.previousChapter.title,
         updated_scene_count: linkedScenes.length,
-        updated_sidecar_count: sidecarUpdates.length,
-        diagnostics: plan.diagnostics,
+        updated_sidecar_count: sidecarWriteResult.updatedCount,
+        diagnostics: [
+          ...plan.diagnostics,
+          ...sidecarWriteResult.diagnostics,
+        ],
         next_steps: [
           "Use list_chapters to confirm the canonical title.",
           "Run diagnose_structure if folder-derived structure may still use the previous chapter title.",
@@ -738,6 +778,7 @@ export function registerMetadataTools(s, {
           if (meta.chapter_id === chapter_id) {
             sidecarUpdates.push({
               scene,
+              filePath: scene.file_path,
               meta: {
                 ...meta,
                 chapter: plan.chapter.sort_index,
@@ -749,9 +790,6 @@ export function registerMetadataTools(s, {
 
         db.exec("BEGIN");
         reorderCanonicalChapter(db, plan.chapter);
-        for (const update of sidecarUpdates) {
-          writeMeta(update.scene.file_path, update.meta);
-        }
         db.exec("COMMIT");
       } catch (err) {
         try {
@@ -768,6 +806,10 @@ export function registerMetadataTools(s, {
         return errorResponse("IO_ERROR", `Failed to reorder chapter '${chapter_id}': ${err.message}`);
       }
 
+      const sidecarWriteResult = writeStructureSidecarUpdates(sidecarUpdates, {
+        failureCode: "SCENE_SIDECAR_UPDATE_FAILED",
+      });
+
       return jsonResponse({
         ok: true,
         action: "reordered",
@@ -781,8 +823,11 @@ export function registerMetadataTools(s, {
         },
         previous_sort_index: plan.previousChapter.sort_index,
         updated_scene_count: linkedScenes.length,
-        updated_sidecar_count: sidecarUpdates.length,
-        diagnostics: plan.diagnostics,
+        updated_sidecar_count: sidecarWriteResult.updatedCount,
+        diagnostics: [
+          ...plan.diagnostics,
+          ...sidecarWriteResult.diagnostics,
+        ],
         next_steps: [
           "Use list_chapters to confirm canonical order.",
           "Run diagnose_structure if folder-derived structure may still use the previous order.",
@@ -827,18 +872,56 @@ export function registerMetadataTools(s, {
       try {
         const { meta } = readMeta(plan.epigraph.file_path, SYNC_DIR, { writable: true });
         const sidecarUpdate = {
+          filePath: plan.epigraph.file_path,
+          meta: {
           ...meta,
           kind: meta.kind ?? "epigraph",
           epigraph_id: plan.epigraph.epigraph_id,
           chapter_id: plan.chapter.chapter_id,
           chapter: plan.chapter.sort_index,
           chapter_title: plan.chapter.title,
+          },
         };
 
         db.exec("BEGIN");
         attachCanonicalEpigraph(db, plan.epigraph);
-        writeMeta(plan.epigraph.file_path, sidecarUpdate);
         db.exec("COMMIT");
+
+        const sidecarWriteResult = writeStructureSidecarUpdates([sidecarUpdate], {
+          failureCode: "EPIGRAPH_SIDECAR_UPDATE_FAILED",
+        });
+
+        return jsonResponse({
+          ok: true,
+          action: "attached",
+          epigraph: {
+            epigraph_id: plan.epigraph.epigraph_id,
+            project_id: plan.epigraph.project_id,
+            chapter_id: plan.epigraph.chapter_id,
+            metadata_stale: plan.epigraph.metadata_stale,
+          },
+          chapter: {
+            chapter_id: plan.chapter.chapter_id,
+            title: plan.chapter.title,
+            sort_index: plan.chapter.sort_index,
+          },
+          previous_chapter: plan.previousChapter
+            ? {
+              chapter_id: plan.previousChapter.chapter_id,
+              title: plan.previousChapter.title,
+              sort_index: plan.previousChapter.sort_index,
+            }
+            : null,
+          updated_sidecar_count: sidecarWriteResult.updatedCount,
+          diagnostics: [
+            ...plan.diagnostics,
+            ...sidecarWriteResult.diagnostics,
+          ],
+          next_steps: [
+            "Use find_epigraphs to confirm the canonical epigraph attachment.",
+            "Run diagnose_structure if folder-derived structure may still imply the previous chapter.",
+          ],
+        });
       } catch (err) {
         try {
           db.exec("ROLLBACK");
@@ -854,35 +937,6 @@ export function registerMetadataTools(s, {
         }
         return errorResponse("IO_ERROR", `Failed to attach epigraph '${epigraph_id}': ${err.message}`);
       }
-
-      return jsonResponse({
-        ok: true,
-        action: "attached",
-        epigraph: {
-          epigraph_id: plan.epigraph.epigraph_id,
-          project_id: plan.epigraph.project_id,
-          chapter_id: plan.epigraph.chapter_id,
-          metadata_stale: plan.epigraph.metadata_stale,
-        },
-        chapter: {
-          chapter_id: plan.chapter.chapter_id,
-          title: plan.chapter.title,
-          sort_index: plan.chapter.sort_index,
-        },
-        previous_chapter: plan.previousChapter
-          ? {
-            chapter_id: plan.previousChapter.chapter_id,
-            title: plan.previousChapter.title,
-            sort_index: plan.previousChapter.sort_index,
-          }
-          : null,
-        updated_sidecar_count: 1,
-        diagnostics: plan.diagnostics,
-        next_steps: [
-          "Use find_epigraphs to confirm the canonical epigraph attachment.",
-          "Run diagnose_structure if folder-derived structure may still imply the previous chapter.",
-        ],
-      });
     }
   );
 
@@ -964,7 +1018,10 @@ export function registerMetadataTools(s, {
         }
 
         const targetChapterId = plan.meta.chapter_id ?? null;
-        if (timeline_position !== undefined) {
+        const effectiveTimelinePosition = plan.timelinePosition;
+        const targetChapterChanged = chapter_id !== undefined
+          && (plan.previousChapterId ?? null) !== targetChapterId;
+        if (effectiveTimelinePosition != null && (timeline_position !== undefined || targetChapterChanged)) {
           const positionConflict = targetChapterId === null
             ? db.prepare(`
               SELECT scene_id
@@ -972,21 +1029,21 @@ export function registerMetadataTools(s, {
               WHERE project_id = ? AND chapter_id IS NULL AND timeline_position = ? AND scene_id != ?
               ORDER BY scene_id
               LIMIT 1
-            `).get(project_id, timeline_position, scene_id)
+            `).get(project_id, effectiveTimelinePosition, scene_id)
             : db.prepare(`
               SELECT scene_id
               FROM scenes
               WHERE project_id = ? AND chapter_id = ? AND timeline_position = ? AND scene_id != ?
               ORDER BY scene_id
               LIMIT 1
-            `).get(project_id, targetChapterId, timeline_position, scene_id);
+            `).get(project_id, targetChapterId, effectiveTimelinePosition, scene_id);
 
           if (positionConflict) {
-            return errorResponse("VALIDATION_ERROR", `timeline_position ${timeline_position} is already used in the target chapter.`, {
+            return errorResponse("VALIDATION_ERROR", `timeline_position ${effectiveTimelinePosition} is already used in the target chapter.`, {
               project_id,
               scene_id,
               chapter_id: targetChapterId,
-              timeline_position,
+              timeline_position: effectiveTimelinePosition,
               existing_scene_id: positionConflict.scene_id,
               next_step: "Choose an unused timeline_position. Automatic resequencing is not part of this command yet.",
             });

--- a/src/workflows/workflow-catalogue.js
+++ b/src/workflows/workflow-catalogue.js
@@ -78,13 +78,15 @@ export const WORKFLOW_CATALOGUE = [
   {
     id: "structure_assignment",
     label: "Manage chapter structure",
-    use_when: "Use when the user wants to create, rename, or reorder a canonical chapter, move an unchaptered scene into a canonical chapter, repair an explicit scene chapter link, or clear a scene's explicit chapter assignment.",
+    use_when: "Use when the user wants to create, rename, or reorder a canonical chapter, attach an epigraph to a chapter, move a scene into a canonical chapter or position, repair an explicit scene chapter link, or clear a scene's explicit chapter assignment.",
     steps: [
       { tool: "find_scenes", note: "Identify the target scene and confirm project_id if the user did not provide both." },
       { tool: "list_chapters", note: "Inspect existing canonical chapters before creating or assigning chapter structure." },
       { tool: "create_chapter", note: "Use when the intended canonical chapter does not exist yet; this creates chapter state only and does not generate folders or scene files." },
       { tool: "rename_chapter", note: "Use when the canonical chapter title should change; this does not rename folders or generated representation paths." },
       { tool: "reorder_chapter", note: "Use when the canonical chapter order should change to an unused sort_index; this does not rename folders or generated representation paths." },
+      { tool: "attach_epigraph", note: "Use when an existing canonical epigraph should belong to a different canonical chapter; this does not move the epigraph source file." },
+      { tool: "move_scene", note: "Use when a scene should move to another canonical chapter and/or unused timeline_position; this does not move the scene source file." },
       { tool: "assign_scene_to_chapter", note: "Use this named structure workflow for chapter assignment or clearing instead of editing chapter fields through generic metadata updates." },
       { tool: "diagnose_structure", note: "Run when the assignment is part of a drift repair workflow or when folder-derived structure may disagree with the requested link." },
     ],

--- a/src/workflows/workflow-catalogue.js
+++ b/src/workflows/workflow-catalogue.js
@@ -78,11 +78,12 @@ export const WORKFLOW_CATALOGUE = [
   {
     id: "structure_assignment",
     label: "Manage chapter structure",
-    use_when: "Use when the user wants to create a canonical chapter, move an unchaptered scene into a canonical chapter, repair an explicit scene chapter link, or clear a scene's explicit chapter assignment.",
+    use_when: "Use when the user wants to create or rename a canonical chapter, move an unchaptered scene into a canonical chapter, repair an explicit scene chapter link, or clear a scene's explicit chapter assignment.",
     steps: [
       { tool: "find_scenes", note: "Identify the target scene and confirm project_id if the user did not provide both." },
       { tool: "list_chapters", note: "Inspect existing canonical chapters before creating or assigning chapter structure." },
       { tool: "create_chapter", note: "Use when the intended canonical chapter does not exist yet; this creates chapter state only and does not generate folders or scene files." },
+      { tool: "rename_chapter", note: "Use when the canonical chapter title should change; this does not rename folders or generated representation paths." },
       { tool: "assign_scene_to_chapter", note: "Use this named structure workflow for chapter assignment or clearing instead of editing chapter fields through generic metadata updates." },
       { tool: "diagnose_structure", note: "Run when the assignment is part of a drift repair workflow or when folder-derived structure may disagree with the requested link." },
     ],

--- a/src/workflows/workflow-catalogue.js
+++ b/src/workflows/workflow-catalogue.js
@@ -77,11 +77,12 @@ export const WORKFLOW_CATALOGUE = [
   },
   {
     id: "structure_assignment",
-    label: "Assign a scene to a chapter",
-    use_when: "Use when the user wants to move an unchaptered scene into a canonical chapter, repair an explicit scene chapter link, or clear a scene's explicit chapter assignment.",
+    label: "Manage chapter structure",
+    use_when: "Use when the user wants to create a canonical chapter, move an unchaptered scene into a canonical chapter, repair an explicit scene chapter link, or clear a scene's explicit chapter assignment.",
     steps: [
       { tool: "find_scenes", note: "Identify the target scene and confirm project_id if the user did not provide both." },
-      { tool: "list_chapters", note: "Choose the canonical chapter_id for the target project before assigning." },
+      { tool: "list_chapters", note: "Inspect existing canonical chapters before creating or assigning chapter structure." },
+      { tool: "create_chapter", note: "Use when the intended canonical chapter does not exist yet; this creates chapter state only and does not generate folders or scene files." },
       { tool: "assign_scene_to_chapter", note: "Use this named structure workflow for chapter assignment or clearing instead of editing chapter fields through generic metadata updates." },
       { tool: "diagnose_structure", note: "Run when the assignment is part of a drift repair workflow or when folder-derived structure may disagree with the requested link." },
     ],

--- a/src/workflows/workflow-catalogue.js
+++ b/src/workflows/workflow-catalogue.js
@@ -78,12 +78,13 @@ export const WORKFLOW_CATALOGUE = [
   {
     id: "structure_assignment",
     label: "Manage chapter structure",
-    use_when: "Use when the user wants to create or rename a canonical chapter, move an unchaptered scene into a canonical chapter, repair an explicit scene chapter link, or clear a scene's explicit chapter assignment.",
+    use_when: "Use when the user wants to create, rename, or reorder a canonical chapter, move an unchaptered scene into a canonical chapter, repair an explicit scene chapter link, or clear a scene's explicit chapter assignment.",
     steps: [
       { tool: "find_scenes", note: "Identify the target scene and confirm project_id if the user did not provide both." },
       { tool: "list_chapters", note: "Inspect existing canonical chapters before creating or assigning chapter structure." },
       { tool: "create_chapter", note: "Use when the intended canonical chapter does not exist yet; this creates chapter state only and does not generate folders or scene files." },
       { tool: "rename_chapter", note: "Use when the canonical chapter title should change; this does not rename folders or generated representation paths." },
+      { tool: "reorder_chapter", note: "Use when the canonical chapter order should change to an unused sort_index; this does not rename folders or generated representation paths." },
       { tool: "assign_scene_to_chapter", note: "Use this named structure workflow for chapter assignment or clearing instead of editing chapter fields through generic metadata updates." },
       { tool: "diagnose_structure", note: "Run when the assignment is part of a drift repair workflow or when folder-derived structure may disagree with the requested link." },
     ],


### PR DESCRIPTION
## Summary

- Adds explicit M7 structure mutation tools for creating, renaming, and reordering chapters.
- Adds explicit scene and epigraph structure commands, including `assign_scene_to_chapter`, `move_scene`, and `attach_epigraph`.
- Keeps file/folder representation changes out of scope and returns diagnostics when canonical state may diverge from path-derived structure.

## Motivation

The target architecture migration calls for sanctioned MCP workflows for structural manuscript changes instead of relying on generic metadata writes or folder inference. This PR expands that command surface while keeping compatibility fields and representation drift visible during the migration.

## Implementation

- Added chapter command planning/persistence helpers for canonical chapter creation, rename, reorder, and epigraph attachment.
- Exposed the new commands through metadata tools and workflow/tool documentation.
- Updated scene movement to validate timeline conflicts against the sidecar-backed chapter state that will actually be persisted and re-indexed.
- Added unit and integration coverage for happy paths, duplicate/conflict handling, path-derived structure conflicts, and stale-index move behavior.

## Testing

- `node --test src/test/integration/metadata.test.mjs`
- `node --test src/test/unit/scene-chapter-assignment.test.mjs src/test/unit/chapter-commands.test.mjs`
- `npm test`

## Risks and tradeoffs

- These commands intentionally update canonical state and explicit compatibility sidecar fields only; they do not move or rename scene files, epigraph files, or Scrivener-compatible folders.
- Automatic resequencing is still out of scope, so occupied chapter order and timeline positions fail fast with guidance.
- Existing compatibility paths remain available during migration.

## Follow-up

- None for this PR.
