### PR TITLE
chore(security): add eslint security checks

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -22,6 +22,12 @@ Track the remaining follow-up work around first-class chapters, deferred divisio
 
 **Status:** Deferred backlog (not active). Canonical chapters and epigraphs, `chapter_id` targeting, dedicated chapter/epigraph tools, and chapter-aware bundle rendering have already shipped; remaining follow-up work is available for future prioritization.
 
+### 🔒 [Filesystem Boundary Hardening](docs/initiatives/backlog/filesystem-boundary/prd.md) 📋
+
+Centralize filesystem containment, symlink, generated-output, and mutation rules so security checks match Writing MCP's local-file product model instead of warning about expected dynamic path usage.
+
+**Status:** Deferred backlog (not active). Candidate follow-up after security linting; requires characterization tests before migrating high-risk write/delete/move surfaces.
+
 ### 📊 [Embedding-Based Search](docs/initiatives/backlog/embeddings-search/prd.md) 📋
 
 Semantic search for queries that require understanding meaning, not just keywords.

--- a/docs/initiatives/backlog/filesystem-boundary/prd.md
+++ b/docs/initiatives/backlog/filesystem-boundary/prd.md
@@ -1,0 +1,217 @@
+# PRD: Filesystem Boundary Hardening
+
+**Status:** 📋 Deferred backlog (not active)
+
+This initiative captures follow-up work discovered while adding security linting to the development workflow.
+It is not part of the current ESLint plugin setup branch unless explicitly selected as active implementation scope.
+
+## Goal
+
+Centralize filesystem access rules so features can read, write, move, and delete manuscript artifacts through application-aware helpers instead of repeating path-safety logic in each workflow.
+
+The product goal is:
+
+- fewer review-missable filesystem safety checks;
+- one clear place for sync-root containment, symlink, overwrite, and deletion policy;
+- security linting that warns about application-relevant risks rather than core product concepts;
+- simpler feature code when adding new file-backed workflows.
+
+## Problem
+
+Writing MCP intentionally works with local manuscript files.
+Generic security lint rules such as "non-literal filesystem path" produce broad warnings because dynamic file paths are central to the product.
+Those warnings are too noisy to enforce directly, but the underlying risk is real:
+
+- write, delete, and move operations appear in multiple feature modules;
+- each module must remember sync-root containment, project ID validation, symlink behavior, and output filename safety;
+- reviewers have to reconstruct the path-safety story from local code instead of recognizing a shared boundary API;
+- future workflows could introduce raw filesystem mutation that bypasses existing guard patterns.
+
+The current codebase already has several good guard patterns, including sync-root output validation and structure restore path checks.
+The issue is distribution, not absence of care.
+
+## Product Boundary
+
+This initiative is about hardening local filesystem boundaries for existing file-backed workflows.
+It should preserve current product behavior unless a later implementation PR explicitly calls out a behavior change.
+
+In scope:
+
+- shared helpers for resolving paths inside `WRITING_SYNC_DIR`;
+- shared helpers for output directories and generated filenames;
+- shared wrappers or guard functions for text writes, deletes, moves, and regular-file checks;
+- clear symlink policy per operation type;
+- migration of high-risk call sites to the shared boundary;
+- project-specific linting to discourage new raw filesystem mutation outside approved modules;
+- characterization tests around existing behavior before refactoring risky paths.
+
+Out of scope:
+
+- changing authored prose storage away from files;
+- replacing SQLite or sidecar metadata architecture;
+- changing Scrivener import semantics;
+- introducing remote filesystem or cloud storage support;
+- making every read operation go through a heavy abstraction when simple reads are already constrained by indexed paths;
+- enabling generic `security/detect-non-literal-fs-filename` warnings as a PR gate.
+
+## Design Principles
+
+1. **Filesystem access is a product feature, not a smell**
+   Dynamic paths are expected. Warnings should focus on unsafe mutation or missing boundary checks, not on the existence of file IO.
+
+2. **Centralize policy, keep intent local**
+   Feature code should still make workflow intent obvious, but containment and symlink rules should live in one place.
+
+3. **Prefer explicit trust boundaries**
+   Helpers should distinguish sync-root paths, generated output paths, existing indexed file paths, and import/source paths.
+
+4. **Make destructive actions recognizable**
+   Writes, deletes, moves, and removals should be easy to search, review, and lint.
+
+5. **Refactor before enforcement**
+   Add lint restrictions only after approved safe paths exist, so the rule guides future code instead of creating migration noise.
+
+## Proposed Architecture
+
+Add a small filesystem boundary module under `src/core/`, with naming to be decided during implementation.
+Candidate responsibilities:
+
+- resolve a candidate path against `WRITING_SYNC_DIR`;
+- resolve paths that may not exist yet by canonicalizing the nearest existing ancestor;
+- validate output directories and generated filenames;
+- assert regular files and reject or explicitly handle symlinks;
+- provide guarded write, delete, and move operations;
+- return consistent validation errors and diagnostic details.
+
+Candidate helper shape:
+
+```js
+resolveInsideSyncDir(candidatePath)
+resolveCandidateInsideSyncDir(candidatePath)
+resolveOutputDirWithinSync(outputDir)
+resolveGeneratedOutputPath(outputDir, fileName)
+assertRegularFile(path)
+writeTextInsideSync(path, content)
+deleteInsideSync(path)
+moveInsideSync(fromPath, toPath)
+```
+
+The exact names can change.
+The important contract is that callers use helpers that encode the filesystem boundary being trusted.
+
+## Filesystem Policy Questions
+
+Implementation should answer these explicitly before broad migration:
+
+- Which operations follow symlinks, and which reject them?
+- Should generated output writes overwrite existing files, fail, or require an explicit option?
+- Which paths may exist outside `WRITING_SYNC_DIR` during import or setup, and are they read-only?
+- Should indexed `scene.file_path` values be revalidated before every write, or only when stale/path diagnostics are present?
+- How should helper errors map to existing MCP error envelopes?
+- Which low-level modules are allowed to perform raw filesystem mutation after the migration?
+
+## Initial High-Risk Surfaces
+
+Prioritize write/delete/move workflows before broad read-only migration:
+
+- Scrivener direct merge relocation in `src/sync/scrivener-direct.js`;
+- import file writes and cleanup in `src/sync/importer.js`;
+- sidecar migration and generated sidecar writes in `src/sync/sync.js`;
+- review bundle output writes in `src/review-bundles/review-bundles-writer.js`;
+- prose edit commits in `src/tools/editing.js`;
+- metadata and styleguide config writes in `src/tools/metadata.js` and `src/tools/styleguide.js`;
+- structure export and restore file validation in `src/structure/structure-export.js` and `src/structure/structure-restore.js`;
+- async job request/result file cleanup in `src/runtime/async-jobs.js`.
+
+## Milestone 1: Boundary Inventory and Characterization
+
+Functional requirements:
+
+1. Inventory raw filesystem mutation call sites.
+2. Categorize each call site as sync-root write, generated output write, import/source read, cleanup/delete, move/rename, or support script.
+3. Document the expected containment and symlink behavior for each category.
+4. Add or identify tests covering current behavior for the highest-risk categories.
+
+Acceptance criteria:
+
+1. A maintainer can see which call sites remain raw and why.
+2. Existing behavior is characterized before shared helpers change it.
+3. No behavior changes are made in this milestone unless explicitly documented.
+
+## Milestone 2: Shared Boundary Helpers
+
+Functional requirements:
+
+1. Extract existing sync-root containment logic into a reusable core module.
+2. Add helpers for candidate paths whose target file may not exist yet.
+3. Add generated output path validation that prevents filename traversal.
+4. Add regular-file and symlink checks for workflows that trust file contents.
+5. Preserve existing error codes and user-facing guidance where possible.
+
+Acceptance criteria:
+
+1. Existing output directory validation still rejects paths outside `WRITING_SYNC_DIR`.
+2. Existing symlink escape tests continue to pass.
+3. Helper tests cover existing paths, missing target paths, symlink ancestors, traversal attempts, and non-regular files.
+
+## Milestone 3: Migrate High-Risk Mutation Surfaces
+
+Functional requirements:
+
+1. Move review bundle outputs to generated-output helpers.
+2. Move structure export and restore checks to shared boundary helpers.
+3. Move prose edit and metadata write paths to sync-root mutation helpers.
+4. Move import and Scrivener relocation paths only after characterization tests are in place.
+5. Keep workflow outputs, diagnostics, and side effects equivalent unless a behavior change is intentionally accepted.
+
+Acceptance criteria:
+
+1. Raw write/delete/move calls are removed from high-risk feature modules or isolated behind approved wrappers.
+2. Existing integration tests for sync, import, editing, review bundles, and structure restore pass.
+3. Reviewers can verify path safety by checking helper choice rather than re-deriving path logic at every call site.
+
+## Milestone 4: Application-Aware Lint Enforcement
+
+Functional requirements:
+
+1. Add a local lint rule or `no-restricted-syntax` configuration for raw filesystem mutation calls.
+2. Allow raw mutation only inside the filesystem boundary module and intentionally scoped support scripts.
+3. Keep generic `security/detect-non-literal-fs-filename` disabled in normal PR linting.
+4. Document how to add a new filesystem workflow safely.
+
+Acceptance criteria:
+
+1. New direct uses of `fs.writeFileSync`, `fs.unlinkSync`, `fs.renameSync`, or `fs.rmSync` in feature modules fail lint.
+2. Existing legitimate filesystem operations pass through approved helpers.
+3. Lint output remains actionable and low-noise.
+
+## Test Strategy
+
+Unit tests:
+
+- path resolution inside and outside sync root;
+- missing target paths with safe and unsafe existing ancestors;
+- symlinked ancestors and symlinked files;
+- generated filename traversal attempts;
+- overwrite, delete, and move helper behavior;
+- error envelope mapping for invalid paths.
+
+Integration tests:
+
+- review bundle output rejects symlink escape and traversal filenames;
+- structure restore refuses exports and referenced files outside sync root;
+- prose edit commit refuses stale or invalid prose paths;
+- Scrivener merge relocation preserves current behavior while using shared helpers;
+- import cleanup does not delete outside the expected import target boundary.
+
+Manual verification:
+
+- run `npm run check:pr`;
+- run representative import, review-bundle, edit, structure export, and restore workflows on a fixture sync directory;
+- inspect lint output after intentionally adding a raw filesystem mutation in a feature module.
+
+## Related
+
+- [Managed Structure Contract](../../../foundations/managed-structure-contract.md)
+- [Structural Authority Hardening](../../done/structural-authority-hardening/prd.md)
+- [Target Architecture Migration](../../done/target-architecture-migration/prd.md)

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,6 +6,9 @@ export default [
   js.configs.recommended,
   security.configs.recommended,
   {
+    plugins: {
+      security,
+    },
     languageOptions: {
       ecmaVersion: 2024,
       sourceType: "module",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,8 +1,10 @@
 import js from "@eslint/js";
 import globals from "globals";
+import security from "eslint-plugin-security";
 
 export default [
   js.configs.recommended,
+  security.configs.recommended,
   {
     languageOptions: {
       ecmaVersion: 2024,
@@ -14,6 +16,30 @@ export default [
     rules: {
       "no-unused-vars": ["error", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
       "no-console": "off",
+      "security/detect-bidi-characters": "error",
+      "security/detect-buffer-noassert": "error",
+      "security/detect-disable-mustache-escape": "error",
+      "security/detect-eval-with-expression": "error",
+      "security/detect-new-buffer": "error",
+      "security/detect-no-csrf-before-method-override": "error",
+      "security/detect-non-literal-require": "error",
+      "security/detect-pseudoRandomBytes": "error",
+      "security/detect-unsafe-regex": "error",
+      "security/detect-non-literal-fs-filename": "off",
+      "security/detect-non-literal-regexp": "off",
+      "security/detect-object-injection": "off",
+    },
+  },
+  {
+    // These modules use small anchored filename/path parsers that safe-regex flags
+    // conservatively. Keep the rule strict elsewhere so new unsafe regexes fail lint.
+    files: [
+      "src/structure/structure-inference.js",
+      "src/sync/importer.js",
+      "src/sync/sync.js",
+    ],
+    rules: {
+      "security/detect-unsafe-regex": "off",
     },
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@eslint/js": "^10.0.1",
         "auto-changelog": "^2.5.1",
         "eslint": "^10.3.0",
+        "eslint-plugin-security": "^4.0.0",
         "globals": "^17.6.0",
         "release-it": "^20.0.1"
       },
@@ -1682,6 +1683,22 @@
         "jiti": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-plugin-security": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-security/-/eslint-plugin-security-4.0.0.tgz",
+      "integrity": "sha512-tfuQT8K/Li1ZxhFzyD8wPIKtlzZxqBcPr9q0jFMQ77wWAbKBVEhaMPVQRTMTvCMUDhwBe5vPVqQPwAGk/ASfxQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-regex": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint-scope": {
@@ -3609,6 +3626,16 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/regexp-tree": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
+      "integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "regexp-tree": "bin/regexp-tree"
+      }
+    },
     "node_modules/release-it": {
       "version": "20.0.1",
       "resolved": "https://registry.npmjs.org/release-it/-/release-it-20.0.1.tgz",
@@ -3736,6 +3763,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/safe-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
+      "integrity": "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regexp-tree": "~0.1.1"
       }
     },
     "node_modules/safer-buffer": {

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "@eslint/js": "^10.0.1",
     "auto-changelog": "^2.5.1",
     "eslint": "^10.3.0",
+    "eslint-plugin-security": "^4.0.0",
     "globals": "^17.6.0",
     "release-it": "^20.0.1"
   },

--- a/release-log.md
+++ b/release-log.md
@@ -6,6 +6,14 @@ This complements `CHANGELOG.md`:
 - `CHANGELOG.md` is technical and release-oriented.
 - This log is plain-language and outcome-oriented.
 
+### 2026-05-20 — Add security linting to the PR gate
+
+- What changed: Added Node security linting to the existing ESLint workflow, with high-confidence unsafe patterns failing lint, noisy project-specific hotspot rules tuned out, and a deferred filesystem-boundary hardening initiative documented for follow-up.
+- Why it matters: Maintainers and AI-assisted contributors get automated review coverage for common JavaScript security mistakes without burying normal PR checks in expected filesystem and metadata warnings.
+- Who is affected: Maintainers and contributors preparing pull requests.
+- Action needed: Run `npm run check:pr` before opening or updating a PR; review any new security lint failures as part of normal code review.
+- PR: TBD
+
 ### 2026-05-19 — Clarify numeric chapter compatibility aliases
 
 - What changed: Numeric `chapter` and `chapters` inputs are now explicitly documented as read-scope compatibility aliases that resolve through canonical chapter identity; structural changes continue to use `chapter_id` and named structure workflows.

--- a/release-log.md
+++ b/release-log.md
@@ -12,7 +12,7 @@ This complements `CHANGELOG.md`:
 - Why it matters: Maintainers and AI-assisted contributors get automated review coverage for common JavaScript security mistakes without burying normal PR checks in expected filesystem and metadata warnings.
 - Who is affected: Maintainers and contributors preparing pull requests.
 - Action needed: Run `npm run check:pr` before opening or updating a PR; review any new security lint failures as part of normal code review.
-- PR: TBD
+- PR: [#211](https://github.com/hannasdev/mcp-writing/pull/211)
 
 ### 2026-05-19 — Clarify numeric chapter compatibility aliases
 


### PR DESCRIPTION
## Summary

- Adds `eslint-plugin-security` to the existing ESLint flat config.
- Promotes high-confidence unsafe JavaScript patterns to lint errors while tuning out noisy rules that do not fit Writing MCP's local-file product model.
- Documents a deferred Filesystem Boundary Hardening initiative for future application-aware filesystem safety work.

## Motivation

Code review occasionally misses security practices, but generic filesystem warnings are too broad for an app that intentionally reads and writes local manuscript files. This adds useful automated checks now while preserving a clean, actionable lint baseline.

## Implementation

- Installed `eslint-plugin-security`.
- Enabled the recommended security config, then overrode rule severities for this codebase.
- Kept `security/detect-non-literal-fs-filename`, `security/detect-non-literal-regexp`, and `security/detect-object-injection` out of normal PR linting because they produce expected noise for dynamic manuscript paths and metadata maps.
- Kept unsafe regex detection strict by default, with scoped exceptions for existing small anchored filename/path parsers.
- Added a backlog PRD for centralizing filesystem boundary handling before adding future raw filesystem mutation lint enforcement.

## Testing

- `npm run lint`
- `npm run check:static`
- `npm run check:pr`

## Risks and tradeoffs

- The filesystem lint rule is intentionally disabled because it warns against dynamic paths, which are core product behavior. The follow-up initiative captures a better application-aware approach.
- Existing transitive `npm audit` findings remain in `basic-ftp` and `brace-expansion`; `npm audit fix --dry-run` indicates they can be addressed by separate transitive bumps.

## Follow-up

- Consider the Filesystem Boundary Hardening initiative when ready to consolidate filesystem mutation guards and add low-noise project-specific linting.
