### PR TITLE
docs: activate database backup initiative

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -4,12 +4,6 @@ Deferred product work that is not currently active.
 
 ## Deferred Backlog (Not Active)
 
-### 🧯 [Database Backup and Recovery](docs/initiatives/backlog/database-backup-recovery/prd.md) 📋
-
-Preserve Git-backed auditability and restore safety as canonical manuscript state moves into SQLite.
-
-**Status:** Deferred backlog (not active). Product direction is defined for deterministic backup artifacts, backup freshness diagnostics, and explicit restore from trusted backups.
-
 ### 🚀 [OpenClaw Integration](docs/initiatives/backlog/openclaw-integration/prd.md) 📋
 
 Deploy Writing MCP as a service in the OpenClaw runtime with the Writing World agent.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -9,7 +9,9 @@ It supports metadata-first reasoning, explicit prose editing workflows, and revi
 
 ## Product Status
 
-Active initiative: none currently selected.
+Active initiative: [Database Backup and Recovery](docs/initiatives/backlog/database-backup-recovery/prd.md).
+
+Current focus: M1 — Backup Domain Model and Manifest. This slice defines deterministic in-memory project backup artifacts for SQLite-canonical state before adding public tools, disk writes, mutation hooks, diagnostics, or restore behavior.
 
 Most recent completed initiative: [Docker, CI, and Deployment Workflow](docs/initiatives/done/docker-ci-deployment/prd.md).
 
@@ -46,6 +48,7 @@ For structural manuscript state, use [Managed Structure Contract](docs/foundatio
 
 - [Features](FEATURES.md) — shipped product capabilities and links to completed initiative docs
 - [Backlog](BACKLOG.md) — deferred product work that is not currently active
+- [Database Backup and Recovery](docs/initiatives/backlog/database-backup-recovery/prd.md) — active initiative for Git-reviewable recovery artifacts for SQLite-canonical state
 - [Conceptual Target Architecture](docs/foundations/target-architecture.md) — idealized architectural model for evaluating future structure, tooling, and workflow decisions
 - [Managed Structure Contract](docs/foundations/managed-structure-contract.md) — design boundaries for structural mutation, generated transparency, import, and maintenance workflows
 - [Docker, CI, and Deployment Workflow](docs/initiatives/done/docker-ci-deployment/prd.md) — completed milestone for supported container build, run, smoke-test, and deployment operations

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Instead of feeding an entire manuscript to an AI and hoping it fits in the conte
 - **Core platform complete:** Metadata-first analysis, sidecar-backed metadata maintenance, AI-assisted prose editing with confirmation + git history, review bundles, and Scrivener Direct extraction are all implemented.
 - **Recently completed:** Docker, CI, and Deployment Workflow made Docker a supported way to build, run, smoke-test, and deploy Writing MCP.
 - **Previous milestone:** Filesystem Boundary Hardening centralized local file mutation through application-aware helpers and lint guardrails.
-- **Active development:** No active initiative is currently selected.
-- **Deferred backlog:** OpenClaw integration, client-agnostic setup, divisions, database backup/recovery, and embeddings search.
+- **Active development:** Database Backup and Recovery is defining deterministic Git-reviewable backup artifacts for SQLite-canonical project state.
+- **Deferred backlog:** OpenClaw integration, client-agnostic setup, divisions, and embeddings search.
 - **Ideas and open questions:** tracked separately so future exploration does not distort the active roadmap.
 
 ## Who it is for

--- a/docs/initiatives/backlog/database-backup-recovery/milestones.md
+++ b/docs/initiatives/backlog/database-backup-recovery/milestones.md
@@ -1,9 +1,11 @@
 # Database Backup and Recovery — Milestones
 
-**Status:** Deferred backlog (not active)
+**Status:** Active
 
 This milestone plan breaks the PRD into independently reviewable slices.
 Each milestone should leave the system in a releasable state and preserve the target architecture rule that SQLite remains canonical while generated backup artifacts provide transparency and explicit recovery input.
+
+Current focus: M1 — Backup Domain Model and Manifest.
 
 ## Objective
 
@@ -28,7 +30,7 @@ Deliverables:
 - Introduce a versioned project backup schema with `manifest.json` and `canonical.snapshot.json`.
 - Define canonical coverage for v1:
   - projects and universes;
-  - scenes and durable scene metadata;
+  - scenes and durable SQLite-canonical scene metadata that cannot be safely reconstructed from prose, sidecars, or sync reindexing alone;
   - chapters, epigraphs, scene placement, and timeline positions;
   - characters, places, threads, reference docs, and explicit reference links.
 - Define excluded derived state:
@@ -38,24 +40,42 @@ Deliverables:
   - transient caches;
   - authored prose bodies.
 - Add deterministic serialization, stable ordering, and checksum calculation.
+- Define full deterministic snapshots as restore authority; do not introduce custom delta chains or event replay as the v1 recovery mechanism.
 - Choose the default generated backup location: `project-backups/<project_id>/`.
+- Record backup schema version, application package version, and SQLite schema version separately.
+- Reserve manifest space for future operation-log support without implementing `operations.jsonl`.
+- Document the explicit v1 table/domain inventory:
+  - include `projects`, owning `universes`, `scenes`, `chapters`, `epigraphs`, `epigraph_characters`, `epigraph_tags`, `scene_characters`, `scene_places`, `scene_tags`, `scene_threads`, `characters`, `character_traits`, `character_relationships`, `places`, `threads`, `reference_docs`, `reference_doc_tags`, and `reference_links` when they belong to or are required by the target project;
+  - exclude `scenes_fts`, `reference_docs_fts`, `async_jobs`, and raw `schema_version` rows from restore authority.
+- Add manifest metadata that warns backup artifacts are Git-trackable but manuscript-sensitive.
+- Keep the snapshot schema open to future deterministic domain-file splitting if one monolithic JSON file becomes too noisy for review.
 
 Acceptance criteria:
 
 - A project backup can be built in memory from SQLite canonical state with deterministic output.
 - The manifest records project identity, backup schema version, app/schema compatibility metadata, coverage summary, and checksums.
+- Snapshot checksums can identify no-op exports so later workflows can avoid rewriting unchanged artifacts.
 - Backup artifacts clearly identify themselves as generated transparency and recovery input, not mutation surfaces.
+- Backup artifacts clearly identify privacy expectations: no authored prose bodies in v1, but metadata and summaries may still be sensitive.
+- Cross-project or universe-level references are represented conservatively enough for diagnostics without granting restore authority over unrelated projects.
+- M1 remains internal-only: no public MCP tool, no generated files on disk, no automatic backup refresh, and no restore application.
 - Existing structure export tests continue to pass unchanged.
 
 Test strategy:
 
 - Unit tests for deterministic serialization and stable ordering.
 - Unit tests for manifest checksum behavior.
+- Unit tests proving equivalent canonical state produces the same snapshot checksum.
 - Unit tests proving excluded tables or rebuildable state are not represented as restore authority.
+- Unit tests proving operation history is advertised as unsupported or absent until M4.
+- Unit tests for project-scoped filtering and conservative cross-scope relationship representation.
 
 Out of scope:
 
 - Public MCP tools.
+- Filesystem writes.
+- Operation history.
+- Freshness diagnostics beyond artifact checksums.
 - Restore application.
 - Automatic refresh after mutations.
 
@@ -101,6 +121,7 @@ Deliverables:
 - Compare current SQLite canonical state to the latest backup using checksums or a database revision marker.
 - Report backup directory, trust status, freshness status, and actionable next steps.
 - Surface backup freshness in runtime or workflow discovery where useful.
+- Decide whether freshness is computed by rebuilding the canonical snapshot and comparing checksums, by introducing a database revision marker, or by combining both. Timestamp-only freshness is not sufficient.
 
 Acceptance criteria:
 
@@ -125,6 +146,9 @@ Out of scope:
 
 Goal: make canonical mutations reviewable as a human-readable event stream.
 
+This milestone supports future audit, provenance, authorship credibility, progress analytics, and tool/agent accountability.
+It must remain separate from restore authority: the current snapshot plus manifest is the recovery source of truth, while operation history explains how the project changed over time.
+
 Deliverables:
 
 - Add an append-only `operations.jsonl` artifact to the backup bundle.
@@ -138,11 +162,13 @@ Deliverables:
   - backup schema and app version metadata.
 - Emit operation records from sanctioned canonical mutation workflows.
 - Keep operation history advisory for audit and review; restore authority remains the canonical snapshot plus manifest.
+- Document rotation, checkpointing, or snapshot-boundary compaction options if operation history becomes too large for practical review.
 
 Acceptance criteria:
 
 - Representative structural mutations append deterministic, meaningful operation records.
 - Operation records are useful in Git review without requiring users to inspect SQLite.
+- Operation records can support later progress and provenance analytics without requiring restore replay.
 - Failure to append the operation log is reported as a backup warning without silently hiding backup drift.
 - Operation log behavior does not make generated files authoritative.
 
@@ -199,6 +225,7 @@ Deliverables:
 - Validate manifest, schema compatibility, project identity, checksums, file references, and conflicts.
 - Produce a restore plan that summarizes rows/entities to create, update, delete, or leave unchanged.
 - Refuse tampered, stale, partial, wrong-project, or incompatible backup bundles.
+- Treat records present in SQLite but absent from the backup as destructive restore candidates that require explicit dry-run reporting and later confirmation.
 - Preserve existing `restore_structure_from_export` behavior as a narrower structure repair workflow.
 
 Acceptance criteria:
@@ -206,6 +233,7 @@ Acceptance criteria:
 - Dry run is the default.
 - Dry run never mutates SQLite or generated files.
 - Restore plans are deterministic and reviewable by a user or AI agent.
+- Restore plans distinguish create, update, delete, unchanged, and refused/conflict cases.
 - Invalid backup bundles return actionable diagnostics rather than partial plans.
 
 Test strategy:
@@ -231,6 +259,7 @@ Deliverables:
 - Regenerate or prompt regeneration of derived indexes after restore.
 - Return a reviewable summary of applied changes and recommended follow-up checks.
 - Ensure failed restore leaves the database unchanged.
+- Require explicit confirmation for destructive deletes or cross-scope changes identified during dry-run planning.
 
 Acceptance criteria:
 
@@ -270,7 +299,7 @@ Acceptance criteria:
 - Users can explain what must be backed up: prose/Git sync root, generated backup artifacts, and live SQLite volume where applicable.
 - Users know that app-level backup artifacts are Git-reviewable recovery input, not a substitute for normal volume backups.
 - Agents are routed toward `export_project_backup`, diagnostics, and dry-run restore instead of editing backup files.
-- The initiative is ready to move from backlog to active implementation when prioritized.
+- The initiative is ready to move to completed status once backup export, diagnostics, restore, and documentation behavior are delivered and validated.
 
 Test strategy:
 

--- a/docs/initiatives/backlog/database-backup-recovery/prd.md
+++ b/docs/initiatives/backlog/database-backup-recovery/prd.md
@@ -1,14 +1,16 @@
 # PRD: Database Backup and Recovery
 
-**Status:** 📋 Deferred backlog (not active)
+**Status:** Active
 
-This work is intentionally deferred until the product is ready to extend the SQLite-canonical architecture with a complete backup and recovery story.
-The need is clear now because structural manuscript state has moved away from files-first authority, but this PRD is not active implementation scope.
+Current focus: M1 — Backup Domain Model and Manifest.
+
+The product is ready to extend the SQLite-canonical architecture with a complete backup and recovery story.
+The need is clear because structural manuscript state has moved away from files-first authority, and the next implementation slice should establish the backup artifact shape before exposing public tools or restore behavior.
 
 Implementation slices are tracked in [milestones.md](milestones.md).
 
 Docker and homeserver volume backup expectations for `/sync` and `/data` are covered by the completed [Docker, CI, and Deployment Workflow](../../done/docker-ci-deployment/prd.md).
-This backlog item is about the separate application-level recovery surface: Git-reviewable backup artifacts generated from SQLite-canonical state, diagnostics, and explicit restore workflows.
+This initiative is about the separate application-level recovery surface: Git-reviewable backup artifacts generated from SQLite-canonical state, diagnostics, and explicit restore workflows.
 
 ## Problem Statement
 
@@ -63,7 +65,9 @@ Those tools remain useful as structure-specific workflows, while the project bac
 - Generate deterministic backup artifacts:
   - `manifest.json` for project identity, schema/app versions, covered domains, checksums, and restore compatibility.
   - `canonical.snapshot.json` for durable canonical state needed to rebuild the project database.
-  - `operations.jsonl` for append-only semantic records of sanctioned canonical mutations.
+- Defer `operations.jsonl` to the semantic operation history milestone. M1 may reserve the manifest field names needed to describe future operation-log support, but it should not implement operation logging.
+- Treat full deterministic snapshots as restore authority. Hash comparison should avoid no-op rewrites, and Git should provide storage/review deltas for changed snapshot content.
+- Do not use custom delta chains or event replay as the primary v1 recovery mechanism.
 - Refresh backup artifacts after successful canonical database mutations.
 - Do not automatically create Git commits in v1. Tools should update Git-trackable files and return guidance to review or commit them.
 - Restore from backup is an explicit maintenance workflow, never an ordinary `sync` side effect.
@@ -73,7 +77,7 @@ Those tools remain useful as structure-specific workflows, while the project bac
 - Include canonical durable state in v1 coverage:
   - projects and universes;
   - chapters, epigraph links, scene chapter membership, and timeline positions;
-  - durable scene metadata indexed from managed metadata;
+  - scene metadata that is durable canonical state in SQLite and not safely reconstructable from prose, sidecar metadata, or sync reindexing alone;
   - characters, places, threads, reference documents, explicit reference links, and other user-authored structured relationships.
 - Exclude derived or rebuildable state from v1 restore authority:
   - FTS tables;
@@ -81,6 +85,97 @@ Those tools remain useful as structure-specific workflows, while the project bac
   - runtime async jobs;
   - transient caches;
   - authored prose bodies.
+
+## Design Considerations
+
+### Initiative Location
+
+This active initiative remains under `docs/initiatives/backlog/` because the repository currently has only `backlog/` and `done/` initiative buckets.
+`PRODUCT.md` is the source of truth for active status.
+If more active initiatives need concurrent tracking later, introduce `docs/initiatives/active/` as a separate docs-taxonomy change instead of moving this initiative as part of M1.
+
+### Canonical Table Inventory
+
+M1 must turn the coverage policy into an explicit table/domain inventory.
+The starting inventory for v1 backup coverage is:
+
+- project identity: `projects`, plus the owning `universes` row when `projects.universe_id` is present
+- manuscript structure: `chapters`, `epigraphs`, `epigraph_characters`, `epigraph_tags`
+- scene identity and placement: `scenes`, `scene_characters`, `scene_places`, `scene_tags`, `scene_threads`
+- world and continuity metadata: `characters`, `character_traits`, `character_relationships`, `places`, `threads`
+- reference material metadata and explicit links: `reference_docs`, `reference_doc_tags`, `reference_links`
+
+The starting exclusion list is:
+
+- rebuildable search indexes: `scenes_fts`, `reference_docs_fts`
+- runtime state: `async_jobs`
+- migration/control metadata: `schema_version`, except for compatibility metadata copied into `manifest.json`
+- authored prose bodies and generated artifacts outside SQLite
+
+If implementation discovers a table whose authority is mixed or ambiguous, M1 should document the decision in the manifest coverage summary and tests rather than silently including it.
+
+### Privacy and Git Expectations
+
+Backup artifacts are intended to be Git-trackable, but they may still contain private story data.
+They can include titles, loglines, summaries, character traits, relationship notes, reference summaries, tags, and structural relationships.
+They must not include authored scene or epigraph prose bodies in v1, but users should treat backup artifacts as manuscript-sensitive material and only commit or push them to repositories they trust.
+
+### Backup File Size and Reviewability
+
+Deterministic JSON should remain reviewable.
+The default M1 shape may use a single `canonical.snapshot.json`, but the schema should allow future splitting into stable domain files if one monolithic snapshot becomes too noisy for Git review.
+Splitting must preserve deterministic checksums and restore compatibility.
+
+### Snapshot Authority vs Delta History
+
+The recovery model should stay snapshot-first.
+Each trusted backup bundle should be able to represent the current restorable canonical project state without replaying a chain of prior events.
+When a freshly generated snapshot is byte-for-byte or checksum equivalent to the existing artifact, export and refresh workflows should avoid rewriting it.
+When it differs, the deterministic artifact should be rewritten and Git should provide the line-level and storage-level delta between versions.
+
+Custom block-chain-like delta chains are out of scope for v1 recovery because they make restore depend on replay order, base availability, chain compaction, and long-range migration correctness.
+Those concerns can be revisited later for audit or analytics, but not as the recovery foundation.
+
+### Future Audit and Provenance
+
+The future `operations.jsonl` scope is valuable for provenance, accountability, and project analytics.
+It may support questions such as who or what changed a project, when changes happened, how much structure or metadata changed during a period, and whether a sudden bulk rewrite deserves review.
+
+That audit trail should be advisory.
+It may inform credibility, contribution timelines, progress statistics, and tool/agent accountability, but v1 restore must not depend on replaying it.
+If operation history grows too large, a later milestone can define rotation, checkpointing, or snapshot-boundary compaction without changing snapshot restore semantics.
+
+### Restore Delete Semantics
+
+Restore milestones must define delete behavior explicitly.
+The default policy should be conservative: if SQLite contains canonical records for the target project that are absent from the backup, restore planning reports them as destructive changes and requires explicit confirmation before applying deletion.
+Dry-run output should distinguish create, update, delete, unchanged, and refused/conflict cases.
+
+### Freshness Marker
+
+M1 should support artifact-level checksums only.
+M3 should decide whether freshness is computed by rebuilding the canonical snapshot and comparing checksums, by introducing a database revision marker, or by combining both.
+Until that decision is made, timestamp-only freshness is not acceptable.
+
+### Relationship to Structure Export
+
+Project backup does not replace `export_structure_snapshot` in v1.
+Structure export remains the narrow, human-readable structure review and repair surface; project backup is the broader recovery surface for SQLite-canonical project state.
+Later milestones may decide whether structure export becomes a view over project backup internals, but the public behavior should stay compatible unless a separate migration plan says otherwise.
+
+### Partial Project and Cross-Scope Relationships
+
+V1 backups are project-scoped.
+Project-scoped entities are included for the target project.
+Universe-level entities are included only when needed to restore the target project's owning universe or when a relationship from project-scoped state references them directly.
+Cross-project relationships should be treated conservatively: M1 should represent enough identity to diagnose external references, while restore milestones should refuse or require explicit confirmation before creating, deleting, or rewriting state owned by another project.
+
+### Backup Scope Clarifications
+
+- Backups are project-scoped in v1. Universe records are included only when needed to restore the owning project relationship; standalone universe-level backup is a separate future concern.
+- Backup schema version, application package version, and SQLite schema version must be recorded separately so compatibility decisions can be explicit.
+- M1 checksums cover deterministic backup artifact content. Restore milestones may add prose file reference checksums when they validate that restored canonical state still points at the expected authored prose files.
+- M1 is an internal domain-model slice: no public MCP tool, no generated files on disk, no automatic mutation hooks, and no restore application.
 
 ## Proposed Interfaces
 
@@ -107,7 +202,6 @@ Unit tests should cover:
 
 - deterministic backup rendering and stable ordering;
 - manifest checksums and schema compatibility;
-- operation log entries for representative canonical mutation tools;
 - stale, missing, wrong-project, incompatible-schema, tampered, and incomplete backup diagnostics;
 - restore planning and conflict detection;
 - failed restore leaving SQLite unchanged.


### PR DESCRIPTION
## Summary

- Activates Database Backup and Recovery as the current product initiative.
- Sets M1 as the focused first slice: Backup Domain Model and Manifest.
- Clarifies that v1 recovery uses full deterministic snapshots as restore authority, with hash checks to avoid no-op rewrites and Git providing review/storage deltas.
- Captures future operation history as an advisory audit/provenance layer rather than the restore mechanism.

## Motivation

SQLite is now canonical for more manuscript structure, so the product needs a recovery story that preserves Git-backed auditability without turning generated files into a second mutation surface.

## Implementation

- Updated `PRODUCT.md`, `README.md`, and `BACKLOG.md` to reflect Database Backup and Recovery as active instead of deferred.
- Tightened the PRD with scope decisions for table coverage, privacy, snapshot size, restore delete semantics, freshness, structure export compatibility, and cross-scope references.
- Expanded the milestone plan so M1 can drive implementation without introducing public tools, filesystem writes, mutation hooks, diagnostics, or restore behavior yet.

## Testing

- `git diff --check origin/main...HEAD`

## Risks and tradeoffs

- The active initiative still lives under `docs/initiatives/backlog/` because the repo has no `active/` bucket today; `PRODUCT.md` is documented as the active-status source of truth.
- Release log was not updated because this changes roadmap/product planning docs only, not shipped runtime behavior.

## Follow-up

- Implement M1 as an internal deterministic backup builder with manifest/schema coverage tests.
