### PR TITLE
docs: add database backup recovery initiative

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -4,6 +4,12 @@ Deferred product work that is not currently active.
 
 ## Deferred Backlog (Not Active)
 
+### 🧯 [Database Backup and Recovery](docs/initiatives/backlog/database-backup-recovery/prd.md) 📋
+
+Preserve Git-backed auditability and restore safety as canonical manuscript state moves into SQLite.
+
+**Status:** Deferred backlog (not active). Product direction is defined for deterministic backup artifacts, backup freshness diagnostics, and explicit restore from trusted backups.
+
 ### 🚀 [OpenClaw Integration](docs/initiatives/backlog/openclaw-integration/prd.md) 📋
 
 Deploy Writing MCP as a service in the OpenClaw runtime with the Writing World agent.

--- a/docs/initiatives/backlog/database-backup-recovery/milestones.md
+++ b/docs/initiatives/backlog/database-backup-recovery/milestones.md
@@ -1,0 +1,290 @@
+# Database Backup and Recovery — Milestones
+
+**Status:** Deferred backlog (not active)
+
+This milestone plan breaks the PRD into independently reviewable slices.
+Each milestone should leave the system in a releasable state and preserve the target architecture rule that SQLite remains canonical while generated backup artifacts provide transparency and explicit recovery input.
+
+## Objective
+
+Add a trustworthy backup and restore story for SQLite-canonical project state without making generated files a daily mutation surface.
+
+## Guardrails
+
+- Do not move authored prose into database backup artifacts.
+- Do not make ordinary `sync` restore or adopt backup files as authority.
+- Keep existing `export_structure_snapshot` and `restore_structure_from_export` behavior working while broader project backups are introduced.
+- Prefer deterministic, Git-reviewable outputs over binary database snapshots for the app-level recovery surface.
+- Keep automatic backup refresh separate from automatic Git commits.
+- Keep restore explicit, dry-run-first, and transactional.
+
+## M1 — Backup Domain Model and Manifest
+
+Goal: define the backup bundle shape before wiring it into mutation workflows.
+
+Deliverables:
+
+- Introduce a versioned project backup schema with `manifest.json` and `canonical.snapshot.json`.
+- Define canonical coverage for v1:
+  - projects and universes;
+  - scenes and durable scene metadata;
+  - chapters, epigraphs, scene placement, and timeline positions;
+  - characters, places, threads, reference docs, and explicit reference links.
+- Define excluded derived state:
+  - FTS tables;
+  - generated reports, bundles, and tool docs;
+  - runtime async jobs;
+  - transient caches;
+  - authored prose bodies.
+- Add deterministic serialization, stable ordering, and checksum calculation.
+- Choose the default generated backup location: `project-backups/<project_id>/`.
+
+Acceptance criteria:
+
+- A project backup can be built in memory from SQLite canonical state with deterministic output.
+- The manifest records project identity, backup schema version, app/schema compatibility metadata, coverage summary, and checksums.
+- Backup artifacts clearly identify themselves as generated transparency and recovery input, not mutation surfaces.
+- Existing structure export tests continue to pass unchanged.
+
+Test strategy:
+
+- Unit tests for deterministic serialization and stable ordering.
+- Unit tests for manifest checksum behavior.
+- Unit tests proving excluded tables or rebuildable state are not represented as restore authority.
+
+Out of scope:
+
+- Public MCP tools.
+- Restore application.
+- Automatic refresh after mutations.
+
+## M2 — Manual Project Backup Export Tool
+
+Goal: expose project backup generation as an explicit workflow.
+
+Deliverables:
+
+- Add `export_project_backup(project_id, output_dir?)`.
+- Write `manifest.json` and `canonical.snapshot.json` under the backup directory.
+- Return artifact paths, relative paths, checksums, coverage summary, and next-step guidance.
+- Route writes through filesystem boundary helpers for generated output.
+- Preserve `export_structure_snapshot` as a structure-specific tool.
+
+Acceptance criteria:
+
+- Export refuses invalid project IDs and output locations outside the sync root.
+- Export output is stable across repeated runs when canonical state has not changed.
+- Tool guidance tells users or agents to review or commit generated backup files without editing them as mutation surfaces.
+- Existing structure export behavior remains compatible.
+
+Test strategy:
+
+- Unit tests for path validation and output rendering.
+- Integration test for exporting a representative fixture project.
+- Regression test showing `export_structure_snapshot` still writes the existing structure export shape.
+
+Out of scope:
+
+- Automatic export after every mutation.
+- Operation history.
+- Restore.
+
+## M3 — Backup Diagnostics and Freshness
+
+Goal: make backup trust visible before backup artifacts are needed for recovery.
+
+Deliverables:
+
+- Add `diagnose_project_backups` or extend existing diagnostics with project backup checks.
+- Detect missing, stale, wrong-project, incompatible-schema, tampered, partial, and unreadable backup bundles.
+- Compare current SQLite canonical state to the latest backup using checksums or a database revision marker.
+- Report backup directory, trust status, freshness status, and actionable next steps.
+- Surface backup freshness in runtime or workflow discovery where useful.
+
+Acceptance criteria:
+
+- Diagnostics distinguish canonical state drift from stale generated backup state.
+- Tampered or partial backup artifacts are refused as trusted recovery input.
+- Missing backups produce guidance to run `export_project_backup`.
+- Diagnostics do not mutate SQLite or generated files.
+
+Test strategy:
+
+- Unit tests for every diagnostic category.
+- Unit tests for checksum mismatch and incompatible schema handling.
+- Integration test for a stale backup after canonical state changes.
+
+Out of scope:
+
+- Auto-repair.
+- Restore application.
+- Git commits.
+
+## M4 — Semantic Operation History
+
+Goal: make canonical mutations reviewable as a human-readable event stream.
+
+Deliverables:
+
+- Add an append-only `operations.jsonl` artifact to the backup bundle.
+- Define a minimal event envelope:
+  - operation name;
+  - project ID;
+  - affected entity IDs;
+  - timestamp;
+  - actor/tool when available;
+  - before/after summary or patch payload;
+  - backup schema and app version metadata.
+- Emit operation records from sanctioned canonical mutation workflows.
+- Keep operation history advisory for audit and review; restore authority remains the canonical snapshot plus manifest.
+
+Acceptance criteria:
+
+- Representative structural mutations append deterministic, meaningful operation records.
+- Operation records are useful in Git review without requiring users to inspect SQLite.
+- Failure to append the operation log is reported as a backup warning without silently hiding backup drift.
+- Operation log behavior does not make generated files authoritative.
+
+Test strategy:
+
+- Unit tests for event envelope rendering.
+- Unit tests for representative mutation event payloads.
+- Integration test for a canonical mutation producing both database change and operation log entry.
+
+Out of scope:
+
+- Event replay as the primary restore mechanism.
+- Rewriting old operation records.
+- Automatic Git commits.
+
+## M5 — Automatic Backup Refresh After Canonical Mutations
+
+Goal: keep generated backup artifacts fresh during ordinary sanctioned workflows.
+
+Deliverables:
+
+- Add a shared post-mutation backup refresh path for canonical database writes.
+- Refresh `manifest.json`, `canonical.snapshot.json`, and `operations.jsonl` after successful canonical mutations.
+- Return clear warnings when backup refresh fails after the canonical mutation succeeds.
+- Ensure refresh behavior is idempotent and does not create Git commits.
+- Update workflow guidance so agents know backup artifacts should normally be fresh after mutation tools run.
+
+Acceptance criteria:
+
+- Canonical mutation tools refresh backup artifacts automatically.
+- A backup refresh failure does not roll back an otherwise valid canonical mutation solely because generated output failed.
+- Failed refresh is visible in the tool response and diagnostics.
+- Repeated mutation and export workflows remain deterministic.
+
+Test strategy:
+
+- Integration tests for representative mutation tools followed by fresh backup diagnostics.
+- Unit tests for post-mutation warning envelopes.
+- Failure-injection tests for generated-output write errors.
+
+Out of scope:
+
+- Full restore implementation.
+- Git commit creation.
+- Backup scheduling outside mutation workflows.
+
+## M6 — Restore Planning and Dry Run
+
+Goal: make recovery inspectable before any canonical state is rewritten.
+
+Deliverables:
+
+- Add `restore_project_from_backup(project_id, backup_path?, dry_run=true)` in dry-run mode.
+- Validate manifest, schema compatibility, project identity, checksums, file references, and conflicts.
+- Produce a restore plan that summarizes rows/entities to create, update, delete, or leave unchanged.
+- Refuse tampered, stale, partial, wrong-project, or incompatible backup bundles.
+- Preserve existing `restore_structure_from_export` behavior as a narrower structure repair workflow.
+
+Acceptance criteria:
+
+- Dry run is the default.
+- Dry run never mutates SQLite or generated files.
+- Restore plans are deterministic and reviewable by a user or AI agent.
+- Invalid backup bundles return actionable diagnostics rather than partial plans.
+
+Test strategy:
+
+- Unit tests for validation and restore-plan construction.
+- Unit tests for checksum, schema, project identity, and file-reference failures.
+- Integration dry-run test against a representative backup bundle.
+
+Out of scope:
+
+- Applying restore changes.
+- Import-style recovery when no trusted backup exists.
+- Restoring prose bodies.
+
+## M7 — Transactional Restore and Rebuild Path
+
+Goal: fulfill the v1 recovery promise by rebuilding canonical database state from a trusted backup.
+
+Deliverables:
+
+- Apply `restore_project_from_backup(..., dry_run=false)` transactionally.
+- Rebuild canonical project state covered by the backup bundle.
+- Regenerate or prompt regeneration of derived indexes after restore.
+- Return a reviewable summary of applied changes and recommended follow-up checks.
+- Ensure failed restore leaves the database unchanged.
+
+Acceptance criteria:
+
+- A trusted backup can reconstruct canonical project state after SQLite loss or targeted canonical-state damage.
+- Restore refuses unsafe input before opening a write transaction.
+- Restore failures roll back all database changes.
+- After restore and derived-index regeneration, core read workflows return expected project state.
+
+Test strategy:
+
+- Transaction tests for successful and failed restore.
+- Integration test deleting or recreating canonical database state from a trusted backup.
+- Integration test for restore followed by sync or derived-index regeneration.
+- Regression test that ordinary `sync` still does not treat backup artifacts as authority.
+
+Out of scope:
+
+- Exact point-in-time restoration of FTS, async jobs, caches, or generated reports.
+- Event-log replay as the primary restore path.
+- Cross-project merge restore.
+
+## M8 — Deployment, Documentation, and Release Readiness
+
+Goal: make the backup system understandable and operationally safe for local, Docker, and homeserver workflows.
+
+Deliverables:
+
+- Update user and maintainer documentation for backup location, Git expectations, restore workflow, and failure handling.
+- Document Docker volume backup expectations for `/sync`, `/data`, and Git remotes.
+- Update generated tool docs and workflow discovery text.
+- Add release-log guidance if the implementation changes user-facing backup or restore behavior.
+- Run manual validation on representative local and containerized projects.
+
+Acceptance criteria:
+
+- Users can explain what must be backed up: prose/Git sync root, generated backup artifacts, and live SQLite volume where applicable.
+- Users know that app-level backup artifacts are Git-reviewable recovery input, not a substitute for normal volume backups.
+- Agents are routed toward `export_project_backup`, diagnostics, and dry-run restore instead of editing backup files.
+- The initiative is ready to move from backlog to active implementation when prioritized.
+
+Test strategy:
+
+- Documentation link checks where practical.
+- Generated tool docs drift check.
+- Manual Docker/local restore walkthrough.
+
+Out of scope:
+
+- Hosted backup service.
+- Client-specific restore UI.
+- Automatic Git push or remote setup.
+
+## Related
+
+- [prd.md](prd.md)
+- [Target Architecture Migration](../../done/target-architecture-migration/prd.md)
+- [Structural Authority Hardening](../../done/structural-authority-hardening/prd.md)
+- [Docker, CI, and Deployment Workflow](../../active/docker-ci-deployment/prd.md)

--- a/docs/initiatives/backlog/database-backup-recovery/prd.md
+++ b/docs/initiatives/backlog/database-backup-recovery/prd.md
@@ -1,0 +1,143 @@
+# PRD: Database Backup and Recovery
+
+**Status:** 📋 Deferred backlog (not active)
+
+This work is intentionally deferred until the product is ready to extend the SQLite-canonical architecture with a complete backup and recovery story.
+The need is clear now because structural manuscript state has moved away from files-first authority, but this PRD is not active implementation scope.
+
+Implementation slices are tracked in [milestones.md](milestones.md).
+
+## Problem Statement
+
+Writing MCP now treats SQLite as the durable canonical model for structural manuscript state, while prose remains file-based.
+That architecture protects structural invariants and gives AI agents one sanctioned mutation path, but it weakens the earlier backup story where most meaningful changes were naturally visible and recoverable through Git.
+
+The current structure export and restore workflows are useful, but they cover a narrow slice of canonical structure.
+As more durable project state lives in SQLite, users need confidence that database loss, stale exports, or deployment mistakes will not strand their manuscript metadata outside normal Git-backed review and recovery habits.
+
+The product needs a backup strategy that preserves the target architecture:
+
+- SQLite remains canonical during daily work.
+- Generated files remain transparency and recovery surfaces, not mutation surfaces.
+- Git remains useful for review, auditability, and off-machine redundancy.
+- Restore is explicit, transactional, and diagnosable.
+
+## Solution
+
+Introduce a project backup system that generates deterministic, Git-trackable backup artifacts from canonical SQLite state.
+Sanctioned canonical mutation workflows refresh those artifacts after successful database writes, and diagnostics report when backups are missing, stale, tampered, incompatible, or incomplete.
+
+The v1 recovery promise is:
+
+- a trusted backup can rebuild canonical project database state after SQLite loss;
+- authored prose remains backed up through normal file and Git workflows;
+- derived indexes, FTS tables, generated reports, caches, and runtime jobs are regenerated rather than restored as authority.
+
+The backup system should extend the existing `export_structure_snapshot` and `restore_structure_from_export` direction rather than replacing it wholesale.
+Those tools remain useful as structure-specific workflows, while the project backup system becomes the broader operational safety net for SQLite-canonical state.
+
+## User Stories
+
+1. As an author, I want database-backed manuscript structure to remain recoverable through Git-backed artifacts, so that I can trust the new architecture as much as the old files-first workflow.
+2. As an author, I want backup artifacts to update after structural changes, so that I do not have to remember a separate backup step during ordinary writing work.
+3. As an author, I want backup failures to be visible, so that I can fix backup freshness before I need recovery.
+4. As an author, I want restore to default to a dry run, so that I can inspect what would change before canonical database state is rewritten.
+5. As an author, I want prose files to stay outside database backup blobs, so that authored text remains readable, diffable, and backed up as plain files.
+6. As an AI agent, I want clear workflow guidance for backup and restore, so that I do not patch generated backup files as if they were normal mutation surfaces.
+7. As an AI agent, I want diagnostics to say whether a backup is trusted, stale, or incompatible, so that I can choose the right recovery path without guessing.
+8. As a maintainer, I want deterministic backup output, so that Git diffs are reviewable and testable.
+9. As a maintainer, I want checksums and schema versions in backup artifacts, so that tampering, partial writes, and incompatible restores are refused.
+10. As a maintainer, I want restore to be transactional, so that failed recovery cannot leave the canonical database half-restored.
+11. As a Docker or homeserver user, I want the runtime to report backup location and freshness, so that volume backup and upgrade instructions are grounded in actual state.
+12. As a project owner, I want Git commits to remain an explicit user or agent decision, so that automatic backup refresh does not create noisy commit history.
+13. As a project owner, I want a semantic operation history for canonical mutations, so that Git review explains what changed and why, not only what the final database snapshot contains.
+14. As a developer, I want existing structure export and restore behavior preserved, so that shipped recovery workflows do not regress while broader backup coverage is added.
+
+## Implementation Decisions
+
+- Add a generated backup bundle under `WRITING_SYNC_DIR`, defaulting to a dedicated `project-backups/<project_id>/` directory.
+- Treat backup files as generated transparency and explicit recovery input. Editing them does not mutate canonical state during daily work.
+- Generate deterministic backup artifacts:
+  - `manifest.json` for project identity, schema/app versions, covered domains, checksums, and restore compatibility.
+  - `canonical.snapshot.json` for durable canonical state needed to rebuild the project database.
+  - `operations.jsonl` for append-only semantic records of sanctioned canonical mutations.
+- Refresh backup artifacts after successful canonical database mutations.
+- Do not automatically create Git commits in v1. Tools should update Git-trackable files and return guidance to review or commit them.
+- Restore from backup is an explicit maintenance workflow, never an ordinary `sync` side effect.
+- Restore defaults to dry run and applies changes transactionally only when explicitly requested.
+- Backup freshness should be based on deterministic checksums or a database revision marker, not timestamps alone.
+- Preserve existing `export_structure_snapshot` and `restore_structure_from_export` tools as narrower structure workflows or compatibility wrappers.
+- Include canonical durable state in v1 coverage:
+  - projects and universes;
+  - chapters, epigraph links, scene chapter membership, and timeline positions;
+  - durable scene metadata indexed from managed metadata;
+  - characters, places, threads, reference documents, explicit reference links, and other user-authored structured relationships.
+- Exclude derived or rebuildable state from v1 restore authority:
+  - FTS tables;
+  - generated reports, bundles, and tool docs;
+  - runtime async jobs;
+  - transient caches;
+  - authored prose bodies.
+
+## Proposed Interfaces
+
+Future implementation should add or extend MCP workflows around these capabilities:
+
+- `export_project_backup(project_id, output_dir?)`
+  - writes the full canonical backup bundle;
+  - returns artifact paths, checksums, coverage summary, and next-step guidance.
+- `restore_project_from_backup(project_id, backup_path?, dry_run=true)`
+  - validates manifest, schema compatibility, project identity, checksums, file references, and conflicts;
+  - returns a restore plan in dry-run mode;
+  - applies canonical database restore transactionally when `dry_run=false`.
+- `diagnose_project_backups` or an extension of existing diagnostics
+  - reports missing, stale, wrong-project, incompatible, tampered, or incomplete backups;
+  - distinguishes canonical drift from stale generated backup state.
+- Runtime and workflow discovery surfaces should report backup directory, freshness status, Git availability, and recommended restore entry points.
+
+## Testing Decisions
+
+Good tests should assert observable backup and restore behavior rather than internal helper structure.
+The important guarantees are deterministic output, trustworthy diagnostics, transactional restore, and preservation of the architecture boundary between canonical state and generated transparency.
+
+Unit tests should cover:
+
+- deterministic backup rendering and stable ordering;
+- manifest checksums and schema compatibility;
+- operation log entries for representative canonical mutation tools;
+- stale, missing, wrong-project, incompatible-schema, tampered, and incomplete backup diagnostics;
+- restore planning and conflict detection;
+- failed restore leaving SQLite unchanged.
+
+Integration tests should cover:
+
+- canonical mutation followed by automatic backup refresh;
+- reviewing backup artifact diffs after a structural change;
+- deleting or recreating SQLite canonical state from a trusted backup;
+- regenerating derived indexes after restore;
+- ordinary `sync` refusing to treat backup artifacts as authority.
+
+Manual validation should cover:
+
+- representative Scrivener-imported projects;
+- local Git repositories with and without remotes;
+- Docker or homeserver deployments with separate `/sync` and `/data` mounts;
+- upgrade and rollback documentation paths.
+
+## Out of Scope
+
+- Moving authored prose into SQLite.
+- Restoring prose bodies from database backup artifacts.
+- Automatically committing backup artifacts to Git.
+- Replacing Git remote backup guidance with a hosted backup service.
+- Exact point-in-time restoration of every SQLite table, including FTS, async jobs, and caches.
+- Using generated backup files as a normal mutation API.
+- Import-style recovery from sidecars and folder layout when no trusted backup exists, except as existing or separately planned repair behavior.
+
+## Further Notes
+
+This initiative should be coordinated with Docker and deployment documentation because mounted volume layout changes the operational backup story.
+The app-level backup bundle protects canonical project state, while deployment docs must still explain backing up the live SQLite volume, the sync Git repository, and any configured remote.
+
+The key product constraint is that backup handling must not undo the target architecture.
+Generated backup files make SQLite-canonical state reviewable and recoverable, but they do not become the primary control plane for manuscript structure.


### PR DESCRIPTION
## Summary

- Adds a deferred backlog PRD for database backup and recovery.
- Breaks the work into milestones from backup schema through restore and deployment docs.
- Adds the initiative to the top-level backlog index.

## Motivation

SQLite is now canonical for structural manuscript state, which weakens the old files-first Git backup story. The new backlog initiative captures a strategy for Git-trackable backup artifacts, freshness diagnostics, semantic operation history, and explicit restore from trusted backups without making generated files authoritative.

## Implementation

- Added docs/initiatives/backlog/database-backup-recovery/prd.md.
- Added docs/initiatives/backlog/database-backup-recovery/milestones.md.
- Linked the initiative from BACKLOG.md.

## Testing

- Not run: documentation-only change.

## Risks and tradeoffs

- Low implementation risk because this is docs-only.
- The main review risk is product scope: the PRD intentionally targets canonical database rebuild, not exact point-in-time restoration of every SQLite table.

## Follow-up

- None for this docs PR. Future implementation should promote the initiative from deferred backlog before code changes begin.
