### PR TITLE
feat: add project database backup foundation

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -11,7 +11,7 @@ It supports metadata-first reasoning, explicit prose editing workflows, and revi
 
 Active initiative: [Database Backup and Recovery](docs/initiatives/backlog/database-backup-recovery/prd.md).
 
-Current focus: M1 — Backup Domain Model and Manifest. This slice defines deterministic in-memory project backup artifacts for SQLite-canonical state before adding public tools, disk writes, mutation hooks, diagnostics, or restore behavior.
+Current focus: M2 — Manual Project Backup Export Tool. The internal deterministic backup domain model and manifest slice is implemented; the next step is exposing explicit backup generation without adding restore or mutation hooks yet.
 
 Most recent completed initiative: [Docker, CI, and Deployment Workflow](docs/initiatives/done/docker-ci-deployment/prd.md).
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -11,7 +11,7 @@ It supports metadata-first reasoning, explicit prose editing workflows, and revi
 
 Active initiative: [Database Backup and Recovery](docs/initiatives/backlog/database-backup-recovery/prd.md).
 
-Current focus: M3 — Backup Diagnostics and Freshness. The manual project backup export tool is implemented; the next step is making backup trust, freshness, and tamper status visible before restore workflows depend on it.
+Current focus: M4 — Semantic Operation History. Project backup diagnostics and freshness checks are implemented; the next step is an advisory operation history that supports provenance and progress analysis without becoming restore authority.
 
 Most recent completed initiative: [Docker, CI, and Deployment Workflow](docs/initiatives/done/docker-ci-deployment/prd.md).
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -11,7 +11,7 @@ It supports metadata-first reasoning, explicit prose editing workflows, and revi
 
 Active initiative: [Database Backup and Recovery](docs/initiatives/backlog/database-backup-recovery/prd.md).
 
-Current focus: M5 — Automatic Backup Refresh After Canonical Mutations. Project backup export, diagnostics, freshness checks, and the initial advisory operation-history path are implemented; the next step is refreshing generated backup artifacts after sanctioned canonical mutations without creating Git commits or making generated files authoritative.
+Current focus: M6 — Restore Planning Dry Run. Project backup export, diagnostics, freshness checks, advisory operation history, and automatic backup refresh after explicit structure mutations are implemented; the next step is a dry-run restore planner that validates trusted backups and previews canonical database changes before any apply workflow exists.
 
 Most recent completed initiative: [Docker, CI, and Deployment Workflow](docs/initiatives/done/docker-ci-deployment/prd.md).
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -11,7 +11,7 @@ It supports metadata-first reasoning, explicit prose editing workflows, and revi
 
 Active initiative: [Database Backup and Recovery](docs/initiatives/backlog/database-backup-recovery/prd.md).
 
-Current focus: M2 — Manual Project Backup Export Tool. The internal deterministic backup domain model and manifest slice is implemented; the next step is exposing explicit backup generation without adding restore or mutation hooks yet.
+Current focus: M3 — Backup Diagnostics and Freshness. The manual project backup export tool is implemented; the next step is making backup trust, freshness, and tamper status visible before restore workflows depend on it.
 
 Most recent completed initiative: [Docker, CI, and Deployment Workflow](docs/initiatives/done/docker-ci-deployment/prd.md).
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -11,7 +11,7 @@ It supports metadata-first reasoning, explicit prose editing workflows, and revi
 
 Active initiative: [Database Backup and Recovery](docs/initiatives/backlog/database-backup-recovery/prd.md).
 
-Current focus: M4 — Semantic Operation History. Project backup diagnostics and freshness checks are implemented; the next step is an advisory operation history that supports provenance and progress analysis without becoming restore authority.
+Current focus: M5 — Automatic Backup Refresh After Canonical Mutations. Project backup export, diagnostics, freshness checks, and the initial advisory operation-history path are implemented; the next step is refreshing generated backup artifacts after sanctioned canonical mutations without creating Git commits or making generated files authoritative.
 
 Most recent completed initiative: [Docker, CI, and Deployment Workflow](docs/initiatives/done/docker-ci-deployment/prd.md).
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -11,7 +11,7 @@ It supports metadata-first reasoning, explicit prose editing workflows, and revi
 
 Active initiative: [Database Backup and Recovery](docs/initiatives/backlog/database-backup-recovery/prd.md).
 
-Current focus: M6 — Restore Planning Dry Run. Project backup export, diagnostics, freshness checks, advisory operation history, and automatic backup refresh after explicit structure mutations are implemented; the next step is a dry-run restore planner that validates trusted backups and previews canonical database changes before any apply workflow exists.
+Current focus: M6 — Restore Planning Dry Run. Project backup export, diagnostics, freshness checks, advisory operation history, and automatic backup refresh after sanctioned project-scoped canonical mutations are implemented; the next step is a dry-run restore planner that validates trusted backups and previews canonical database changes before any apply workflow exists.
 
 Most recent completed initiative: [Docker, CI, and Deployment Workflow](docs/initiatives/done/docker-ci-deployment/prd.md).
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Instead of feeding an entire manuscript to an AI and hoping it fits in the conte
 - **Core platform complete:** Metadata-first analysis, sidecar-backed metadata maintenance, AI-assisted prose editing with confirmation + git history, review bundles, and Scrivener Direct extraction are all implemented.
 - **Recently completed:** Docker, CI, and Deployment Workflow made Docker a supported way to build, run, smoke-test, and deploy Writing MCP.
 - **Previous milestone:** Filesystem Boundary Hardening centralized local file mutation through application-aware helpers and lint guardrails.
-- **Active development:** Database Backup and Recovery now has project backup export, freshness diagnostics, advisory operation history, and automatic backup refresh after explicit structure mutations; the next slice focuses on dry-run restore planning.
+- **Active development:** Database Backup and Recovery now has project backup export, freshness diagnostics, advisory operation history, and automatic backup refresh after sanctioned project-scoped canonical mutations; the next slice focuses on dry-run restore planning.
 - **Deferred backlog:** OpenClaw integration, client-agnostic setup, divisions, and embeddings search.
 - **Ideas and open questions:** tracked separately so future exploration does not distort the active roadmap.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Instead of feeding an entire manuscript to an AI and hoping it fits in the conte
 - **Core platform complete:** Metadata-first analysis, sidecar-backed metadata maintenance, AI-assisted prose editing with confirmation + git history, review bundles, and Scrivener Direct extraction are all implemented.
 - **Recently completed:** Docker, CI, and Deployment Workflow made Docker a supported way to build, run, smoke-test, and deploy Writing MCP.
 - **Previous milestone:** Filesystem Boundary Hardening centralized local file mutation through application-aware helpers and lint guardrails.
-- **Active development:** Database Backup and Recovery is defining deterministic Git-reviewable backup artifacts for SQLite-canonical project state.
+- **Active development:** Database Backup and Recovery now has explicit project backup export; the next slice focuses on backup diagnostics and freshness reporting.
 - **Deferred backlog:** OpenClaw integration, client-agnostic setup, divisions, and embeddings search.
 - **Ideas and open questions:** tracked separately so future exploration does not distort the active roadmap.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Instead of feeding an entire manuscript to an AI and hoping it fits in the conte
 - **Core platform complete:** Metadata-first analysis, sidecar-backed metadata maintenance, AI-assisted prose editing with confirmation + git history, review bundles, and Scrivener Direct extraction are all implemented.
 - **Recently completed:** Docker, CI, and Deployment Workflow made Docker a supported way to build, run, smoke-test, and deploy Writing MCP.
 - **Previous milestone:** Filesystem Boundary Hardening centralized local file mutation through application-aware helpers and lint guardrails.
-- **Active development:** Database Backup and Recovery now has explicit project backup export; the next slice focuses on backup diagnostics and freshness reporting.
+- **Active development:** Database Backup and Recovery now has explicit project backup export and freshness diagnostics; the next slice focuses on advisory operation history.
 - **Deferred backlog:** OpenClaw integration, client-agnostic setup, divisions, and embeddings search.
 - **Ideas and open questions:** tracked separately so future exploration does not distort the active roadmap.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Instead of feeding an entire manuscript to an AI and hoping it fits in the conte
 - **Core platform complete:** Metadata-first analysis, sidecar-backed metadata maintenance, AI-assisted prose editing with confirmation + git history, review bundles, and Scrivener Direct extraction are all implemented.
 - **Recently completed:** Docker, CI, and Deployment Workflow made Docker a supported way to build, run, smoke-test, and deploy Writing MCP.
 - **Previous milestone:** Filesystem Boundary Hardening centralized local file mutation through application-aware helpers and lint guardrails.
-- **Active development:** Database Backup and Recovery now has project backup export, freshness diagnostics, and an initial advisory operation-history path; the next slice focuses on automatic backup refresh after canonical mutations.
+- **Active development:** Database Backup and Recovery now has project backup export, freshness diagnostics, advisory operation history, and automatic backup refresh after explicit structure mutations; the next slice focuses on dry-run restore planning.
 - **Deferred backlog:** OpenClaw integration, client-agnostic setup, divisions, and embeddings search.
 - **Ideas and open questions:** tracked separately so future exploration does not distort the active roadmap.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Instead of feeding an entire manuscript to an AI and hoping it fits in the conte
 - **Core platform complete:** Metadata-first analysis, sidecar-backed metadata maintenance, AI-assisted prose editing with confirmation + git history, review bundles, and Scrivener Direct extraction are all implemented.
 - **Recently completed:** Docker, CI, and Deployment Workflow made Docker a supported way to build, run, smoke-test, and deploy Writing MCP.
 - **Previous milestone:** Filesystem Boundary Hardening centralized local file mutation through application-aware helpers and lint guardrails.
-- **Active development:** Database Backup and Recovery now has explicit project backup export and freshness diagnostics; the next slice focuses on advisory operation history.
+- **Active development:** Database Backup and Recovery now has project backup export, freshness diagnostics, and an initial advisory operation-history path; the next slice focuses on automatic backup refresh after canonical mutations.
 - **Deferred backlog:** OpenClaw integration, client-agnostic setup, divisions, and embeddings search.
 - **Ideas and open questions:** tracked separately so future exploration does not distort the active roadmap.
 

--- a/docs/agents/tools.md
+++ b/docs/agents/tools.md
@@ -9,6 +9,7 @@
 - [`sync`](#sync)
 - [`diagnose_structure`](#diagnose_structure)
 - [`export_structure_snapshot`](#export_structure_snapshot)
+- [`export_project_backup`](#export_project_backup)
 - [`restore_structure_from_export`](#restore_structure_from_export)
 - [`import_scrivener_sync`](#import_scrivener_sync)
 - [`import_scrivener_sync_async`](#import_scrivener_sync_async)
@@ -104,6 +105,17 @@ Generate a deterministic JSON structure export from SQLite canonical state for G
 | --- | --- | :---: | --- |
 | `project_id` | `string` | Yes | Project ID to export (e.g. 'test-novel'). |
 | `output_dir` | `string` | No | Directory under WRITING_SYNC_DIR where the export JSON should be written. Defaults to structure-exports. |
+
+---
+
+## export_project_backup
+
+Generate a deterministic project backup bundle from SQLite canonical state. Writes manifest.json and canonical.snapshot.json under WRITING_SYNC_DIR for explicit review and future restore workflows; this is generated transparency only and does not mutate canonical state.
+
+| Parameter | Type | Required | Description |
+| --- | --- | :---: | --- |
+| `project_id` | `string` | Yes | Project ID to back up (e.g. 'test-novel' or 'universe-1/book-1-the-lamb'). |
+| `output_dir` | `string` | No | Directory under WRITING_SYNC_DIR where manifest.json and canonical.snapshot.json should be written. Defaults to project-backups/<project_id>. |
 
 ---
 

--- a/docs/agents/tools.md
+++ b/docs/agents/tools.md
@@ -10,6 +10,7 @@
 - [`diagnose_structure`](#diagnose_structure)
 - [`export_structure_snapshot`](#export_structure_snapshot)
 - [`export_project_backup`](#export_project_backup)
+- [`diagnose_project_backups`](#diagnose_project_backups)
 - [`restore_structure_from_export`](#restore_structure_from_export)
 - [`import_scrivener_sync`](#import_scrivener_sync)
 - [`import_scrivener_sync_async`](#import_scrivener_sync_async)
@@ -116,6 +117,17 @@ Generate a deterministic project backup bundle from SQLite canonical state. Writ
 | --- | --- | :---: | --- |
 | `project_id` | `string` | Yes | Project ID to back up (e.g. 'test-novel' or 'universe-1/book-1-the-lamb'). |
 | `output_dir` | `string` | No | Directory under WRITING_SYNC_DIR where manifest.json and canonical.snapshot.json should be written. Defaults to project-backups/<project_id>. |
+
+---
+
+## diagnose_project_backups
+
+Run read-only diagnostics for a generated project backup bundle. Reports missing, partial, wrong-project, incompatible-schema, tampered, unreadable, and stale backups without mutating SQLite or generated files.
+
+| Parameter | Type | Required | Description |
+| --- | --- | :---: | --- |
+| `project_id` | `string` | Yes | Project ID whose backup bundle should be diagnosed (e.g. 'test-novel'). |
+| `backup_dir` | `string` | No | Directory under WRITING_SYNC_DIR containing manifest.json and canonical.snapshot.json. Defaults to project-backups/<project_id>. |
 
 ---
 

--- a/docs/agents/tools.md
+++ b/docs/agents/tools.md
@@ -111,12 +111,12 @@ Generate a deterministic JSON structure export from SQLite canonical state for G
 
 ## export_project_backup
 
-Generate a deterministic project backup bundle from SQLite canonical state. Writes manifest.json and canonical.snapshot.json under WRITING_SYNC_DIR for explicit review and future restore workflows; this is generated transparency only and does not mutate canonical state.
+Generate a deterministic project backup bundle from SQLite canonical state. Writes manifest.json, canonical.snapshot.json, and operations.jsonl under WRITING_SYNC_DIR for explicit review and future restore workflows; this is generated transparency only and does not mutate canonical state.
 
 | Parameter | Type | Required | Description |
 | --- | --- | :---: | --- |
 | `project_id` | `string` | Yes | Project ID to back up (e.g. 'test-novel' or 'universe-1/book-1-the-lamb'). |
-| `output_dir` | `string` | No | Directory under WRITING_SYNC_DIR where manifest.json and canonical.snapshot.json should be written. Defaults to project-backups/<project_id>. |
+| `output_dir` | `string` | No | Directory under WRITING_SYNC_DIR where manifest.json, canonical.snapshot.json, and operations.jsonl should be written. Defaults to project-backups/<project_id>. |
 
 ---
 

--- a/docs/initiatives/backlog/database-backup-recovery/milestones.md
+++ b/docs/initiatives/backlog/database-backup-recovery/milestones.md
@@ -261,10 +261,11 @@ Evidence:
 - [src/tools/metadata.js](../../../../src/tools/metadata.js)
 - [src/test/unit/project-backup-refresh.test.mjs](../../../../src/test/unit/project-backup-refresh.test.mjs)
 - [src/test/integration/metadata.test.mjs](../../../../src/test/integration/metadata.test.mjs)
+- [src/test/integration/search.test.mjs](../../../../src/test/integration/search.test.mjs)
 
 Notes:
 
-- Explicit chapter structure mutation workflows now refresh project backup artifacts and append advisory operation history after successful canonical changes.
+- Project-scoped chapter structure, scene metadata, world-entity, thread, and reference-link mutation workflows now refresh project backup artifacts and append advisory operation history after successful canonical changes.
 - Generated backup refresh remains separate from Git commits and reports warnings without rolling back the successful canonical mutation.
 
 ## M6 — Restore Planning and Dry Run

--- a/docs/initiatives/backlog/database-backup-recovery/milestones.md
+++ b/docs/initiatives/backlog/database-backup-recovery/milestones.md
@@ -5,7 +5,7 @@
 This milestone plan breaks the PRD into independently reviewable slices.
 Each milestone should leave the system in a releasable state and preserve the target architecture rule that SQLite remains canonical while generated backup artifacts provide transparency and explicit recovery input.
 
-Current focus: M1 — Backup Domain Model and Manifest.
+Current focus: M2 — Manual Project Backup Export Tool.
 
 ## Objective
 
@@ -22,6 +22,8 @@ Docker volume backup and rollback guidance already lives in the completed Docker
 - Keep restore explicit, dry-run-first, and transactional.
 
 ## M1 — Backup Domain Model and Manifest
+
+Status: Delivered.
 
 Goal: define the backup bundle shape before wiring it into mutation workflows.
 
@@ -79,7 +81,14 @@ Out of scope:
 - Restore application.
 - Automatic refresh after mutations.
 
+Evidence:
+
+- [src/structure/project-backup.js](../../../../src/structure/project-backup.js)
+- [src/test/unit/project-backup.test.mjs](../../../../src/test/unit/project-backup.test.mjs)
+
 ## M2 — Manual Project Backup Export Tool
+
+Status: Current focus.
 
 Goal: expose project backup generation as an explicit workflow.
 

--- a/docs/initiatives/backlog/database-backup-recovery/milestones.md
+++ b/docs/initiatives/backlog/database-backup-recovery/milestones.md
@@ -258,14 +258,18 @@ Out of scope:
 Evidence:
 
 - [src/structure/project-backup-refresh.js](../../../../src/structure/project-backup-refresh.js)
+- [src/tools/editing.js](../../../../src/tools/editing.js)
 - [src/tools/metadata.js](../../../../src/tools/metadata.js)
+- [src/tools/sync.js](../../../../src/tools/sync.js)
 - [src/test/unit/project-backup-refresh.test.mjs](../../../../src/test/unit/project-backup-refresh.test.mjs)
+- [src/test/integration/editing.test.mjs](../../../../src/test/integration/editing.test.mjs)
 - [src/test/integration/metadata.test.mjs](../../../../src/test/integration/metadata.test.mjs)
 - [src/test/integration/search.test.mjs](../../../../src/test/integration/search.test.mjs)
+- [src/test/integration/sync.test.mjs](../../../../src/test/integration/sync.test.mjs)
 
 Notes:
 
-- Project-scoped chapter structure, scene metadata, world-entity, thread, and reference-link mutation workflows now refresh project backup artifacts and append advisory operation history after successful canonical changes.
+- Project-scoped chapter structure, scene metadata, prose edit commit, enrichment, world-entity, thread, and reference-link mutation workflows now refresh project backup artifacts and append advisory operation history after successful canonical changes.
 - Generated backup refresh remains separate from Git commits and reports warnings without rolling back the successful canonical mutation.
 
 ## M6 — Restore Planning and Dry Run

--- a/docs/initiatives/backlog/database-backup-recovery/milestones.md
+++ b/docs/initiatives/backlog/database-backup-recovery/milestones.md
@@ -5,7 +5,7 @@
 This milestone plan breaks the PRD into independently reviewable slices.
 Each milestone should leave the system in a releasable state and preserve the target architecture rule that SQLite remains canonical while generated backup artifacts provide transparency and explicit recovery input.
 
-Current focus: M2 — Manual Project Backup Export Tool.
+Current focus: M3 — Backup Diagnostics and Freshness.
 
 ## Objective
 
@@ -88,7 +88,7 @@ Evidence:
 
 ## M2 — Manual Project Backup Export Tool
 
-Status: Current focus.
+Status: Delivered.
 
 Goal: expose project backup generation as an explicit workflow.
 
@@ -119,7 +119,15 @@ Out of scope:
 - Operation history.
 - Restore.
 
+Evidence:
+
+- [src/tools/sync.js](../../../../src/tools/sync.js)
+- [src/structure/project-backup.js](../../../../src/structure/project-backup.js)
+- [src/test/integration/sync.test.mjs](../../../../src/test/integration/sync.test.mjs)
+
 ## M3 — Backup Diagnostics and Freshness
+
+Status: Current focus.
 
 Goal: make backup trust visible before backup artifacts are needed for recovery.
 

--- a/docs/initiatives/backlog/database-backup-recovery/milestones.md
+++ b/docs/initiatives/backlog/database-backup-recovery/milestones.md
@@ -5,7 +5,7 @@
 This milestone plan breaks the PRD into independently reviewable slices.
 Each milestone should leave the system in a releasable state and preserve the target architecture rule that SQLite remains canonical while generated backup artifacts provide transparency and explicit recovery input.
 
-Current focus: M5 — Automatic Backup Refresh After Canonical Mutations.
+Current focus: M6 — Restore Planning and Dry Run.
 
 ## Objective
 
@@ -224,7 +224,7 @@ Notes:
 
 ## M5 — Automatic Backup Refresh After Canonical Mutations
 
-Status: Current focus.
+Status: Delivered.
 
 Goal: keep generated backup artifacts fresh during ordinary sanctioned workflows.
 
@@ -255,7 +255,21 @@ Out of scope:
 - Git commit creation.
 - Backup scheduling outside mutation workflows.
 
+Evidence:
+
+- [src/structure/project-backup-refresh.js](../../../../src/structure/project-backup-refresh.js)
+- [src/tools/metadata.js](../../../../src/tools/metadata.js)
+- [src/test/unit/project-backup-refresh.test.mjs](../../../../src/test/unit/project-backup-refresh.test.mjs)
+- [src/test/integration/metadata.test.mjs](../../../../src/test/integration/metadata.test.mjs)
+
+Notes:
+
+- Explicit chapter structure mutation workflows now refresh project backup artifacts and append advisory operation history after successful canonical changes.
+- Generated backup refresh remains separate from Git commits and reports warnings without rolling back the successful canonical mutation.
+
 ## M6 — Restore Planning and Dry Run
+
+Status: Current focus.
 
 Goal: make recovery inspectable before any canonical state is rewritten.
 

--- a/docs/initiatives/backlog/database-backup-recovery/milestones.md
+++ b/docs/initiatives/backlog/database-backup-recovery/milestones.md
@@ -5,7 +5,7 @@
 This milestone plan breaks the PRD into independently reviewable slices.
 Each milestone should leave the system in a releasable state and preserve the target architecture rule that SQLite remains canonical while generated backup artifacts provide transparency and explicit recovery input.
 
-Current focus: M4 — Semantic Operation History.
+Current focus: M5 — Automatic Backup Refresh After Canonical Mutations.
 
 ## Objective
 
@@ -167,7 +167,7 @@ Evidence:
 
 ## M4 — Semantic Operation History
 
-Status: Current focus.
+Status: Delivered.
 
 Goal: make canonical mutations reviewable as a human-readable event stream.
 
@@ -209,7 +209,22 @@ Out of scope:
 - Rewriting old operation records.
 - Automatic Git commits.
 
+Evidence:
+
+- [src/structure/project-backup-operations.js](../../../../src/structure/project-backup-operations.js)
+- [src/structure/project-backup.js](../../../../src/structure/project-backup.js)
+- [src/tools/metadata.js](../../../../src/tools/metadata.js)
+- [src/test/unit/project-backup-operations.test.mjs](../../../../src/test/unit/project-backup-operations.test.mjs)
+- [src/test/integration/metadata.test.mjs](../../../../src/test/integration/metadata.test.mjs)
+
+Notes:
+
+- Initial mutation coverage is deliberately narrow: `create_chapter` proves the event envelope, append-only artifact, and warning behavior on a representative sanctioned structural workflow.
+- M5 should generalize the post-mutation path so backup refresh and operation-history emission are applied consistently across canonical mutation tools.
+
 ## M5 — Automatic Backup Refresh After Canonical Mutations
+
+Status: Current focus.
 
 Goal: keep generated backup artifacts fresh during ordinary sanctioned workflows.
 

--- a/docs/initiatives/backlog/database-backup-recovery/milestones.md
+++ b/docs/initiatives/backlog/database-backup-recovery/milestones.md
@@ -5,7 +5,7 @@
 This milestone plan breaks the PRD into independently reviewable slices.
 Each milestone should leave the system in a releasable state and preserve the target architecture rule that SQLite remains canonical while generated backup artifacts provide transparency and explicit recovery input.
 
-Current focus: M3 — Backup Diagnostics and Freshness.
+Current focus: M4 — Semantic Operation History.
 
 ## Objective
 
@@ -127,7 +127,7 @@ Evidence:
 
 ## M3 — Backup Diagnostics and Freshness
 
-Status: Current focus.
+Status: Delivered.
 
 Goal: make backup trust visible before backup artifacts are needed for recovery.
 
@@ -159,7 +159,15 @@ Out of scope:
 - Restore application.
 - Git commits.
 
+Evidence:
+
+- [src/structure/project-backup-diagnostics.js](../../../../src/structure/project-backup-diagnostics.js)
+- [src/test/unit/project-backup-diagnostics.test.mjs](../../../../src/test/unit/project-backup-diagnostics.test.mjs)
+- [src/test/integration/sync.test.mjs](../../../../src/test/integration/sync.test.mjs)
+
 ## M4 — Semantic Operation History
+
+Status: Current focus.
 
 Goal: make canonical mutations reviewable as a human-readable event stream.
 

--- a/docs/initiatives/backlog/database-backup-recovery/prd.md
+++ b/docs/initiatives/backlog/database-backup-recovery/prd.md
@@ -2,10 +2,11 @@
 
 **Status:** Active
 
-Current focus: M1 — Backup Domain Model and Manifest.
+Current focus: M2 — Manual Project Backup Export Tool.
 
 The product is ready to extend the SQLite-canonical architecture with a complete backup and recovery story.
-The need is clear because structural manuscript state has moved away from files-first authority, and the next implementation slice should establish the backup artifact shape before exposing public tools or restore behavior.
+The need is clear because structural manuscript state has moved away from files-first authority.
+The internal backup artifact shape is implemented; the next implementation slice should expose explicit project backup generation without restore behavior or automatic mutation hooks.
 
 Implementation slices are tracked in [milestones.md](milestones.md).
 

--- a/docs/initiatives/backlog/database-backup-recovery/prd.md
+++ b/docs/initiatives/backlog/database-backup-recovery/prd.md
@@ -2,11 +2,11 @@
 
 **Status:** Active
 
-Current focus: M4 — Semantic Operation History.
+Current focus: M5 — Automatic Backup Refresh After Canonical Mutations.
 
 The product is ready to extend the SQLite-canonical architecture with a complete backup and recovery story.
 The need is clear because structural manuscript state has moved away from files-first authority.
-The internal backup artifact shape, explicit project backup export tool, and project backup diagnostics are implemented; the next implementation slice should add advisory operation history for provenance, progress analysis, and tool accountability without making restore depend on event replay.
+The internal backup artifact shape, explicit project backup export tool, project backup diagnostics, and initial advisory operation-history path are implemented; the next implementation slice should refresh generated backup artifacts after sanctioned canonical mutations without creating Git commits or making generated files authoritative.
 
 Implementation slices are tracked in [milestones.md](milestones.md).
 
@@ -66,7 +66,7 @@ Those tools remain useful as structure-specific workflows, while the project bac
 - Generate deterministic backup artifacts:
   - `manifest.json` for project identity, schema/app versions, covered domains, checksums, and restore compatibility.
   - `canonical.snapshot.json` for durable canonical state needed to rebuild the project database.
-- Defer `operations.jsonl` to the semantic operation history milestone. M1 may reserve the manifest field names needed to describe future operation-log support, but it should not implement operation logging.
+  - `operations.jsonl` for advisory semantic mutation history, provenance, progress analysis, and tool accountability.
 - Treat full deterministic snapshots as restore authority. Hash comparison should avoid no-op rewrites, and Git should provide storage/review deltas for changed snapshot content.
 - Do not use custom delta chains or event replay as the primary v1 recovery mechanism.
 - Refresh backup artifacts after successful canonical database mutations.
@@ -139,7 +139,7 @@ Those concerns can be revisited later for audit or analytics, but not as the rec
 
 ### Future Audit and Provenance
 
-The future `operations.jsonl` scope is valuable for provenance, accountability, and project analytics.
+The `operations.jsonl` scope is valuable for provenance, accountability, and project analytics.
 It may support questions such as who or what changed a project, when changes happened, how much structure or metadata changed during a period, and whether a sudden bulk rewrite deserves review.
 
 That audit trail should be advisory.

--- a/docs/initiatives/backlog/database-backup-recovery/prd.md
+++ b/docs/initiatives/backlog/database-backup-recovery/prd.md
@@ -2,11 +2,11 @@
 
 **Status:** Active
 
-Current focus: M3 — Backup Diagnostics and Freshness.
+Current focus: M4 — Semantic Operation History.
 
 The product is ready to extend the SQLite-canonical architecture with a complete backup and recovery story.
 The need is clear because structural manuscript state has moved away from files-first authority.
-The internal backup artifact shape and explicit project backup export tool are implemented; the next implementation slice should make backup trust, freshness, and tamper status visible before restore behavior depends on it.
+The internal backup artifact shape, explicit project backup export tool, and project backup diagnostics are implemented; the next implementation slice should add advisory operation history for provenance, progress analysis, and tool accountability without making restore depend on event replay.
 
 Implementation slices are tracked in [milestones.md](milestones.md).
 

--- a/docs/initiatives/backlog/database-backup-recovery/prd.md
+++ b/docs/initiatives/backlog/database-backup-recovery/prd.md
@@ -2,11 +2,11 @@
 
 **Status:** Active
 
-Current focus: M2 — Manual Project Backup Export Tool.
+Current focus: M3 — Backup Diagnostics and Freshness.
 
 The product is ready to extend the SQLite-canonical architecture with a complete backup and recovery story.
 The need is clear because structural manuscript state has moved away from files-first authority.
-The internal backup artifact shape is implemented; the next implementation slice should expose explicit project backup generation without restore behavior or automatic mutation hooks.
+The internal backup artifact shape and explicit project backup export tool are implemented; the next implementation slice should make backup trust, freshness, and tamper status visible before restore behavior depends on it.
 
 Implementation slices are tracked in [milestones.md](milestones.md).
 

--- a/docs/initiatives/backlog/database-backup-recovery/prd.md
+++ b/docs/initiatives/backlog/database-backup-recovery/prd.md
@@ -2,11 +2,11 @@
 
 **Status:** Active
 
-Current focus: M5 — Automatic Backup Refresh After Canonical Mutations.
+Current focus: M6 — Restore Planning Dry Run.
 
 The product is ready to extend the SQLite-canonical architecture with a complete backup and recovery story.
 The need is clear because structural manuscript state has moved away from files-first authority.
-The internal backup artifact shape, explicit project backup export tool, project backup diagnostics, and initial advisory operation-history path are implemented; the next implementation slice should refresh generated backup artifacts after sanctioned canonical mutations without creating Git commits or making generated files authoritative.
+The internal backup artifact shape, explicit project backup export tool, project backup diagnostics, advisory operation history, and automatic backup refresh after explicit structure mutations are implemented; the next implementation slice should add dry-run restore planning that validates trusted backup bundles and previews canonical database changes before any apply workflow exists.
 
 Implementation slices are tracked in [milestones.md](milestones.md).
 

--- a/docs/initiatives/backlog/database-backup-recovery/prd.md
+++ b/docs/initiatives/backlog/database-backup-recovery/prd.md
@@ -6,7 +6,7 @@ Current focus: M6 — Restore Planning Dry Run.
 
 The product is ready to extend the SQLite-canonical architecture with a complete backup and recovery story.
 The need is clear because structural manuscript state has moved away from files-first authority.
-The internal backup artifact shape, explicit project backup export tool, project backup diagnostics, advisory operation history, and automatic backup refresh after explicit structure mutations are implemented; the next implementation slice should add dry-run restore planning that validates trusted backup bundles and previews canonical database changes before any apply workflow exists.
+The internal backup artifact shape, explicit project backup export tool, project backup diagnostics, advisory operation history, and automatic backup refresh after sanctioned project-scoped canonical mutations are implemented; the next implementation slice should add dry-run restore planning that validates trusted backup bundles and previews canonical database changes before any apply workflow exists.
 
 Implementation slices are tracked in [milestones.md](milestones.md).
 

--- a/release-log.md
+++ b/release-log.md
@@ -9,8 +9,8 @@ This complements `CHANGELOG.md`:
 ### 2026-05-24 — Refresh project backups after canonical mutations
 
 - What changed: Sanctioned project-scoped canonical mutation tools now append advisory operation history and refresh generated project backup artifacts after successful database changes.
-- Why it matters: Authors and AI agents get fresh `manifest.json`, `canonical.snapshot.json`, and `operations.jsonl` during normal structure, metadata, thread, and reference-link workflows without needing a separate manual export step.
-- Who is affected: Authors, maintainers, and AI agents using project-scoped chapter, epigraph, scene, world-entity, thread, and reference-link mutation tools.
+- Why it matters: Authors and AI agents get fresh `manifest.json`, `canonical.snapshot.json`, and `operations.jsonl` during normal structure, metadata, editing, enrichment, thread, and reference-link workflows without needing a separate manual export step.
+- Who is affected: Authors, maintainers, and AI agents using project-scoped chapter, epigraph, scene, edit, enrichment, world-entity, thread, and reference-link mutation tools.
 - Action needed: Review or commit generated backup artifact diffs after canonical changes; if a tool returns `backup_warnings`, run `diagnose_project_backups` or `export_project_backup`.
 - PR: [#219](https://github.com/hannasdev/mcp-writing/pull/219)
 

--- a/release-log.md
+++ b/release-log.md
@@ -6,6 +6,14 @@ This complements `CHANGELOG.md`:
 - `CHANGELOG.md` is technical and release-oriented.
 - This log is plain-language and outcome-oriented.
 
+### 2026-05-24 — Add advisory project operation history
+
+- What changed: Project backup bundles now include `operations.jsonl`, and `create_chapter` appends an advisory semantic operation record after the canonical database mutation succeeds.
+- Why it matters: Authors and AI agents can review how SQLite-canonical structure changed over time, while restore still depends on the manifest and deterministic snapshot rather than event replay.
+- Who is affected: Authors, maintainers, and AI agents reviewing generated project backup artifacts or auditing chapter-creation workflows.
+- Action needed: Review `operations.jsonl` alongside `manifest.json` and `canonical.snapshot.json`; treat it as provenance and analytics context, not a mutation or restore authority.
+- PR: Pending
+
 ### 2026-05-24 — Diagnose project backup trust and freshness
 
 - What changed: Added `diagnose_project_backups`, a read-only check for missing, partial, wrong-project, incompatible, tampered, unreadable, and stale project backup bundles.

--- a/release-log.md
+++ b/release-log.md
@@ -12,7 +12,7 @@ This complements `CHANGELOG.md`:
 - Why it matters: Authors and AI agents get fresh `manifest.json`, `canonical.snapshot.json`, and `operations.jsonl` during normal structure, metadata, thread, and reference-link workflows without needing a separate manual export step.
 - Who is affected: Authors, maintainers, and AI agents using project-scoped chapter, epigraph, scene, world-entity, thread, and reference-link mutation tools.
 - Action needed: Review or commit generated backup artifact diffs after canonical changes; if a tool returns `backup_warnings`, run `diagnose_project_backups` or `export_project_backup`.
-- PR: Pending
+- PR: [#219](https://github.com/hannasdev/mcp-writing/pull/219)
 
 ### 2026-05-24 — Add advisory project operation history
 
@@ -20,7 +20,7 @@ This complements `CHANGELOG.md`:
 - Why it matters: Authors and AI agents can review how SQLite-canonical structure changed over time, while restore still depends on the manifest and deterministic snapshot rather than event replay.
 - Who is affected: Authors, maintainers, and AI agents reviewing generated project backup artifacts or auditing chapter-creation workflows.
 - Action needed: Review `operations.jsonl` alongside `manifest.json` and `canonical.snapshot.json`; treat it as provenance and analytics context, not a mutation or restore authority.
-- PR: Pending
+- PR: [#219](https://github.com/hannasdev/mcp-writing/pull/219)
 
 ### 2026-05-24 — Diagnose project backup trust and freshness
 
@@ -28,7 +28,7 @@ This complements `CHANGELOG.md`:
 - Why it matters: Authors and AI agents can tell whether a generated backup is safe recovery input before restore tooling depends on it.
 - Who is affected: Authors, maintainers, and AI agents reviewing or preparing SQLite-canonical project recovery artifacts.
 - Action needed: Run `diagnose_project_backups` before relying on a generated project backup; regenerate stale or untrusted bundles with `export_project_backup`.
-- PR: Pending
+- PR: [#219](https://github.com/hannasdev/mcp-writing/pull/219)
 
 ### 2026-05-23 — Export project backup bundles
 
@@ -36,7 +36,7 @@ This complements `CHANGELOG.md`:
 - Why it matters: Authors and AI agents can review and commit broader SQLite-canonical project state before restore workflows exist, without making generated backup files a mutation surface.
 - Who is affected: Authors, maintainers, and AI agents preparing recovery artifacts for SQLite-canonical projects.
 - Action needed: Run `export_project_backup` when you want a manual backup checkpoint; review or commit the generated files, but do not edit them as canonical changes.
-- PR: Pending
+- PR: [#219](https://github.com/hannasdev/mcp-writing/pull/219)
 
 ### 2026-05-23 — Complete chapter and epigraph structure alignment
 

--- a/release-log.md
+++ b/release-log.md
@@ -6,6 +6,14 @@ This complements `CHANGELOG.md`:
 - `CHANGELOG.md` is technical and release-oriented.
 - This log is plain-language and outcome-oriented.
 
+### 2026-05-23 — Export project backup bundles
+
+- What changed: Added `export_project_backup`, which writes a deterministic `manifest.json` and `canonical.snapshot.json` backup bundle under the sync root for a project.
+- Why it matters: Authors and AI agents can review and commit broader SQLite-canonical project state before restore workflows exist, without making generated backup files a mutation surface.
+- Who is affected: Authors, maintainers, and AI agents preparing recovery artifacts for SQLite-canonical projects.
+- Action needed: Run `export_project_backup` when you want a manual backup checkpoint; review or commit the generated files, but do not edit them as canonical changes.
+- PR: Pending
+
 ### 2026-05-23 — Complete chapter and epigraph structure alignment
 
 - What changed: Moved the chapter/epigraph initiative to completed status, documented canonical read ordering through chapter `sort_index`, aligned metadata lint with shipped scene structure fields, and split larger division support into its own backlog item.

--- a/release-log.md
+++ b/release-log.md
@@ -6,6 +6,14 @@ This complements `CHANGELOG.md`:
 - `CHANGELOG.md` is technical and release-oriented.
 - This log is plain-language and outcome-oriented.
 
+### 2026-05-24 — Refresh project backups after structure mutations
+
+- What changed: Explicit structure mutation tools now append advisory operation history and refresh generated project backup artifacts after successful canonical database changes.
+- Why it matters: Authors and AI agents get fresh `manifest.json`, `canonical.snapshot.json`, and `operations.jsonl` during normal structure workflows without needing a separate manual export step.
+- Who is affected: Authors, maintainers, and AI agents using chapter, epigraph, and scene structure mutation tools.
+- Action needed: Review or commit generated backup artifact diffs after structure changes; if a tool returns `backup_warnings`, run `diagnose_project_backups` or `export_project_backup`.
+- PR: Pending
+
 ### 2026-05-24 — Add advisory project operation history
 
 - What changed: Project backup bundles now include `operations.jsonl`, and `create_chapter` appends an advisory semantic operation record after the canonical database mutation succeeds.

--- a/release-log.md
+++ b/release-log.md
@@ -6,6 +6,14 @@ This complements `CHANGELOG.md`:
 - `CHANGELOG.md` is technical and release-oriented.
 - This log is plain-language and outcome-oriented.
 
+### 2026-05-24 — Diagnose project backup trust and freshness
+
+- What changed: Added `diagnose_project_backups`, a read-only check for missing, partial, wrong-project, incompatible, tampered, unreadable, and stale project backup bundles.
+- Why it matters: Authors and AI agents can tell whether a generated backup is safe recovery input before restore tooling depends on it.
+- Who is affected: Authors, maintainers, and AI agents reviewing or preparing SQLite-canonical project recovery artifacts.
+- Action needed: Run `diagnose_project_backups` before relying on a generated project backup; regenerate stale or untrusted bundles with `export_project_backup`.
+- PR: Pending
+
 ### 2026-05-23 — Export project backup bundles
 
 - What changed: Added `export_project_backup`, which writes a deterministic `manifest.json` and `canonical.snapshot.json` backup bundle under the sync root for a project.

--- a/release-log.md
+++ b/release-log.md
@@ -6,12 +6,12 @@ This complements `CHANGELOG.md`:
 - `CHANGELOG.md` is technical and release-oriented.
 - This log is plain-language and outcome-oriented.
 
-### 2026-05-24 — Refresh project backups after structure mutations
+### 2026-05-24 — Refresh project backups after canonical mutations
 
-- What changed: Explicit structure mutation tools now append advisory operation history and refresh generated project backup artifacts after successful canonical database changes.
-- Why it matters: Authors and AI agents get fresh `manifest.json`, `canonical.snapshot.json`, and `operations.jsonl` during normal structure workflows without needing a separate manual export step.
-- Who is affected: Authors, maintainers, and AI agents using chapter, epigraph, and scene structure mutation tools.
-- Action needed: Review or commit generated backup artifact diffs after structure changes; if a tool returns `backup_warnings`, run `diagnose_project_backups` or `export_project_backup`.
+- What changed: Sanctioned project-scoped canonical mutation tools now append advisory operation history and refresh generated project backup artifacts after successful database changes.
+- Why it matters: Authors and AI agents get fresh `manifest.json`, `canonical.snapshot.json`, and `operations.jsonl` during normal structure, metadata, thread, and reference-link workflows without needing a separate manual export step.
+- Who is affected: Authors, maintainers, and AI agents using project-scoped chapter, epigraph, scene, world-entity, thread, and reference-link mutation tools.
+- Action needed: Review or commit generated backup artifact diffs after canonical changes; if a tool returns `backup_warnings`, run `diagnose_project_backups` or `export_project_backup`.
 - PR: Pending
 
 ### 2026-05-24 — Add advisory project operation history

--- a/src/core/filesystem-boundary.js
+++ b/src/core/filesystem-boundary.js
@@ -454,6 +454,18 @@ export function writeGeneratedOutputFile(filePath, data, {
   }
 }
 
+export function appendGeneratedOutputFile(filePath, data, {
+  encoding,
+  errorCode = "INVALID_OUTPUT_PATH",
+} = {}) {
+  assertRegularFileWriteTarget(filePath, { errorCode });
+  if (encoding) {
+    fs.appendFileSync(filePath, data, encoding);
+  } else {
+    fs.appendFileSync(filePath, data);
+  }
+}
+
 export function copyFileInsideBoundary(sourcePath, targetPath, {
   sourceBoundaryRoot,
   sourceBoundaryRootReal = sourceBoundaryRoot,

--- a/src/index.js
+++ b/src/index.js
@@ -469,6 +469,7 @@ function createMcpServer() {
     SYNC_DIR_ABS,
     SYNC_DIR_REAL,
     SYNC_DIR_WRITABLE,
+    MCP_SERVER_VERSION,
     GIT_ENABLED,
     asyncJobs,
     errorResponse,

--- a/src/structure/project-backup-diagnostics.js
+++ b/src/structure/project-backup-diagnostics.js
@@ -44,7 +44,19 @@ function fileState(filePath) {
   if (!fs.existsSync(filePath)) {
     return { exists: false, readable: false, regular: false, symlink: false };
   }
-  const stat = fs.lstatSync(filePath);
+  let stat;
+  try {
+    stat = fs.lstatSync(filePath);
+  } catch (error) {
+    return {
+      exists: true,
+      readable: false,
+      regular: false,
+      symlink: false,
+      error: "lstat_failed",
+      message: error instanceof Error ? error.message : String(error),
+    };
+  }
   return {
     exists: true,
     readable: true,
@@ -59,7 +71,7 @@ function readJsonFile(filePath) {
     return { ok: false, state, error: "missing" };
   }
   if (state.symlink || !state.regular) {
-    return { ok: false, state, error: state.symlink ? "symlink" : "not_regular" };
+    return { ok: false, state, error: state.error ?? (state.symlink ? "symlink" : "not_regular"), message: state.message };
   }
   try {
     return {

--- a/src/structure/project-backup-diagnostics.js
+++ b/src/structure/project-backup-diagnostics.js
@@ -159,12 +159,27 @@ export function runProjectBackupDiagnostics(db, {
     }
   }
 
-  const built = buildProjectBackup(db, {
-    projectId,
-    syncDir,
-    applicationVersion,
-    backupLocation,
-  });
+  let built;
+  try {
+    built = buildProjectBackup(db, {
+      projectId,
+      syncDir,
+      applicationVersion,
+      backupLocation,
+    });
+  } catch (error) {
+    built = {
+      ok: false,
+      error: {
+        message: error instanceof Error ? error.message : String(error),
+        details: {
+          project_id: projectId,
+          backup_dir: resolvedBackupDir,
+          phase: "current_snapshot",
+        },
+      },
+    };
+  }
   if (!built.ok) {
     addDiagnostic(
       diagnostics,

--- a/src/structure/project-backup-diagnostics.js
+++ b/src/structure/project-backup-diagnostics.js
@@ -1,0 +1,319 @@
+import fs from "node:fs";
+import path from "node:path";
+import {
+  buildProjectBackup,
+  computeProjectBackupBundleChecksum,
+  computeProjectBackupSnapshotChecksum,
+  PROJECT_BACKUP_SCHEMA_VERSION,
+} from "./project-backup.js";
+
+const MANIFEST_FILE = "manifest.json";
+const SNAPSHOT_FILE = "canonical.snapshot.json";
+
+function countBy(items, key) {
+  const result = {};
+  for (const item of items) {
+    const value = item[key] ?? "unknown";
+    result[value] = (result[value] ?? 0) + 1;
+  }
+  return result;
+}
+
+function normalizeRelativePath(syncDir, filePath) {
+  return path.relative(syncDir, filePath).split(path.sep).filter(Boolean).join("/");
+}
+
+function createDiagnostic(type, message, details = {}, {
+  severity = "warning",
+  nextStep = null,
+} = {}) {
+  return {
+    type,
+    severity,
+    message,
+    details,
+    ...(nextStep ? { next_step: nextStep } : {}),
+  };
+}
+
+function addDiagnostic(diagnostics, type, message, details = {}, options = {}) {
+  diagnostics.push(createDiagnostic(type, message, details, options));
+}
+
+function fileState(filePath) {
+  if (!fs.existsSync(filePath)) {
+    return { exists: false, readable: false, regular: false, symlink: false };
+  }
+  const stat = fs.lstatSync(filePath);
+  return {
+    exists: true,
+    readable: true,
+    regular: stat.isFile(),
+    symlink: stat.isSymbolicLink(),
+  };
+}
+
+function readJsonFile(filePath) {
+  const state = fileState(filePath);
+  if (!state.exists) {
+    return { ok: false, state, error: "missing" };
+  }
+  if (state.symlink || !state.regular) {
+    return { ok: false, state, error: state.symlink ? "symlink" : "not_regular" };
+  }
+  try {
+    return {
+      ok: true,
+      state,
+      value: JSON.parse(fs.readFileSync(filePath, "utf8")),
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      state,
+      error: "unreadable_json",
+      message: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+function statusFromDiagnostics(diagnostics) {
+  if (diagnostics.some(diagnostic => diagnostic.type === "project_backup_stale")) return "stale";
+  if (diagnostics.length) return "untrusted";
+  return "current";
+}
+
+export function runProjectBackupDiagnostics(db, {
+  syncDir,
+  backupDir = null,
+  projectId,
+  applicationVersion = "0.0.0",
+} = {}) {
+  const diagnostics = [];
+  const resolvedBackupDir = path.resolve(backupDir ?? path.join(syncDir, "project-backups", projectId));
+  const relativeBackupDir = normalizeRelativePath(syncDir, resolvedBackupDir);
+  const backupLocation = relativeBackupDir ? `${relativeBackupDir}/` : "./";
+  const manifestPath = path.join(resolvedBackupDir, MANIFEST_FILE);
+  const snapshotPath = path.join(resolvedBackupDir, SNAPSHOT_FILE);
+  const manifestRead = readJsonFile(manifestPath);
+  const snapshotRead = readJsonFile(snapshotPath);
+
+  if (!manifestRead.state.exists && !snapshotRead.state.exists) {
+    addDiagnostic(
+      diagnostics,
+      "project_backup_missing",
+      `Project backup for "${projectId}" is missing.`,
+      {
+        project_id: projectId,
+        backup_dir: resolvedBackupDir,
+        relative_backup_dir: relativeBackupDir,
+      },
+      { nextStep: "Run export_project_backup for this project, then review or commit the generated backup bundle." }
+    );
+  } else if (!manifestRead.state.exists || !snapshotRead.state.exists) {
+    addDiagnostic(
+      diagnostics,
+      "project_backup_partial",
+      `Project backup for "${projectId}" is incomplete.`,
+      {
+        project_id: projectId,
+        backup_dir: resolvedBackupDir,
+        manifest_exists: manifestRead.state.exists,
+        canonical_snapshot_exists: snapshotRead.state.exists,
+      },
+      { nextStep: "Regenerate the backup with export_project_backup before using it for recovery." }
+    );
+  }
+
+  for (const [label, readResult, filePath] of [
+    ["manifest", manifestRead, manifestPath],
+    ["canonical_snapshot", snapshotRead, snapshotPath],
+  ]) {
+    if (!readResult.state.exists) continue;
+    if (!readResult.ok) {
+      addDiagnostic(
+        diagnostics,
+        "project_backup_unreadable",
+        `Project backup ${label} is not readable as trusted JSON.`,
+        {
+          project_id: projectId,
+          backup_dir: resolvedBackupDir,
+          file: filePath,
+          reason: readResult.error,
+          message: readResult.message ?? null,
+        },
+        { nextStep: "Regenerate the backup with export_project_backup before using it for recovery." }
+      );
+    }
+  }
+
+  const built = buildProjectBackup(db, {
+    projectId,
+    syncDir,
+    applicationVersion,
+    backupLocation,
+  });
+  if (!built.ok) {
+    addDiagnostic(
+      diagnostics,
+      "project_backup_current_snapshot_failed",
+      built.error.message,
+      built.error.details,
+      { severity: "error", nextStep: "Confirm the project_id exists before diagnosing its backup bundle." }
+    );
+  }
+
+  const manifest = manifestRead.ok ? manifestRead.value : null;
+  const snapshot = snapshotRead.ok ? snapshotRead.value : null;
+
+  if (manifest) {
+    if (manifest.artifact_kind !== "project_backup") {
+      addDiagnostic(
+        diagnostics,
+        "project_backup_wrong_artifact",
+        `Backup manifest for "${projectId}" is not a project backup artifact.`,
+        {
+          project_id: projectId,
+          backup_dir: resolvedBackupDir,
+          artifact_kind: manifest.artifact_kind ?? null,
+        },
+        { nextStep: "Regenerate the backup with export_project_backup." }
+      );
+    }
+    if (manifest.project_id !== projectId) {
+      addDiagnostic(
+        diagnostics,
+        "project_backup_wrong_project",
+        `Backup manifest belongs to project "${manifest.project_id ?? "unknown"}", not "${projectId}".`,
+        {
+          project_id: projectId,
+          backup_dir: resolvedBackupDir,
+          manifest_project_id: manifest.project_id ?? null,
+        },
+        { nextStep: "Choose the backup directory for the requested project or regenerate the backup." }
+      );
+    }
+    if (manifest.schema_version !== PROJECT_BACKUP_SCHEMA_VERSION) {
+      addDiagnostic(
+        diagnostics,
+        "project_backup_incompatible_schema",
+        `Backup manifest schema version "${manifest.schema_version ?? "unknown"}" is not compatible with this server.`,
+        {
+          project_id: projectId,
+          backup_dir: resolvedBackupDir,
+          backup_schema_version: manifest.schema_version ?? null,
+          expected_schema_version: PROJECT_BACKUP_SCHEMA_VERSION,
+        },
+        { nextStep: "Regenerate the backup with a compatible server version before using it for recovery." }
+      );
+    }
+  }
+
+  if (snapshot && snapshot.project?.project_id !== projectId) {
+    addDiagnostic(
+      diagnostics,
+      "project_backup_wrong_project",
+      `Backup snapshot belongs to project "${snapshot.project?.project_id ?? "unknown"}", not "${projectId}".`,
+      {
+        project_id: projectId,
+        backup_dir: resolvedBackupDir,
+        snapshot_project_id: snapshot.project?.project_id ?? null,
+      },
+      { nextStep: "Choose the backup directory for the requested project or regenerate the backup." }
+    );
+  }
+
+  if (manifest && snapshot) {
+    const exportedSnapshotChecksum = manifest.checksums?.canonical_snapshot_sha256 ?? null;
+    const computedSnapshotChecksum = computeProjectBackupSnapshotChecksum(snapshot);
+    if (!exportedSnapshotChecksum || exportedSnapshotChecksum !== computedSnapshotChecksum) {
+      addDiagnostic(
+        diagnostics,
+        "project_backup_checksum_mismatch",
+        `Project backup snapshot checksum does not match manifest for "${projectId}".`,
+        {
+          project_id: projectId,
+          backup_dir: resolvedBackupDir,
+          exported_checksum: exportedSnapshotChecksum,
+          computed_checksum: computedSnapshotChecksum,
+        },
+        { nextStep: "Regenerate the backup with export_project_backup before using it for recovery." }
+      );
+    }
+
+    const exportedBundleChecksum = manifest.checksums?.bundle_sha256 ?? null;
+    const computedBundleChecksum = computeProjectBackupBundleChecksum({ manifest, snapshot });
+    if (!exportedBundleChecksum || exportedBundleChecksum !== computedBundleChecksum) {
+      addDiagnostic(
+        diagnostics,
+        "project_backup_bundle_checksum_mismatch",
+        `Project backup bundle checksum does not match manifest for "${projectId}".`,
+        {
+          project_id: projectId,
+          backup_dir: resolvedBackupDir,
+          exported_checksum: exportedBundleChecksum,
+          computed_checksum: computedBundleChecksum,
+        },
+        { nextStep: "Regenerate the backup with export_project_backup before using it for recovery." }
+      );
+    }
+
+    const canCheckFreshness = diagnostics.length === 0;
+    if (canCheckFreshness && built.ok && exportedSnapshotChecksum === computedSnapshotChecksum) {
+      const currentChecksum = built.manifest.checksums.canonical_snapshot_sha256;
+      if (exportedSnapshotChecksum !== currentChecksum) {
+        addDiagnostic(
+          diagnostics,
+          "project_backup_stale",
+          `Project backup for "${projectId}" is stale relative to current SQLite canonical state.`,
+          {
+            project_id: projectId,
+            backup_dir: resolvedBackupDir,
+            exported_checksum: exportedSnapshotChecksum,
+            current_checksum: currentChecksum,
+          },
+          { nextStep: "Regenerate the backup with export_project_backup, then review the Git diff." }
+        );
+      }
+    }
+  }
+
+  diagnostics.sort((a, b) => {
+    const typeCompare = a.type.localeCompare(b.type);
+    if (typeCompare) return typeCompare;
+    return a.message.localeCompare(b.message);
+  });
+
+  const status = statusFromDiagnostics(diagnostics);
+  return {
+    ok: diagnostics.length === 0,
+    checked: {
+      project_id: projectId,
+      backup_dir: resolvedBackupDir,
+      relative_backup_dir: relativeBackupDir,
+      files: {
+        manifest: manifestPath,
+        canonical_snapshot: snapshotPath,
+      },
+      manifest_exists: manifestRead.state.exists,
+      canonical_snapshot_exists: snapshotRead.state.exists,
+    },
+    trust: {
+      trusted: diagnostics.length === 0,
+      status,
+      freshness: status === "current" ? "current" : status === "stale" ? "stale" : "unknown",
+      schema_version: manifest?.schema_version ?? null,
+      backup_location: manifest?.backup_location ?? null,
+      checksums: manifest?.checksums ?? null,
+    },
+    summary: {
+      total: diagnostics.length,
+      by_type: countBy(diagnostics, "type"),
+      by_severity: countBy(diagnostics, "severity"),
+    },
+    diagnostics,
+    next_steps: diagnostics.length
+      ? ["Follow diagnostic next_step guidance before treating this backup as recovery input."]
+      : ["Project backup is trusted and current relative to SQLite canonical state."],
+  };
+}

--- a/src/structure/project-backup-operations.js
+++ b/src/structure/project-backup-operations.js
@@ -1,0 +1,116 @@
+import fs from "node:fs";
+import path from "node:path";
+import {
+  appendGeneratedOutputFile,
+  assertRegularFileWriteTarget,
+  ensureDirectoryInsideBoundary,
+  resolveGeneratedOutputPath,
+  writeGeneratedOutputFile,
+} from "../core/filesystem-boundary.js";
+import { CURRENT_SCHEMA_VERSION } from "../core/db.js";
+
+export const PROJECT_BACKUP_OPERATION_SCHEMA_VERSION = 1;
+export const PROJECT_BACKUP_OPERATION_LOG_FILE = "operations.jsonl";
+const PROJECT_BACKUP_SCHEMA_VERSION = 1;
+
+function stableStringify(value, indent = 0) {
+  const seen = new WeakSet();
+  function normalize(input) {
+    if (input === null || typeof input !== "object") return input;
+    if (seen.has(input)) {
+      throw new TypeError("Cannot stable-stringify circular structure.");
+    }
+    seen.add(input);
+    if (Array.isArray(input)) {
+      const array = input.map(normalize);
+      seen.delete(input);
+      return array;
+    }
+    const object = {};
+    for (const key of Object.keys(input).sort()) {
+      object[key] = normalize(input[key]);
+    }
+    seen.delete(input);
+    return object;
+  }
+
+  return JSON.stringify(normalize(value), null, indent);
+}
+
+export function buildProjectBackupOperationRecord({
+  operation,
+  projectId,
+  affected = {},
+  timestamp = new Date().toISOString(),
+  actor = null,
+  before = null,
+  after = null,
+  summary = null,
+  applicationVersion = "0.0.0",
+  metadata = {},
+} = {}) {
+  if (!operation || typeof operation !== "string") {
+    throw new TypeError("operation is required.");
+  }
+  if (!projectId || typeof projectId !== "string") {
+    throw new TypeError("projectId is required.");
+  }
+
+  return {
+    artifact_kind: "project_backup_operation",
+    schema_version: PROJECT_BACKUP_OPERATION_SCHEMA_VERSION,
+    backup_schema_version: PROJECT_BACKUP_SCHEMA_VERSION,
+    project_id: projectId,
+    operation,
+    timestamp,
+    actor,
+    affected,
+    summary,
+    before,
+    after,
+    metadata,
+    advisory: true,
+    restore_authority: false,
+    compatibility: {
+      application_version: applicationVersion,
+      current_sqlite_schema_version: CURRENT_SCHEMA_VERSION,
+    },
+  };
+}
+
+export function renderProjectBackupOperationRecord(record) {
+  return `${stableStringify(record, 0)}\n`;
+}
+
+export function ensureProjectBackupOperationLog({ outputDir }) {
+  const normalizedOutputDir = path.resolve(outputDir);
+  ensureDirectoryInsideBoundary(normalizedOutputDir, { label: "backup output_dir" });
+  const operationLogPath = resolveGeneratedOutputPath(normalizedOutputDir, PROJECT_BACKUP_OPERATION_LOG_FILE);
+  assertRegularFileWriteTarget(operationLogPath);
+
+  if (fs.existsSync(operationLogPath)) {
+    return {
+      operationLogPath,
+      written: false,
+    };
+  }
+
+  writeGeneratedOutputFile(operationLogPath, "", { encoding: "utf8" });
+  return {
+    operationLogPath,
+    written: true,
+  };
+}
+
+export function appendProjectBackupOperationRecord(record, { outputDir }) {
+  const { operationLogPath } = ensureProjectBackupOperationLog({ outputDir });
+  appendGeneratedOutputFile(
+    operationLogPath,
+    renderProjectBackupOperationRecord(record),
+    { encoding: "utf8" }
+  );
+  return {
+    operationLogPath,
+    appended: true,
+  };
+}

--- a/src/structure/project-backup-refresh.js
+++ b/src/structure/project-backup-refresh.js
@@ -18,6 +18,13 @@ function createBackupWarning(code, message, details = {}) {
   };
 }
 
+export function createToolActor(id) {
+  return {
+    type: "tool",
+    id,
+  };
+}
+
 export function buildPostMutationBackupWarning({
   projectId,
   operation,

--- a/src/structure/project-backup-refresh.js
+++ b/src/structure/project-backup-refresh.js
@@ -1,0 +1,148 @@
+import path from "node:path";
+import { buildProjectBackup, writeProjectBackupFiles } from "./project-backup.js";
+import {
+  appendProjectBackupOperationRecord,
+  buildProjectBackupOperationRecord,
+} from "./project-backup-operations.js";
+
+function relativePath(syncDirAbs, filePath) {
+  return path.relative(syncDirAbs, filePath).split(path.sep).filter(Boolean).join("/");
+}
+
+function createBackupWarning(code, message, details = {}) {
+  return {
+    code,
+    severity: "warning",
+    message,
+    details,
+  };
+}
+
+export function buildPostMutationBackupWarning({
+  projectId,
+  operation,
+  phase,
+  error,
+  details = {},
+}) {
+  const message = error instanceof Error ? error.message : String(error);
+  return createBackupWarning(
+    phase === "operation_history"
+      ? "OPERATION_LOG_APPEND_FAILED"
+      : "PROJECT_BACKUP_REFRESH_FAILED",
+    phase === "operation_history"
+      ? `Canonical mutation '${operation}' succeeded, but the advisory backup operation log could not be updated: ${message}`
+      : `Canonical mutation '${operation}' succeeded, but generated project backup artifacts could not be refreshed: ${message}`,
+    {
+      project_id: projectId,
+      operation,
+      phase,
+      ...details,
+    }
+  );
+}
+
+export function refreshProjectBackupAfterMutation(db, {
+  syncDir,
+  projectId,
+  applicationVersion = "0.0.0",
+  operation,
+  actor = null,
+  affected = {},
+  before = null,
+  after = null,
+  summary = null,
+  metadata = {},
+  timestamp,
+  buildBackup = buildProjectBackup,
+  writeBackup = writeProjectBackupFiles,
+  appendOperation = appendProjectBackupOperationRecord,
+} = {}) {
+  if (!syncDir) throw new TypeError("syncDir is required.");
+  if (!projectId) throw new TypeError("projectId is required.");
+  if (!operation) throw new TypeError("operation is required.");
+
+  const syncDirAbs = path.resolve(syncDir);
+  const outputDir = path.join(syncDirAbs, "project-backups", projectId);
+  const relativeOutputDir = relativePath(syncDirAbs, outputDir);
+  const backupLocation = relativeOutputDir ? `${relativeOutputDir}/` : "./";
+  const warnings = [];
+
+  let operationHistory = null;
+  const operationRecord = buildProjectBackupOperationRecord({
+    operation,
+    projectId,
+    timestamp,
+    actor,
+    affected,
+    before,
+    after,
+    summary,
+    applicationVersion,
+    metadata,
+  });
+
+  try {
+    const appended = appendOperation(operationRecord, { outputDir });
+    operationHistory = {
+      appended: appended.appended,
+      path: appended.operationLogPath,
+      relative_path: relativePath(syncDirAbs, appended.operationLogPath),
+      advisory: true,
+      restore_authority: false,
+    };
+  } catch (error) {
+    warnings.push(buildPostMutationBackupWarning({
+      projectId,
+      operation,
+      phase: "operation_history",
+      error,
+    }));
+  }
+
+  let backupRefresh = null;
+  try {
+    const built = buildBackup(db, {
+      projectId,
+      syncDir: syncDirAbs,
+      applicationVersion,
+      backupLocation,
+    });
+    if (!built.ok) {
+      throw new Error(built.error?.message ?? "Project backup could not be built.");
+    }
+    const written = writeBackup(built, { outputDir });
+    backupRefresh = {
+      ok: true,
+      output_dir: outputDir,
+      relative_output_dir: relativeOutputDir,
+      files: {
+        manifest: written.manifestPath,
+        canonical_snapshot: written.snapshotPath,
+        operations: written.operationLogPath,
+      },
+      relative_files: {
+        manifest: relativePath(syncDirAbs, written.manifestPath),
+        canonical_snapshot: relativePath(syncDirAbs, written.snapshotPath),
+        operations: relativePath(syncDirAbs, written.operationLogPath),
+      },
+      written: written.written,
+      generated_transparency: true,
+      restore_authority: "manifest_and_canonical_snapshot",
+      git_commit_created: false,
+    };
+  } catch (error) {
+    warnings.push(buildPostMutationBackupWarning({
+      projectId,
+      operation,
+      phase: "backup_refresh",
+      error,
+    }));
+  }
+
+  return {
+    operation_history: operationHistory,
+    backup_refresh: backupRefresh,
+    backup_warnings: warnings,
+  };
+}

--- a/src/structure/project-backup-refresh.js
+++ b/src/structure/project-backup-refresh.js
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { validateProjectId } from "../sync/importer.js";
 import { buildProjectBackup, writeProjectBackupFiles } from "./project-backup.js";
 import {
   appendProjectBackupOperationRecord,
@@ -68,6 +69,10 @@ export function refreshProjectBackupAfterMutation(db, {
   if (!syncDir) throw new TypeError("syncDir is required.");
   if (!projectId) throw new TypeError("projectId is required.");
   if (!operation) throw new TypeError("operation is required.");
+  const projectIdCheck = validateProjectId(projectId);
+  if (!projectIdCheck.ok) {
+    throw new TypeError(projectIdCheck.reason);
+  }
 
   const syncDirAbs = path.resolve(syncDir);
   const outputDir = path.join(syncDirAbs, "project-backups", projectId);

--- a/src/structure/project-backup.js
+++ b/src/structure/project-backup.js
@@ -1,6 +1,8 @@
 import crypto from "node:crypto";
+import fs from "node:fs";
 import path from "node:path";
 import {
+  assertRegularFileWriteTarget,
   ensureDirectoryInsideBoundary,
   resolveGeneratedOutputPath,
   writeGeneratedOutputFile,
@@ -276,19 +278,34 @@ export function renderProjectBackupArtifact(value) {
   return `${stableStringify(value, 2)}\n`;
 }
 
+function writeGeneratedOutputFileIfChanged(filePath, rendered) {
+  assertRegularFileWriteTarget(filePath);
+  if (fs.existsSync(filePath) && fs.readFileSync(filePath, "utf8") === rendered) {
+    return false;
+  }
+  writeGeneratedOutputFile(filePath, rendered, { encoding: "utf8" });
+  return true;
+}
+
 export function writeProjectBackupFiles(bundle, { outputDir }) {
   const normalizedOutputDir = path.resolve(outputDir);
   ensureDirectoryInsideBoundary(normalizedOutputDir, { label: "backup output_dir" });
 
   const manifestPath = resolveGeneratedOutputPath(normalizedOutputDir, "manifest.json");
   const snapshotPath = resolveGeneratedOutputPath(normalizedOutputDir, "canonical.snapshot.json");
+  const renderedManifest = renderProjectBackupArtifact(bundle.manifest);
+  const renderedSnapshot = renderProjectBackupArtifact(bundle.snapshot);
 
-  writeGeneratedOutputFile(manifestPath, renderProjectBackupArtifact(bundle.manifest), { encoding: "utf8" });
-  writeGeneratedOutputFile(snapshotPath, renderProjectBackupArtifact(bundle.snapshot), { encoding: "utf8" });
+  const manifestWritten = writeGeneratedOutputFileIfChanged(manifestPath, renderedManifest);
+  const snapshotWritten = writeGeneratedOutputFileIfChanged(snapshotPath, renderedSnapshot);
 
   return {
     manifestPath,
     snapshotPath,
+    written: {
+      manifest: manifestWritten,
+      canonical_snapshot: snapshotWritten,
+    },
   };
 }
 
@@ -296,6 +313,7 @@ export function buildProjectBackup(db, {
   projectId,
   syncDir = null,
   applicationVersion = "0.0.0",
+  backupLocation = null,
 } = {}) {
   const project = db.prepare(`
     SELECT project_id, universe_id, name
@@ -322,7 +340,7 @@ export function buildProjectBackup(db, {
     generated_transparency: true,
     mutation_surface: false,
     project_id: project.project_id,
-    backup_location: `project-backups/${project.project_id}/`,
+    backup_location: backupLocation ?? `project-backups/${project.project_id}/`,
     compatibility: {
       application_version: applicationVersion,
       sqlite_schema_version: querySchemaVersion(db),

--- a/src/structure/project-backup.js
+++ b/src/structure/project-backup.js
@@ -115,17 +115,81 @@ function collectScopedWorldRows(db, table, {
   universeId,
   idColumn,
   orderBy,
+  includeUniverseIds = new Set(),
 }) {
+  const universeIds = [...includeUniverseIds];
   const rows = db.prepare(`
     SELECT *
     FROM ${table}
     WHERE project_id = ?
-       OR (? IS NOT NULL AND project_id IS NULL AND universe_id = ?)
+       OR (
+         ? IS NOT NULL
+         AND project_id IS NULL
+         AND universe_id = ?
+         AND ${idColumn} IN (${universeIds.map(() => "?").join(",") || "NULL"})
+       )
     ORDER BY ${orderBy}
-  `).all(projectId, universeId, universeId);
+  `).all(projectId, universeId, universeId, ...universeIds);
   return {
     rows,
     ids: new Set(rows.map(row => row[idColumn])),
+  };
+}
+
+function collectReferenceDocsForBackup(db, {
+  projectId,
+  universeId,
+}) {
+  let rows = collectProjectScopedRows(db, "reference_docs", projectId, "doc_id");
+  const ids = new Set(rows.map(row => row.doc_id));
+
+  let changed = true;
+  while (changed) {
+    changed = false;
+    const sourceIds = [...ids];
+    const links = db.prepare(`
+      SELECT *
+      FROM reference_links
+      WHERE source_project_id = ?
+         OR (
+           source_project_id = ''
+           AND source_kind = 'reference'
+           AND source_id IN (${sourceIds.map(() => "?").join(",") || "NULL"})
+         )
+      ORDER BY source_kind, source_project_id, source_id, target_doc_id, relation
+    `).all(projectId, ...sourceIds);
+
+    const targetIds = sortedUnique(links.map(row => row.target_doc_id).filter(id => !ids.has(id)));
+    if (!targetIds.length) continue;
+
+    const universeRows = universeId
+      ? db.prepare(`
+        SELECT *
+        FROM reference_docs
+        WHERE project_id IS NULL
+          AND universe_id = ?
+          AND doc_id IN (${targetIds.map(() => "?").join(",")})
+        ORDER BY doc_id
+      `).all(universeId, ...targetIds)
+      : [];
+
+    for (const row of universeRows) {
+      if (ids.has(row.doc_id)) continue;
+      ids.add(row.doc_id);
+      rows.push(row);
+      changed = true;
+    }
+  }
+
+  rows = rows.sort((a, b) => {
+    const projectOrder = Number(a.project_id === null) - Number(b.project_id === null);
+    if (projectOrder !== 0) return projectOrder;
+    return a.doc_id.localeCompare(b.doc_id);
+  });
+
+  return {
+    rows,
+    ids,
   };
 }
 
@@ -157,12 +221,17 @@ function collectProjectBackupSnapshot(db, { project, syncDir }) {
   const sceneTags = collectProjectScopedRows(db, "scene_tags", projectId, "scene_id, tag");
   const sceneThreads = collectProjectScopedRows(db, "scene_threads", projectId, "scene_id, thread_id");
   const threads = collectProjectScopedRows(db, "threads", projectId, "thread_id");
+  const directlyReferencedCharacterIds = new Set([
+    ...sceneCharacters.map(row => row.character_id),
+    ...epigraphCharacters.map(row => row.character_id),
+  ]);
 
   const characters = collectScopedWorldRows(db, "characters", {
     projectId,
     universeId: project.universe_id,
     idColumn: "character_id",
     orderBy: "project_id IS NULL, character_id",
+    includeUniverseIds: directlyReferencedCharacterIds,
   });
   const characterTraits = characters.ids.size
     ? db.prepare(`
@@ -187,13 +256,12 @@ function collectProjectBackupSnapshot(db, { project, syncDir }) {
     universeId: project.universe_id,
     idColumn: "place_id",
     orderBy: "project_id IS NULL, place_id",
+    includeUniverseIds: new Set(scenePlaces.map(row => row.place_id)),
   });
 
-  const referenceDocs = collectScopedWorldRows(db, "reference_docs", {
+  const referenceDocs = collectReferenceDocsForBackup(db, {
     projectId,
     universeId: project.universe_id,
-    idColumn: "doc_id",
-    orderBy: "project_id IS NULL, doc_id",
   });
   const referenceDocTags = referenceDocs.ids.size
     ? db.prepare(`

--- a/src/structure/project-backup.js
+++ b/src/structure/project-backup.js
@@ -209,6 +209,7 @@ function collectProjectBackupSnapshot(db, { project, syncDir }) {
     WHERE source_project_id = ?
        OR (
          source_project_id = ''
+         AND source_kind = 'reference'
          AND source_id IN (${[...referenceDocs.ids].map(() => "?").join(",") || "NULL"})
        )
     ORDER BY source_kind, source_project_id, source_id, target_doc_id, relation

--- a/src/structure/project-backup.js
+++ b/src/structure/project-backup.js
@@ -1,0 +1,358 @@
+import crypto from "node:crypto";
+import path from "node:path";
+import { CURRENT_SCHEMA_VERSION } from "../core/db.js";
+
+export const PROJECT_BACKUP_SCHEMA_VERSION = 1;
+
+const INCLUDED_TABLES = [
+  "projects",
+  "universes",
+  "scenes",
+  "chapters",
+  "epigraphs",
+  "epigraph_characters",
+  "epigraph_tags",
+  "scene_characters",
+  "scene_places",
+  "scene_tags",
+  "scene_threads",
+  "characters",
+  "character_traits",
+  "character_relationships",
+  "places",
+  "threads",
+  "reference_docs",
+  "reference_doc_tags",
+  "reference_links",
+];
+
+const EXCLUDED_TABLES = [
+  "scenes_fts",
+  "reference_docs_fts",
+  "async_jobs",
+  "schema_version",
+];
+
+function stableStringify(value, indent = 2) {
+  const seen = new WeakSet();
+  function normalize(input) {
+    if (input === null || typeof input !== "object") return input;
+    if (seen.has(input)) {
+      throw new TypeError("Cannot stable-stringify circular structure.");
+    }
+    seen.add(input);
+    if (Array.isArray(input)) {
+      const array = input.map(normalize);
+      seen.delete(input);
+      return array;
+    }
+    const object = {};
+    for (const key of Object.keys(input).sort()) {
+      object[key] = normalize(input[key]);
+    }
+    seen.delete(input);
+    return object;
+  }
+
+  return JSON.stringify(normalize(value), null, indent);
+}
+
+function sha256(value) {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}
+
+function normalizePathForBackup(syncDir, filePath) {
+  if (!filePath) return null;
+  if (!syncDir) return filePath;
+  const syncRoot = path.resolve(syncDir);
+  const resolvedPath = path.isAbsolute(filePath)
+    ? path.resolve(filePath)
+    : path.resolve(syncRoot, filePath);
+  const normalized = path.relative(syncRoot, resolvedPath);
+  if (normalized.startsWith("..") || path.isAbsolute(normalized)) {
+    throw new Error(`Cannot back up path outside sync_dir: ${filePath}`);
+  }
+  return normalized.split(path.sep).join("/");
+}
+
+function querySchemaVersion(db) {
+  return db.prepare(`SELECT version FROM schema_version WHERE id = 1`).get()?.version ?? null;
+}
+
+function sortedUnique(values) {
+  return [...new Set(values.filter(value => value !== null && value !== undefined && value !== ""))].sort();
+}
+
+function mapPath(row, key, syncDir) {
+  return {
+    ...row,
+    [key]: normalizePathForBackup(syncDir, row[key]),
+  };
+}
+
+function collectProjectScopedRows(db, table, projectId, orderBy) {
+  return db.prepare(`
+    SELECT *
+    FROM ${table}
+    WHERE project_id = ?
+    ORDER BY ${orderBy}
+  `).all(projectId);
+}
+
+function collectScopedWorldRows(db, table, {
+  projectId,
+  universeId,
+  idColumn,
+  orderBy,
+}) {
+  const rows = db.prepare(`
+    SELECT *
+    FROM ${table}
+    WHERE project_id = ?
+       OR (? IS NOT NULL AND project_id IS NULL AND universe_id = ?)
+    ORDER BY ${orderBy}
+  `).all(projectId, universeId, universeId);
+  return {
+    rows,
+    ids: new Set(rows.map(row => row[idColumn])),
+  };
+}
+
+function collectProjectBackupSnapshot(db, { project, syncDir }) {
+  const projectId = project.project_id;
+  const universe = project.universe_id
+    ? db.prepare(`
+      SELECT universe_id, name
+      FROM universes
+      WHERE universe_id = ?
+    `).get(project.universe_id) ?? null
+    : null;
+
+  const chapters = collectProjectScopedRows(db, "chapters", projectId, "sort_index, chapter_id")
+    .map(row => mapPath(row, "source_path", syncDir));
+  const scenes = collectProjectScopedRows(db, "scenes", projectId, "part, chapter, timeline_position, scene_id")
+    .map(row => mapPath(row, "file_path", syncDir));
+  const epigraphs = db.prepare(`
+    SELECT epigraph_id, project_id, chapter_id, file_path, prose_checksum, metadata_stale, updated_at
+    FROM epigraphs
+    WHERE project_id = ?
+    ORDER BY chapter_id, epigraph_id
+  `).all(projectId).map(row => mapPath(row, "file_path", syncDir));
+
+  const epigraphCharacters = collectProjectScopedRows(db, "epigraph_characters", projectId, "epigraph_id, character_id");
+  const epigraphTags = collectProjectScopedRows(db, "epigraph_tags", projectId, "epigraph_id, tag");
+  const sceneCharacters = collectProjectScopedRows(db, "scene_characters", projectId, "scene_id, character_id");
+  const scenePlaces = collectProjectScopedRows(db, "scene_places", projectId, "scene_id, place_id");
+  const sceneTags = collectProjectScopedRows(db, "scene_tags", projectId, "scene_id, tag");
+  const sceneThreads = collectProjectScopedRows(db, "scene_threads", projectId, "scene_id, thread_id");
+  const threads = collectProjectScopedRows(db, "threads", projectId, "thread_id");
+
+  const characters = collectScopedWorldRows(db, "characters", {
+    projectId,
+    universeId: project.universe_id,
+    idColumn: "character_id",
+    orderBy: "project_id IS NULL, character_id",
+  });
+  const characterTraits = characters.ids.size
+    ? db.prepare(`
+      SELECT *
+      FROM character_traits
+      WHERE character_id IN (${[...characters.ids].map(() => "?").join(",")})
+      ORDER BY character_id, trait
+    `).all(...characters.ids)
+    : [];
+
+  const characterRelationships = db.prepare(`
+    SELECT *
+    FROM character_relationships
+    WHERE from_character IN (${[...characters.ids].map(() => "?").join(",") || "NULL"})
+       OR to_character IN (${[...characters.ids].map(() => "?").join(",") || "NULL"})
+       OR scene_id IN (${scenes.map(() => "?").join(",") || "NULL"})
+    ORDER BY from_character, to_character, relationship_type, scene_id, note
+  `).all(...characters.ids, ...characters.ids, ...scenes.map(row => row.scene_id));
+
+  const places = collectScopedWorldRows(db, "places", {
+    projectId,
+    universeId: project.universe_id,
+    idColumn: "place_id",
+    orderBy: "project_id IS NULL, place_id",
+  });
+
+  const referenceDocs = collectScopedWorldRows(db, "reference_docs", {
+    projectId,
+    universeId: project.universe_id,
+    idColumn: "doc_id",
+    orderBy: "project_id IS NULL, doc_id",
+  });
+  const referenceDocTags = referenceDocs.ids.size
+    ? db.prepare(`
+      SELECT *
+      FROM reference_doc_tags
+      WHERE doc_id IN (${[...referenceDocs.ids].map(() => "?").join(",")})
+      ORDER BY doc_id, tag
+    `).all(...referenceDocs.ids)
+    : [];
+  const referenceLinks = db.prepare(`
+    SELECT *
+    FROM reference_links
+    WHERE source_project_id = ?
+       OR (
+         source_project_id = ''
+         AND source_id IN (${[...referenceDocs.ids].map(() => "?").join(",") || "NULL"})
+       )
+    ORDER BY source_kind, source_project_id, source_id, target_doc_id, relation
+  `).all(projectId, ...referenceDocs.ids);
+
+  const includedCharacterIds = characters.ids;
+  const includedPlaceIds = places.ids;
+  const includedReferenceDocIds = referenceDocs.ids;
+  const externalReferences = {
+    character_ids: sortedUnique([
+      ...sceneCharacters.map(row => row.character_id),
+      ...epigraphCharacters.map(row => row.character_id),
+      ...characterRelationships.flatMap(row => [row.from_character, row.to_character]),
+    ].filter(id => !includedCharacterIds.has(id))),
+    place_ids: sortedUnique(scenePlaces.map(row => row.place_id).filter(id => !includedPlaceIds.has(id))),
+    reference_doc_ids: sortedUnique(referenceLinks.map(row => row.target_doc_id).filter(id => !includedReferenceDocIds.has(id))),
+  };
+
+  return {
+    project: {
+      project_id: project.project_id,
+      universe_id: project.universe_id ?? null,
+      name: project.name,
+    },
+    universe: universe
+      ? {
+          universe_id: universe.universe_id,
+          name: universe.name,
+        }
+      : null,
+    chapters,
+    scenes,
+    epigraphs,
+    epigraph_characters: epigraphCharacters,
+    epigraph_tags: epigraphTags,
+    scene_characters: sceneCharacters,
+    scene_places: scenePlaces,
+    scene_tags: sceneTags,
+    scene_threads: sceneThreads,
+    characters: characters.rows.map(row => mapPath(row, "file_path", syncDir)),
+    character_traits: characterTraits,
+    character_relationships: characterRelationships,
+    places: places.rows.map(row => mapPath(row, "file_path", syncDir)),
+    threads,
+    reference_docs: referenceDocs.rows.map(row => mapPath(row, "file_path", syncDir)),
+    reference_doc_tags: referenceDocTags,
+    reference_links: referenceLinks,
+    external_references: externalReferences,
+    operation_history: {
+      supported: false,
+      authority: false,
+      planned_artifact: "operations.jsonl",
+    },
+  };
+}
+
+export function computeProjectBackupSnapshotChecksum(snapshot) {
+  return sha256(stableStringify(snapshot, 0));
+}
+
+export function computeProjectBackupBundleChecksum(bundle) {
+  const { manifest = {}, snapshot = {} } = bundle ?? {};
+  const { checksums: _checksums, ...manifestWithoutChecksums } = manifest;
+  return sha256(stableStringify({
+    manifest: manifestWithoutChecksums,
+    snapshot,
+  }, 0));
+}
+
+export function renderProjectBackupArtifact(value) {
+  return `${stableStringify(value, 2)}\n`;
+}
+
+export function buildProjectBackup(db, {
+  projectId,
+  syncDir = null,
+  applicationVersion = "0.0.0",
+} = {}) {
+  const project = db.prepare(`
+    SELECT project_id, universe_id, name
+    FROM projects
+    WHERE project_id = ?
+  `).get(projectId);
+  if (!project) {
+    return {
+      ok: false,
+      error: {
+        code: "NOT_FOUND",
+        message: `Project '${projectId}' not found.`,
+        details: { project_id: projectId },
+      },
+    };
+  }
+
+  const snapshot = collectProjectBackupSnapshot(db, { project, syncDir });
+  const snapshotChecksum = computeProjectBackupSnapshotChecksum(snapshot);
+  const manifestBase = {
+    artifact_kind: "project_backup",
+    schema_version: PROJECT_BACKUP_SCHEMA_VERSION,
+    canonical_source: "sqlite",
+    generated_transparency: true,
+    mutation_surface: false,
+    project_id: project.project_id,
+    backup_location: `project-backups/${project.project_id}/`,
+    compatibility: {
+      application_version: applicationVersion,
+      sqlite_schema_version: querySchemaVersion(db),
+      current_sqlite_schema_version: CURRENT_SCHEMA_VERSION,
+    },
+    restore_policy: {
+      authority: "full_snapshot",
+      custom_delta_chains: false,
+      event_replay_required: false,
+      operation_history_authority: false,
+    },
+    operation_history: {
+      supported: false,
+      planned_artifact: "operations.jsonl",
+      purpose: "future audit, provenance, progress analytics, and tool accountability",
+    },
+    privacy: {
+      git_trackable: true,
+      manuscript_sensitive: true,
+      includes_authored_prose_bodies: false,
+      note: "Backup artifacts may include titles, summaries, tags, relationship notes, and structural metadata.",
+    },
+    coverage: {
+      included_tables: INCLUDED_TABLES,
+      excluded_tables: EXCLUDED_TABLES,
+      split_snapshot_supported: false,
+      counts: {
+        chapters: snapshot.chapters.length,
+        scenes: snapshot.scenes.length,
+        epigraphs: snapshot.epigraphs.length,
+        characters: snapshot.characters.length,
+        places: snapshot.places.length,
+        threads: snapshot.threads.length,
+        reference_docs: snapshot.reference_docs.length,
+        external_character_references: snapshot.external_references.character_ids.length,
+        external_place_references: snapshot.external_references.place_ids.length,
+        external_reference_doc_references: snapshot.external_references.reference_doc_ids.length,
+      },
+    },
+  };
+  const manifest = {
+    ...manifestBase,
+    checksums: {
+      canonical_snapshot_sha256: snapshotChecksum,
+      bundle_sha256: computeProjectBackupBundleChecksum({ manifest: manifestBase, snapshot }),
+    },
+  };
+
+  return {
+    ok: true,
+    manifest,
+    snapshot,
+  };
+}

--- a/src/structure/project-backup.js
+++ b/src/structure/project-backup.js
@@ -1,5 +1,10 @@
 import crypto from "node:crypto";
 import path from "node:path";
+import {
+  ensureDirectoryInsideBoundary,
+  resolveGeneratedOutputPath,
+  writeGeneratedOutputFile,
+} from "../core/filesystem-boundary.js";
 import { CURRENT_SCHEMA_VERSION } from "../core/db.js";
 
 export const PROJECT_BACKUP_SCHEMA_VERSION = 1;
@@ -269,6 +274,22 @@ export function computeProjectBackupBundleChecksum(bundle) {
 
 export function renderProjectBackupArtifact(value) {
   return `${stableStringify(value, 2)}\n`;
+}
+
+export function writeProjectBackupFiles(bundle, { outputDir }) {
+  const normalizedOutputDir = path.resolve(outputDir);
+  ensureDirectoryInsideBoundary(normalizedOutputDir, { label: "backup output_dir" });
+
+  const manifestPath = resolveGeneratedOutputPath(normalizedOutputDir, "manifest.json");
+  const snapshotPath = resolveGeneratedOutputPath(normalizedOutputDir, "canonical.snapshot.json");
+
+  writeGeneratedOutputFile(manifestPath, renderProjectBackupArtifact(bundle.manifest), { encoding: "utf8" });
+  writeGeneratedOutputFile(snapshotPath, renderProjectBackupArtifact(bundle.snapshot), { encoding: "utf8" });
+
+  return {
+    manifestPath,
+    snapshotPath,
+  };
 }
 
 export function buildProjectBackup(db, {

--- a/src/structure/project-backup.js
+++ b/src/structure/project-backup.js
@@ -8,6 +8,10 @@ import {
   writeGeneratedOutputFile,
 } from "../core/filesystem-boundary.js";
 import { CURRENT_SCHEMA_VERSION } from "../core/db.js";
+import {
+  ensureProjectBackupOperationLog,
+  PROJECT_BACKUP_OPERATION_LOG_FILE,
+} from "./project-backup-operations.js";
 
 export const PROJECT_BACKUP_SCHEMA_VERSION = 1;
 
@@ -254,9 +258,10 @@ function collectProjectBackupSnapshot(db, { project, syncDir }) {
     reference_links: referenceLinks,
     external_references: externalReferences,
     operation_history: {
-      supported: false,
+      supported: true,
       authority: false,
-      planned_artifact: "operations.jsonl",
+      advisory: true,
+      artifact: PROJECT_BACKUP_OPERATION_LOG_FILE,
     },
   };
 }
@@ -298,13 +303,16 @@ export function writeProjectBackupFiles(bundle, { outputDir }) {
 
   const manifestWritten = writeGeneratedOutputFileIfChanged(manifestPath, renderedManifest);
   const snapshotWritten = writeGeneratedOutputFileIfChanged(snapshotPath, renderedSnapshot);
+  const operationLog = ensureProjectBackupOperationLog({ outputDir: normalizedOutputDir });
 
   return {
     manifestPath,
     snapshotPath,
+    operationLogPath: operationLog.operationLogPath,
     written: {
       manifest: manifestWritten,
       canonical_snapshot: snapshotWritten,
+      operations: operationLog.written,
     },
   };
 }
@@ -353,8 +361,10 @@ export function buildProjectBackup(db, {
       operation_history_authority: false,
     },
     operation_history: {
-      supported: false,
-      planned_artifact: "operations.jsonl",
+      supported: true,
+      advisory: true,
+      artifact: PROJECT_BACKUP_OPERATION_LOG_FILE,
+      authority: false,
       purpose: "future audit, provenance, progress analytics, and tool accountability",
     },
     privacy: {

--- a/src/test/integration/editing.test.mjs
+++ b/src/test/integration/editing.test.mjs
@@ -77,6 +77,8 @@ describe("commit_edit behavior", { concurrency: 1 }, () => {
     );
     assert.equal(typeof commitResult.next_step, "string");
     assert.ok(commitResult.next_step.includes("get_scene_prose"));
+    assert.equal(commitResult.backup_refresh.ok, true);
+    assert.deepEqual(commitResult.backup_warnings, []);
     if (typeof commitResult.snapshot_commit === "string") {
       assert.notEqual(commitResult.snapshot_commit, "");
     }

--- a/src/test/integration/metadata.test.mjs
+++ b/src/test/integration/metadata.test.mjs
@@ -871,6 +871,9 @@ describe("update_character_sheet tool", () => {
       fields: { arc_summary: "Overcomes isolation to build genuine trust." },
     });
     assert.ok(text.includes("Updated character sheet"));
+    const parsed = JSON.parse(text);
+    assert.equal(parsed.backup_refresh.ok, true);
+    assert.deepEqual(parsed.backup_warnings, []);
 
     const sheet = await callWriteTool("get_character_sheet", { character_id: "elena" });
     assert.ok(sheet.includes("Overcomes isolation"), `Expected updated arc, got: ${sheet.slice(0, 300)}`);
@@ -892,6 +895,9 @@ describe("update_place_sheet tool", () => {
       fields: { name: "Harbor District (Revised)" },
     });
     assert.ok(text.includes("Updated place sheet"));
+    const parsed = JSON.parse(text);
+    assert.equal(parsed.backup_refresh.ok, true);
+    assert.deepEqual(parsed.backup_warnings, []);
 
     const listed = await callWriteTool("list_places");
     assert.ok(listed.includes("Harbor District (Revised)"), `Expected updated name in list_places, got: ${listed.slice(0, 300)}`);
@@ -928,6 +934,9 @@ describe("update_scene_metadata status field", () => {
       fields: { status: "needs-revision" },
     });
     assert.ok(text.includes("Updated metadata"));
+    const parsed = JSON.parse(text);
+    assert.equal(parsed.backup_refresh.ok, true);
+    assert.deepEqual(parsed.backup_warnings, []);
 
     // Verify the status field was written to the sidecar on disk
     const sidecarFile = path.join(writeSyncDir, "projects", "test-novel", "part-1", "chapter-1", "sc-001.meta.yaml");
@@ -951,6 +960,8 @@ describe("create_character_sheet tool", () => {
 
     assert.equal(parsed.ok, true);
     assert.equal(parsed.id, "char-mira-nystrom");
+    assert.equal(parsed.backup_refresh.ok, true);
+    assert.deepEqual(parsed.backup_warnings, []);
     assert.ok(fs.existsSync(parsed.prose_path));
     assert.ok(fs.existsSync(parsed.meta_path));
     assert.ok(fs.existsSync(path.join(path.dirname(parsed.prose_path), "arc.md")));

--- a/src/test/integration/metadata.test.mjs
+++ b/src/test/integration/metadata.test.mjs
@@ -290,6 +290,11 @@ describe("create_chapter tool", () => {
     assert.equal(createParsed.operation_history.relative_path, "project-backups/test-novel/operations.jsonl");
     assert.equal(createParsed.operation_history.advisory, true);
     assert.equal(createParsed.operation_history.restore_authority, false);
+    assert.equal(createParsed.backup_refresh.ok, true);
+    assert.equal(createParsed.backup_refresh.relative_output_dir, "project-backups/test-novel");
+    assert.equal(createParsed.backup_refresh.written.manifest, true);
+    assert.equal(createParsed.backup_refresh.written.canonical_snapshot, true);
+    assert.equal(createParsed.backup_refresh.git_commit_created, false);
     assert.ok(createParsed.next_steps.some((step) => step.includes("assign_scene_to_chapter")));
 
     const chaptersText = await callWriteTool("list_chapters", { project_id: "test-novel" });
@@ -308,6 +313,13 @@ describe("create_chapter tool", () => {
     assert.equal(operationRecord.after.chapter.title, "M7 New Crossing");
     assert.equal(operationRecord.advisory, true);
     assert.equal(operationRecord.restore_authority, false);
+
+    const backupDiagnosticText = await callWriteTool("diagnose_project_backups", {
+      project_id: "test-novel",
+    });
+    const backupDiagnosticParsed = JSON.parse(backupDiagnosticText);
+    assert.equal(backupDiagnosticParsed.ok, true);
+    assert.equal(backupDiagnosticParsed.trust.status, "current");
   });
 
   test("rejects creating a chapter at an occupied sort index", async () => {

--- a/src/test/integration/metadata.test.mjs
+++ b/src/test/integration/metadata.test.mjs
@@ -285,11 +285,29 @@ describe("create_chapter tool", () => {
     assert.equal(createParsed.chapter.title, "M7 New Crossing");
     assert.equal(createParsed.chapter.sort_index, 99);
     assert.equal(createParsed.diagnostics[0].code, "REPRESENTATION_DEFERRED");
+    assert.deepEqual(createParsed.backup_warnings, []);
+    assert.equal(createParsed.operation_history.appended, true);
+    assert.equal(createParsed.operation_history.relative_path, "project-backups/test-novel/operations.jsonl");
+    assert.equal(createParsed.operation_history.advisory, true);
+    assert.equal(createParsed.operation_history.restore_authority, false);
     assert.ok(createParsed.next_steps.some((step) => step.includes("assign_scene_to_chapter")));
 
     const chaptersText = await callWriteTool("list_chapters", { project_id: "test-novel" });
     const chaptersParsed = JSON.parse(chaptersText);
     assert.ok(chaptersParsed.results.some((row) => row.chapter_id === "ch-99-m7-new-crossing"));
+
+    const operationLines = fs.readFileSync(
+      path.join(writeSyncDir, "project-backups", "test-novel", "operations.jsonl"),
+      "utf8"
+    ).trimEnd().split("\n");
+    const operationRecord = JSON.parse(operationLines.at(-1));
+    assert.equal(operationRecord.operation, "create_chapter");
+    assert.equal(operationRecord.project_id, "test-novel");
+    assert.deepEqual(operationRecord.affected.chapters, ["ch-99-m7-new-crossing"]);
+    assert.equal(operationRecord.actor.id, "create_chapter");
+    assert.equal(operationRecord.after.chapter.title, "M7 New Crossing");
+    assert.equal(operationRecord.advisory, true);
+    assert.equal(operationRecord.restore_authority, false);
   });
 
   test("rejects creating a chapter at an occupied sort index", async () => {

--- a/src/test/integration/search.test.mjs
+++ b/src/test/integration/search.test.mjs
@@ -733,6 +733,8 @@ describe("reference link tools", () => {
     assert.equal(applyParsed.applied_count, 1);
     assert.equal(applyParsed.applied_links[0].target_doc_id, "ref-apply-mode");
     assert.equal(applyParsed.applied_links[0].origin, "explicit");
+    assert.equal(applyParsed.backup_refresh.ok, true);
+    assert.deepEqual(applyParsed.backup_warnings, []);
 
     const listedText = await callWriteTool("list_scene_references", {
       scene_id: "sc-001",
@@ -857,6 +859,8 @@ describe("upsert_thread_link tool", () => {
     assert.equal(parsed.thread.project_id, "test-novel");
     assert.equal(parsed.link.scene_id, "sc-001");
     assert.equal(parsed.link.beat, "Opening");
+    assert.equal(parsed.backup_refresh.ok, true);
+    assert.deepEqual(parsed.backup_warnings, []);
   });
 
   test("updates existing link beat idempotently", async () => {
@@ -931,6 +935,8 @@ describe("upsert_reference_link tool", () => {
     assert.equal(parsed.link.source_id, "sc-upsert-ref-001");
     assert.equal(parsed.link.target_doc_id, "ref-upsert-target");
     assert.equal(parsed.link.relation, "informs");
+    assert.equal(parsed.backup_refresh.ok, true);
+    assert.deepEqual(parsed.backup_warnings, []);
 
     const sidecarText = fs.readFileSync(scenePath.replace(/\.md$/, ".meta.yaml"), "utf8");
     assert.ok(sidecarText.includes("reference_links:"));

--- a/src/test/integration/search.test.mjs
+++ b/src/test/integration/search.test.mjs
@@ -863,6 +863,18 @@ describe("upsert_thread_link tool", () => {
     assert.deepEqual(parsed.backup_warnings, []);
   });
 
+  test("rejects invalid project id before writing thread links", async () => {
+    const text = await callWriteTool("upsert_thread_link", {
+      project_id: "../outside",
+      thread_id: "thread-invalid-project",
+      thread_name: "Invalid Project",
+      scene_id: "sc-001",
+    });
+    const parsed = JSON.parse(text);
+    assert.equal(parsed.ok, false);
+    assert.equal(parsed.error.code, "INVALID_PROJECT_ID");
+  });
+
   test("updates existing link beat idempotently", async () => {
     const text = await callWriteTool("upsert_thread_link", {
       project_id: "test-novel",

--- a/src/test/integration/sync.test.mjs
+++ b/src/test/integration/sync.test.mjs
@@ -134,6 +134,7 @@ describe("sync tool", () => {
     assert.equal(parsed.relative_output_dir, "project-backups/test-novel");
     assert.equal(parsed.relative_files.manifest, "project-backups/test-novel/manifest.json");
     assert.equal(parsed.relative_files.canonical_snapshot, "project-backups/test-novel/canonical.snapshot.json");
+    assert.equal(parsed.relative_files.operations, "project-backups/test-novel/operations.jsonl");
     assert.equal(parsed.manifest.canonical_source, "sqlite");
     assert.equal(parsed.manifest.generated_transparency, true);
     assert.equal(parsed.manifest.mutation_surface, false);
@@ -146,6 +147,7 @@ describe("sync tool", () => {
 
     const manifestPath = path.join(writeSyncDir, "project-backups", "test-novel", "manifest.json");
     const snapshotPath = path.join(writeSyncDir, "project-backups", "test-novel", "canonical.snapshot.json");
+    const operationsPath = path.join(writeSyncDir, "project-backups", "test-novel", "operations.jsonl");
     const firstManifest = fs.readFileSync(manifestPath, "utf8");
     const firstSnapshot = fs.readFileSync(snapshotPath, "utf8");
     const manifest = JSON.parse(firstManifest);
@@ -155,7 +157,9 @@ describe("sync tool", () => {
     assert.equal(manifest.backup_location, "project-backups/test-novel/");
     assert.equal(manifest.checksums.canonical_snapshot_sha256, parsed.manifest.checksums.canonical_snapshot_sha256);
     assert.equal(snapshot.project.project_id, "test-novel");
-    assert.equal(snapshot.operation_history.supported, false);
+    assert.equal(snapshot.operation_history.supported, true);
+    assert.equal(snapshot.operation_history.artifact, "operations.jsonl");
+    assert.equal(fs.readFileSync(operationsPath, "utf8"), "");
     assert.ok(snapshot.scenes.some(scene => scene.scene_id === "sc-001"));
     assert.equal(firstSnapshot.includes("This authored epigraph body must not enter"), false);
 
@@ -166,6 +170,7 @@ describe("sync tool", () => {
     assert.deepEqual(secondParsed.written, {
       manifest: false,
       canonical_snapshot: false,
+      operations: false,
     });
     assert.equal(fs.readFileSync(manifestPath, "utf8"), firstManifest);
     assert.equal(fs.readFileSync(snapshotPath, "utf8"), firstSnapshot);
@@ -184,6 +189,7 @@ describe("sync tool", () => {
     assert.deepEqual(parsed.written, {
       manifest: true,
       canonical_snapshot: true,
+      operations: true,
     });
 
     const manifestPath = path.join(writeSyncDir, "manual-backups", "test-novel", "manifest.json");

--- a/src/test/integration/sync.test.mjs
+++ b/src/test/integration/sync.test.mjs
@@ -191,6 +191,31 @@ describe("sync tool", () => {
     assert.equal(manifest.backup_location, "manual-backups/test-novel/");
   });
 
+  test("diagnose_project_backups reports stale backup after canonical state changes", async () => {
+    await callWriteTool("export_project_backup", {
+      project_id: "test-novel",
+      output_dir: "diagnostic-backups/test-novel",
+    });
+
+    await callWriteTool("create_chapter", {
+      project_id: "test-novel",
+      title: "Diagnostic Freshness Chapter",
+      sort_index: 99,
+      chapter_id: "ch-99-diagnostic-freshness",
+    });
+
+    const text = await callWriteTool("diagnose_project_backups", {
+      project_id: "test-novel",
+      backup_dir: "diagnostic-backups/test-novel",
+    });
+    const parsed = JSON.parse(text);
+
+    assert.equal(parsed.ok, false);
+    assert.equal(parsed.trust.status, "stale");
+    assert.equal(parsed.summary.by_type.project_backup_stale, 1);
+    assert.match(parsed.diagnostics[0].next_step, /export_project_backup/);
+  });
+
   test("export_project_backup refuses output outside the sync directory", async () => {
     const text = await callWriteTool("export_project_backup", {
       project_id: "test-novel",
@@ -1064,6 +1089,17 @@ describe("enrich_scene_characters_batch tool", () => {
       const backupParsed = JSON.parse(backupResult.content?.[0]?.text ?? "{}");
       assert.equal(backupParsed.ok, false);
       assert.equal(backupParsed.error.code, "READ_ONLY");
+
+      const diagnosticResult = await roClient.callTool({
+        name: "diagnose_project_backups",
+        arguments: {
+          project_id: "test-novel",
+        },
+      });
+      const diagnosticParsed = JSON.parse(diagnosticResult.content?.[0]?.text ?? "{}");
+      assert.equal(diagnosticParsed.error, undefined);
+      assert.equal(diagnosticParsed.checked.project_id, "test-novel");
+      assert.equal(typeof diagnosticParsed.trust.status, "string");
     } finally {
       try { await roClient?.close(); } catch {}
       if (roProc) roProc.kill();

--- a/src/test/integration/sync.test.mjs
+++ b/src/test/integration/sync.test.mjs
@@ -137,6 +137,7 @@ describe("sync tool", () => {
     assert.equal(parsed.manifest.canonical_source, "sqlite");
     assert.equal(parsed.manifest.generated_transparency, true);
     assert.equal(parsed.manifest.mutation_surface, false);
+    assert.equal(parsed.manifest.backup_location, "project-backups/test-novel/");
     assert.equal(parsed.manifest.restore_policy.authority, "full_snapshot");
     assert.equal(parsed.manifest.restore_policy.custom_delta_chains, false);
     assert.equal(parsed.manifest.privacy.includes_authored_prose_bodies, false);
@@ -151,17 +152,43 @@ describe("sync tool", () => {
     const snapshot = JSON.parse(firstSnapshot);
 
     assert.equal(manifest.project_id, "test-novel");
+    assert.equal(manifest.backup_location, "project-backups/test-novel/");
     assert.equal(manifest.checksums.canonical_snapshot_sha256, parsed.manifest.checksums.canonical_snapshot_sha256);
     assert.equal(snapshot.project.project_id, "test-novel");
     assert.equal(snapshot.operation_history.supported, false);
     assert.ok(snapshot.scenes.some(scene => scene.scene_id === "sc-001"));
     assert.equal(firstSnapshot.includes("This authored epigraph body must not enter"), false);
 
-    await callWriteTool("export_project_backup", {
+    const secondText = await callWriteTool("export_project_backup", {
       project_id: "test-novel",
+    });
+    const secondParsed = JSON.parse(secondText);
+    assert.deepEqual(secondParsed.written, {
+      manifest: false,
+      canonical_snapshot: false,
     });
     assert.equal(fs.readFileSync(manifestPath, "utf8"), firstManifest);
     assert.equal(fs.readFileSync(snapshotPath, "utf8"), firstSnapshot);
+  });
+
+  test("export_project_backup records custom output_dir in manifest", async () => {
+    const text = await callWriteTool("export_project_backup", {
+      project_id: "test-novel",
+      output_dir: "manual-backups/test-novel",
+    });
+    const parsed = JSON.parse(text);
+
+    assert.equal(parsed.ok, true);
+    assert.equal(parsed.relative_output_dir, "manual-backups/test-novel");
+    assert.equal(parsed.manifest.backup_location, "manual-backups/test-novel/");
+    assert.deepEqual(parsed.written, {
+      manifest: true,
+      canonical_snapshot: true,
+    });
+
+    const manifestPath = path.join(writeSyncDir, "manual-backups", "test-novel", "manifest.json");
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+    assert.equal(manifest.backup_location, "manual-backups/test-novel/");
   });
 
   test("export_project_backup refuses output outside the sync directory", async () => {

--- a/src/test/integration/sync.test.mjs
+++ b/src/test/integration/sync.test.mjs
@@ -159,7 +159,12 @@ describe("sync tool", () => {
     assert.equal(snapshot.project.project_id, "test-novel");
     assert.equal(snapshot.operation_history.supported, true);
     assert.equal(snapshot.operation_history.artifact, "operations.jsonl");
-    assert.equal(fs.readFileSync(operationsPath, "utf8"), "");
+    const firstOperations = fs.readFileSync(operationsPath, "utf8");
+    for (const line of firstOperations.trim().split("\n").filter(Boolean)) {
+      const operation = JSON.parse(line);
+      assert.equal(operation.artifact_kind, "project_backup_operation");
+      assert.equal(operation.project_id, "test-novel");
+    }
     assert.ok(snapshot.scenes.some(scene => scene.scene_id === "sc-001"));
     assert.equal(firstSnapshot.includes("This authored epigraph body must not enter"), false);
 
@@ -174,6 +179,7 @@ describe("sync tool", () => {
     });
     assert.equal(fs.readFileSync(manifestPath, "utf8"), firstManifest);
     assert.equal(fs.readFileSync(snapshotPath, "utf8"), firstSnapshot);
+    assert.equal(fs.readFileSync(operationsPath, "utf8"), firstOperations);
   });
 
   test("export_project_backup records custom output_dir in manifest", async () => {
@@ -1014,6 +1020,8 @@ describe("enrich_scene_characters_batch tool", () => {
       assert.equal(done.job.result.ok, true);
       assert.equal(done.job.result.scenes_changed, 1);
       assert.equal(done.job.result.links_added >= 1, true);
+      assert.equal(done.job.result.backup_refresh.ok, true);
+      assert.deepEqual(done.job.result.backup_warnings, []);
 
       // Ensure parent index is refreshed before asserting link visibility.
       await callWriteTool("sync");
@@ -1276,6 +1284,8 @@ describe("enrich_scene tool", () => {
     assert.equal(enrich.ok, true);
     assert.equal(enrich.action, "enriched");
     assert.equal(enrich.scene_id, "sc-001");
+    assert.equal(enrich.backup_refresh.ok, true);
+    assert.deepEqual(enrich.backup_warnings, []);
 
     const freshArcText = await callWriteTool("get_arc", { character_id: "elena" });
     const freshArc = JSON.parse(freshArcText);

--- a/src/test/integration/sync.test.mjs
+++ b/src/test/integration/sync.test.mjs
@@ -123,6 +123,58 @@ describe("sync tool", () => {
     assert.equal(secondContent, firstContent);
   });
 
+  test("export_project_backup writes stable generated backup bundle", async () => {
+    const text = await callWriteTool("export_project_backup", {
+      project_id: "test-novel",
+    });
+    const parsed = JSON.parse(text);
+
+    assert.equal(parsed.ok, true);
+    assert.equal(parsed.action, "exported");
+    assert.equal(parsed.relative_output_dir, "project-backups/test-novel");
+    assert.equal(parsed.relative_files.manifest, "project-backups/test-novel/manifest.json");
+    assert.equal(parsed.relative_files.canonical_snapshot, "project-backups/test-novel/canonical.snapshot.json");
+    assert.equal(parsed.manifest.canonical_source, "sqlite");
+    assert.equal(parsed.manifest.generated_transparency, true);
+    assert.equal(parsed.manifest.mutation_surface, false);
+    assert.equal(parsed.manifest.restore_policy.authority, "full_snapshot");
+    assert.equal(parsed.manifest.restore_policy.custom_delta_chains, false);
+    assert.equal(parsed.manifest.privacy.includes_authored_prose_bodies, false);
+    assert.match(parsed.manifest.checksums.canonical_snapshot_sha256, /^[a-f0-9]{64}$/);
+    assert.match(parsed.manifest.checksums.bundle_sha256, /^[a-f0-9]{64}$/);
+
+    const manifestPath = path.join(writeSyncDir, "project-backups", "test-novel", "manifest.json");
+    const snapshotPath = path.join(writeSyncDir, "project-backups", "test-novel", "canonical.snapshot.json");
+    const firstManifest = fs.readFileSync(manifestPath, "utf8");
+    const firstSnapshot = fs.readFileSync(snapshotPath, "utf8");
+    const manifest = JSON.parse(firstManifest);
+    const snapshot = JSON.parse(firstSnapshot);
+
+    assert.equal(manifest.project_id, "test-novel");
+    assert.equal(manifest.checksums.canonical_snapshot_sha256, parsed.manifest.checksums.canonical_snapshot_sha256);
+    assert.equal(snapshot.project.project_id, "test-novel");
+    assert.equal(snapshot.operation_history.supported, false);
+    assert.ok(snapshot.scenes.some(scene => scene.scene_id === "sc-001"));
+    assert.equal(firstSnapshot.includes("This authored epigraph body must not enter"), false);
+
+    await callWriteTool("export_project_backup", {
+      project_id: "test-novel",
+    });
+    assert.equal(fs.readFileSync(manifestPath, "utf8"), firstManifest);
+    assert.equal(fs.readFileSync(snapshotPath, "utf8"), firstSnapshot);
+  });
+
+  test("export_project_backup refuses output outside the sync directory", async () => {
+    const text = await callWriteTool("export_project_backup", {
+      project_id: "test-novel",
+      output_dir: os.tmpdir(),
+    });
+    const parsed = JSON.parse(text);
+
+    assert.equal(parsed.ok, false);
+    assert.equal(parsed.error.code, "INVALID_OUTPUT_DIR");
+  });
+
   test("restore_structure_from_export dry-run validates current export", async () => {
     await callWriteTool("export_structure_snapshot", {
       project_id: "test-novel",
@@ -975,6 +1027,16 @@ describe("enrich_scene_characters_batch tool", () => {
       const parsed = JSON.parse(result.content?.[0]?.text ?? "{}");
       assert.equal(parsed.ok, false);
       assert.equal(parsed.error.code, "READ_ONLY");
+
+      const backupResult = await roClient.callTool({
+        name: "export_project_backup",
+        arguments: {
+          project_id: "test-novel",
+        },
+      });
+      const backupParsed = JSON.parse(backupResult.content?.[0]?.text ?? "{}");
+      assert.equal(backupParsed.ok, false);
+      assert.equal(backupParsed.error.code, "READ_ONLY");
     } finally {
       try { await roClient?.close(); } catch {}
       if (roProc) roProc.kill();

--- a/src/test/unit/project-backup-diagnostics.test.mjs
+++ b/src/test/unit/project-backup-diagnostics.test.mjs
@@ -1,0 +1,221 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { openDb } from "../../core/db.js";
+import {
+  buildProjectBackup,
+  renderProjectBackupArtifact,
+  writeProjectBackupFiles,
+} from "../../structure/project-backup.js";
+import { runProjectBackupDiagnostics } from "../../structure/project-backup-diagnostics.js";
+
+const UPDATED_AT = "2026-05-24T10:00:00.000Z";
+
+function seedFixture(db) {
+  db.prepare(`
+    INSERT INTO projects (project_id, universe_id, name)
+    VALUES (?, ?, ?)
+  `).run("test-novel", null, "Test Novel");
+  db.prepare(`
+    INSERT INTO projects (project_id, universe_id, name)
+    VALUES (?, ?, ?)
+  `).run("other-novel", null, "Other Novel");
+  db.prepare(`
+    INSERT INTO chapters (
+      chapter_id, project_id, title, sort_index, logline, source_path, source_checksum, metadata_stale, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    "ch-01-first",
+    "test-novel",
+    "First",
+    1,
+    "Opening chapter.",
+    "projects/test-novel/chapters/ch-01",
+    "chapter-checksum",
+    0,
+    UPDATED_AT
+  );
+  db.prepare(`
+    INSERT INTO scenes (
+      scene_id, project_id, chapter_id, title, part, chapter, chapter_title, pov, logline,
+      scene_change, causality, stakes, scene_functions, save_the_cat_beat, timeline_position,
+      story_time, word_count, file_path, prose_checksum, metadata_stale, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    "sc-first",
+    "test-novel",
+    "ch-01-first",
+    "First Scene",
+    1,
+    1,
+    "First",
+    "Elena",
+    "First scene logline.",
+    null,
+    null,
+    null,
+    null,
+    null,
+    1,
+    null,
+    1000,
+    "projects/test-novel/chapters/ch-01/sc-first.md",
+    "scene-checksum",
+    0,
+    UPDATED_AT
+  );
+  db.prepare(`
+    INSERT INTO chapters (
+      chapter_id, project_id, title, sort_index, logline, source_path, source_checksum, metadata_stale, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    "ch-other",
+    "other-novel",
+    "Other",
+    1,
+    null,
+    "projects/other-novel/chapters/ch-other",
+    null,
+    0,
+    UPDATED_AT
+  );
+}
+
+function withFixture(fn) {
+  const db = openDb(":memory:");
+  const syncDir = fs.mkdtempSync(path.join(os.tmpdir(), "mcp-writing-backup-diagnostics-sync-"));
+  const backupDir = path.join(syncDir, "project-backups", "test-novel");
+  try {
+    seedFixture(db);
+    fs.mkdirSync(backupDir, { recursive: true });
+    return fn({ db, syncDir, backupDir });
+  } finally {
+    db.close();
+    fs.rmSync(syncDir, { recursive: true, force: true });
+  }
+}
+
+function exportFixtureBackup(db, syncDir, backupDir, projectId = "test-novel") {
+  const relativeBackupDir = path.relative(syncDir, backupDir).split(path.sep).join("/");
+  const built = buildProjectBackup(db, {
+    projectId,
+    syncDir,
+    applicationVersion: "9.9.9",
+    backupLocation: `${relativeBackupDir}/`,
+  });
+  assert.equal(built.ok, true);
+  writeProjectBackupFiles(built, { outputDir: backupDir });
+  return built;
+}
+
+function diagnose(db, syncDir, backupDir, projectId = "test-novel") {
+  return runProjectBackupDiagnostics(db, {
+    syncDir,
+    backupDir,
+    projectId,
+    applicationVersion: "9.9.9",
+  });
+}
+
+function diagnosticTypes(result) {
+  return result.diagnostics.map(diagnostic => diagnostic.type);
+}
+
+describe("runProjectBackupDiagnostics", () => {
+  test("reports a trusted current backup", () => withFixture(({ db, syncDir, backupDir }) => {
+    exportFixtureBackup(db, syncDir, backupDir);
+
+    const result = diagnose(db, syncDir, backupDir);
+
+    assert.equal(result.ok, true);
+    assert.equal(result.trust.trusted, true);
+    assert.equal(result.trust.status, "current");
+    assert.equal(result.trust.freshness, "current");
+    assert.deepEqual(result.diagnostics, []);
+  }));
+
+  test("reports missing backup bundles", () => withFixture(({ db, syncDir, backupDir }) => {
+    fs.rmSync(backupDir, { recursive: true, force: true });
+
+    const result = diagnose(db, syncDir, backupDir);
+
+    assert.equal(result.ok, false);
+    assert.deepEqual(diagnosticTypes(result), ["project_backup_missing"]);
+    assert.equal(result.trust.status, "untrusted");
+  }));
+
+  test("reports partial backup bundles", () => withFixture(({ db, syncDir, backupDir }) => {
+    exportFixtureBackup(db, syncDir, backupDir);
+    fs.rmSync(path.join(backupDir, "canonical.snapshot.json"));
+
+    const result = diagnose(db, syncDir, backupDir);
+
+    assert.equal(result.ok, false);
+    assert.deepEqual(diagnosticTypes(result), ["project_backup_partial"]);
+  }));
+
+  test("reports unreadable JSON", () => withFixture(({ db, syncDir, backupDir }) => {
+    exportFixtureBackup(db, syncDir, backupDir);
+    fs.writeFileSync(path.join(backupDir, "manifest.json"), "{not-json", "utf8");
+
+    const result = diagnose(db, syncDir, backupDir);
+
+    assert.equal(result.ok, false);
+    assert.deepEqual(diagnosticTypes(result), ["project_backup_unreadable"]);
+  }));
+
+  test("reports wrong-project backup bundles", () => withFixture(({ db, syncDir, backupDir }) => {
+    exportFixtureBackup(db, syncDir, backupDir, "test-novel");
+
+    const result = diagnose(db, syncDir, backupDir, "other-novel");
+
+    assert.equal(result.ok, false);
+    assert.deepEqual(new Set(diagnosticTypes(result)), new Set(["project_backup_wrong_project"]));
+  }));
+
+  test("reports incompatible schema versions", () => withFixture(({ db, syncDir, backupDir }) => {
+    exportFixtureBackup(db, syncDir, backupDir);
+    const manifestPath = path.join(backupDir, "manifest.json");
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+    manifest.schema_version = 999;
+    fs.writeFileSync(manifestPath, renderProjectBackupArtifact(manifest), "utf8");
+
+    const result = diagnose(db, syncDir, backupDir);
+
+    assert.equal(result.ok, false);
+    assert.ok(diagnosticTypes(result).includes("project_backup_incompatible_schema"));
+    assert.ok(diagnosticTypes(result).includes("project_backup_bundle_checksum_mismatch"));
+  }));
+
+  test("reports tampered snapshots", () => withFixture(({ db, syncDir, backupDir }) => {
+    exportFixtureBackup(db, syncDir, backupDir);
+    const snapshotPath = path.join(backupDir, "canonical.snapshot.json");
+    const snapshot = JSON.parse(fs.readFileSync(snapshotPath, "utf8"));
+    snapshot.project.name = "Tampered";
+    fs.writeFileSync(snapshotPath, renderProjectBackupArtifact(snapshot), "utf8");
+
+    const result = diagnose(db, syncDir, backupDir);
+
+    assert.equal(result.ok, false);
+    assert.ok(diagnosticTypes(result).includes("project_backup_checksum_mismatch"));
+    assert.ok(diagnosticTypes(result).includes("project_backup_bundle_checksum_mismatch"));
+  }));
+
+  test("reports stale backups after canonical state changes", () => withFixture(({ db, syncDir, backupDir }) => {
+    exportFixtureBackup(db, syncDir, backupDir);
+    db.prepare(`
+      UPDATE scenes
+      SET title = ?
+      WHERE project_id = ? AND scene_id = ?
+    `).run("Updated Scene", "test-novel", "sc-first");
+
+    const result = diagnose(db, syncDir, backupDir);
+
+    assert.equal(result.ok, false);
+    assert.deepEqual(diagnosticTypes(result), ["project_backup_stale"]);
+    assert.equal(result.trust.status, "stale");
+    assert.equal(result.trust.freshness, "stale");
+  }));
+});

--- a/src/test/unit/project-backup-diagnostics.test.mjs
+++ b/src/test/unit/project-backup-diagnostics.test.mjs
@@ -193,6 +193,28 @@ describe("runProjectBackupDiagnostics", () => {
     assert.equal(result.diagnostics[0].details.reason, "not_regular");
   }));
 
+  test("reports lstat failures as unreadable backup files", () => withFixture(({ db, syncDir, backupDir }) => {
+    exportFixtureBackup(db, syncDir, backupDir);
+    const originalLstatSync = fs.lstatSync;
+    const manifestPath = path.join(backupDir, "manifest.json");
+    fs.lstatSync = (filePath, ...args) => {
+      if (filePath === manifestPath) {
+        throw new Error("permission denied");
+      }
+      return originalLstatSync.call(fs, filePath, ...args);
+    };
+    try {
+      const result = diagnose(db, syncDir, backupDir);
+
+      assert.equal(result.ok, false);
+      assert.deepEqual(diagnosticTypes(result), ["project_backup_unreadable"]);
+      assert.equal(result.diagnostics[0].details.reason, "lstat_failed");
+      assert.equal(result.diagnostics[0].details.message, "permission denied");
+    } finally {
+      fs.lstatSync = originalLstatSync;
+    }
+  }));
+
   test("reports wrong-project backup bundles", () => withFixture(({ db, syncDir, backupDir }) => {
     exportFixtureBackup(db, syncDir, backupDir, "test-novel");
 

--- a/src/test/unit/project-backup-diagnostics.test.mjs
+++ b/src/test/unit/project-backup-diagnostics.test.mjs
@@ -224,6 +224,23 @@ describe("runProjectBackupDiagnostics", () => {
     assert.deepEqual(new Set(diagnosticTypes(result)), new Set(["project_backup_wrong_project"]));
   }));
 
+  test("reports current snapshot build failures without throwing", () => withFixture(({ db, syncDir, backupDir }) => {
+    exportFixtureBackup(db, syncDir, backupDir);
+    db.prepare(`
+      UPDATE scenes
+      SET file_path = ?
+      WHERE project_id = ? AND scene_id = ?
+    `).run(path.join(path.dirname(syncDir), "outside.md"), "test-novel", "sc-first");
+
+    const result = diagnose(db, syncDir, backupDir);
+
+    assert.equal(result.ok, false);
+    assert.deepEqual(diagnosticTypes(result), ["project_backup_current_snapshot_failed"]);
+    assert.equal(result.diagnostics[0].severity, "error");
+    assert.match(result.diagnostics[0].message, /outside sync_dir/);
+    assert.equal(result.diagnostics[0].details.phase, "current_snapshot");
+  }));
+
   test("reports incompatible schema versions", () => withFixture(({ db, syncDir, backupDir }) => {
     exportFixtureBackup(db, syncDir, backupDir);
     const manifestPath = path.join(backupDir, "manifest.json");

--- a/src/test/unit/project-backup-diagnostics.test.mjs
+++ b/src/test/unit/project-backup-diagnostics.test.mjs
@@ -166,6 +166,33 @@ describe("runProjectBackupDiagnostics", () => {
     assert.deepEqual(diagnosticTypes(result), ["project_backup_unreadable"]);
   }));
 
+  test("refuses symlinked backup files as untrusted", () => withFixture(({ db, syncDir, backupDir }) => {
+    exportFixtureBackup(db, syncDir, backupDir);
+    const manifestPath = path.join(backupDir, "manifest.json");
+    const manifestTargetPath = path.join(backupDir, "manifest-target.json");
+    fs.renameSync(manifestPath, manifestTargetPath);
+    fs.symlinkSync(manifestTargetPath, manifestPath);
+
+    const result = diagnose(db, syncDir, backupDir);
+
+    assert.equal(result.ok, false);
+    assert.deepEqual(diagnosticTypes(result), ["project_backup_unreadable"]);
+    assert.equal(result.diagnostics[0].details.reason, "symlink");
+  }));
+
+  test("refuses non-regular backup files as untrusted", () => withFixture(({ db, syncDir, backupDir }) => {
+    exportFixtureBackup(db, syncDir, backupDir);
+    const snapshotPath = path.join(backupDir, "canonical.snapshot.json");
+    fs.rmSync(snapshotPath);
+    fs.mkdirSync(snapshotPath);
+
+    const result = diagnose(db, syncDir, backupDir);
+
+    assert.equal(result.ok, false);
+    assert.deepEqual(diagnosticTypes(result), ["project_backup_unreadable"]);
+    assert.equal(result.diagnostics[0].details.reason, "not_regular");
+  }));
+
   test("reports wrong-project backup bundles", () => withFixture(({ db, syncDir, backupDir }) => {
     exportFixtureBackup(db, syncDir, backupDir, "test-novel");
 

--- a/src/test/unit/project-backup-operations.test.mjs
+++ b/src/test/unit/project-backup-operations.test.mjs
@@ -1,0 +1,103 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  appendProjectBackupOperationRecord,
+  buildProjectBackupOperationRecord,
+  ensureProjectBackupOperationLog,
+  renderProjectBackupOperationRecord,
+} from "../../structure/project-backup-operations.js";
+
+describe("project backup operation history", () => {
+  test("builds a minimal advisory operation envelope", () => {
+    const record = buildProjectBackupOperationRecord({
+      operation: "create_chapter",
+      projectId: "test-novel",
+      timestamp: "2026-05-24T10:00:00.000Z",
+      applicationVersion: "9.9.9",
+      actor: {
+        type: "tool",
+        id: "create_chapter",
+      },
+      affected: {
+        chapters: ["ch-99-new-crossing"],
+      },
+      summary: "Created chapter.",
+      before: null,
+      after: {
+        chapter: {
+          chapter_id: "ch-99-new-crossing",
+          title: "New Crossing",
+        },
+      },
+    });
+
+    assert.equal(record.artifact_kind, "project_backup_operation");
+    assert.equal(record.schema_version, 1);
+    assert.equal(record.backup_schema_version, 1);
+    assert.equal(record.operation, "create_chapter");
+    assert.equal(record.project_id, "test-novel");
+    assert.equal(record.actor.id, "create_chapter");
+    assert.deepEqual(record.affected.chapters, ["ch-99-new-crossing"]);
+    assert.equal(record.advisory, true);
+    assert.equal(record.restore_authority, false);
+    assert.equal(record.compatibility.application_version, "9.9.9");
+    assert.equal(typeof record.compatibility.current_sqlite_schema_version, "number");
+  });
+
+  test("renders stable single-line JSONL records", () => {
+    const record = buildProjectBackupOperationRecord({
+      operation: "create_chapter",
+      projectId: "test-novel",
+      timestamp: "2026-05-24T10:00:00.000Z",
+      actor: { id: "create_chapter", type: "tool" },
+      affected: { chapters: ["ch-99-new-crossing"] },
+      applicationVersion: "9.9.9",
+    });
+
+    const rendered = renderProjectBackupOperationRecord(record);
+    assert.match(rendered, /^\{.*\}\n$/);
+    assert.equal(rendered.split("\n").length, 2);
+    assert.equal(JSON.parse(rendered).operation, "create_chapter");
+    assert.equal(rendered, renderProjectBackupOperationRecord(record));
+  });
+
+  test("creates an empty log once and appends records without rewriting history", () => {
+    const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), "mcp-writing-operations-"));
+    try {
+      const firstEnsure = ensureProjectBackupOperationLog({ outputDir });
+      assert.equal(firstEnsure.written, true);
+      assert.equal(fs.readFileSync(firstEnsure.operationLogPath, "utf8"), "");
+
+      const secondEnsure = ensureProjectBackupOperationLog({ outputDir });
+      assert.equal(secondEnsure.written, false);
+
+      const firstRecord = buildProjectBackupOperationRecord({
+        operation: "create_chapter",
+        projectId: "test-novel",
+        timestamp: "2026-05-24T10:00:00.000Z",
+        actor: { id: "create_chapter", type: "tool" },
+        affected: { chapters: ["ch-01-first"] },
+      });
+      const secondRecord = buildProjectBackupOperationRecord({
+        operation: "create_chapter",
+        projectId: "test-novel",
+        timestamp: "2026-05-24T11:00:00.000Z",
+        actor: { id: "create_chapter", type: "tool" },
+        affected: { chapters: ["ch-02-second"] },
+      });
+
+      appendProjectBackupOperationRecord(firstRecord, { outputDir });
+      appendProjectBackupOperationRecord(secondRecord, { outputDir });
+
+      const lines = fs.readFileSync(firstEnsure.operationLogPath, "utf8").trimEnd().split("\n");
+      assert.equal(lines.length, 2);
+      assert.equal(JSON.parse(lines[0]).affected.chapters[0], "ch-01-first");
+      assert.equal(JSON.parse(lines[1]).affected.chapters[0], "ch-02-second");
+    } finally {
+      fs.rmSync(outputDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/test/unit/project-backup-refresh.test.mjs
+++ b/src/test/unit/project-backup-refresh.test.mjs
@@ -94,6 +94,17 @@ describe("project backup post-mutation refresh", () => {
     assert.equal(result.backup_warnings[0].details.phase, "operation_history");
   });
 
+  test("rejects invalid project ids before deriving backup paths", () => {
+    assert.throws(
+      () => refreshProjectBackupAfterMutation(null, {
+        syncDir: "/tmp/mcp-writing-sync",
+        projectId: "../outside",
+        operation: "create_chapter",
+      }),
+      /project_id must not contain/
+    );
+  });
+
   test("reports backup write failures without hiding operation history", () => {
     const result = refreshProjectBackupAfterMutation(null, {
       syncDir: "/tmp/mcp-writing-sync",

--- a/src/test/unit/project-backup-refresh.test.mjs
+++ b/src/test/unit/project-backup-refresh.test.mjs
@@ -1,0 +1,140 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import {
+  buildPostMutationBackupWarning,
+  refreshProjectBackupAfterMutation,
+} from "../../structure/project-backup-refresh.js";
+
+describe("project backup post-mutation refresh", () => {
+  test("returns operation history and backup refresh details from injected writers", () => {
+    const syncDir = "/tmp/mcp-writing-sync";
+    const result = refreshProjectBackupAfterMutation(null, {
+      syncDir,
+      projectId: "test-novel",
+      applicationVersion: "9.9.9",
+      operation: "create_chapter",
+      actor: { type: "tool", id: "create_chapter" },
+      affected: { chapters: ["ch-99-new-crossing"] },
+      summary: "Created chapter.",
+      buildBackup: (_db, options) => ({
+        ok: true,
+        manifest: {
+          project_id: options.projectId,
+        },
+        snapshot: {
+          project: {
+            project_id: options.projectId,
+          },
+        },
+      }),
+      writeBackup: (_bundle, { outputDir }) => ({
+        manifestPath: path.join(outputDir, "manifest.json"),
+        snapshotPath: path.join(outputDir, "canonical.snapshot.json"),
+        operationLogPath: path.join(outputDir, "operations.jsonl"),
+        written: {
+          manifest: true,
+          canonical_snapshot: true,
+          operations: false,
+        },
+      }),
+      appendOperation: (record, { outputDir }) => {
+        assert.equal(record.operation, "create_chapter");
+        assert.equal(record.project_id, "test-novel");
+        assert.equal(record.restore_authority, false);
+        return {
+          appended: true,
+          operationLogPath: path.join(outputDir, "operations.jsonl"),
+        };
+      },
+    });
+
+    assert.deepEqual(result.backup_warnings, []);
+    assert.equal(result.operation_history.appended, true);
+    assert.equal(result.operation_history.relative_path, "project-backups/test-novel/operations.jsonl");
+    assert.equal(result.backup_refresh.ok, true);
+    assert.equal(result.backup_refresh.relative_output_dir, "project-backups/test-novel");
+    assert.deepEqual(result.backup_refresh.written, {
+      manifest: true,
+      canonical_snapshot: true,
+      operations: false,
+    });
+    assert.equal(result.backup_refresh.git_commit_created, false);
+  });
+
+  test("reports operation append failures without blocking snapshot refresh", () => {
+    const result = refreshProjectBackupAfterMutation(null, {
+      syncDir: "/tmp/mcp-writing-sync",
+      projectId: "test-novel",
+      operation: "rename_chapter",
+      buildBackup: () => ({
+        ok: true,
+        manifest: {},
+        snapshot: {},
+      }),
+      writeBackup: (_bundle, { outputDir }) => ({
+        manifestPath: path.join(outputDir, "manifest.json"),
+        snapshotPath: path.join(outputDir, "canonical.snapshot.json"),
+        operationLogPath: path.join(outputDir, "operations.jsonl"),
+        written: {
+          manifest: false,
+          canonical_snapshot: true,
+          operations: false,
+        },
+      }),
+      appendOperation: () => {
+        throw new Error("append denied");
+      },
+    });
+
+    assert.equal(result.operation_history, null);
+    assert.equal(result.backup_refresh.ok, true);
+    assert.equal(result.backup_warnings.length, 1);
+    assert.equal(result.backup_warnings[0].code, "OPERATION_LOG_APPEND_FAILED");
+    assert.equal(result.backup_warnings[0].details.phase, "operation_history");
+  });
+
+  test("reports backup write failures without hiding operation history", () => {
+    const result = refreshProjectBackupAfterMutation(null, {
+      syncDir: "/tmp/mcp-writing-sync",
+      projectId: "test-novel",
+      operation: "reorder_chapter",
+      buildBackup: () => ({
+        ok: true,
+        manifest: {},
+        snapshot: {},
+      }),
+      writeBackup: () => {
+        throw new Error("disk full");
+      },
+      appendOperation: (_record, { outputDir }) => ({
+        appended: true,
+        operationLogPath: path.join(outputDir, "operations.jsonl"),
+      }),
+    });
+
+    assert.equal(result.operation_history.appended, true);
+    assert.equal(result.backup_refresh, null);
+    assert.equal(result.backup_warnings.length, 1);
+    assert.equal(result.backup_warnings[0].code, "PROJECT_BACKUP_REFRESH_FAILED");
+    assert.equal(result.backup_warnings[0].details.phase, "backup_refresh");
+  });
+
+  test("builds consistent warning envelopes", () => {
+    const warning = buildPostMutationBackupWarning({
+      projectId: "test-novel",
+      operation: "create_chapter",
+      phase: "backup_refresh",
+      error: new Error("write failed"),
+      details: {
+        chapter_id: "ch-99-new-crossing",
+      },
+    });
+
+    assert.equal(warning.code, "PROJECT_BACKUP_REFRESH_FAILED");
+    assert.equal(warning.severity, "warning");
+    assert.match(warning.message, /create_chapter/);
+    assert.equal(warning.details.project_id, "test-novel");
+    assert.equal(warning.details.chapter_id, "ch-99-new-crossing");
+  });
+});

--- a/src/test/unit/project-backup.test.mjs
+++ b/src/test/unit/project-backup.test.mjs
@@ -310,10 +310,14 @@ describe("buildProjectBackup", () => {
       assert.equal(first.manifest.restore_policy.authority, "full_snapshot");
       assert.equal(first.manifest.restore_policy.custom_delta_chains, false);
       assert.equal(first.manifest.restore_policy.event_replay_required, false);
-      assert.equal(first.manifest.operation_history.supported, false);
+      assert.equal(first.manifest.operation_history.supported, true);
+      assert.equal(first.manifest.operation_history.artifact, "operations.jsonl");
+      assert.equal(first.manifest.operation_history.authority, false);
 
       assert.deepEqual(first.snapshot.chapters.map(row => row.chapter_id), ["ch-01-first", "ch-02-second"]);
       assert.deepEqual(first.snapshot.scenes.map(row => row.scene_id), ["sc-first", "sc-second"]);
+      assert.equal(first.snapshot.operation_history.supported, true);
+      assert.equal(first.snapshot.operation_history.authority, false);
       assert.equal(first.snapshot.chapters[0].source_path, "projects/test-novel/chapters/ch-01");
       assert.equal(first.snapshot.scenes[0].file_path, "projects/test-novel/chapters/ch-01/sc-first.md");
       assert.equal(first.snapshot.characters.find(row => row.character_id === "char-shared").file_path, "universes/shared-universe/world/characters/shared.md");
@@ -401,17 +405,22 @@ describe("buildProjectBackup", () => {
       assert.deepEqual(firstWrite.written, {
         manifest: true,
         canonical_snapshot: true,
+        operations: true,
       });
+      assert.equal(fs.readFileSync(firstWrite.operationLogPath, "utf8"), "");
       const manifestBefore = fs.statSync(firstWrite.manifestPath).mtimeMs;
       const snapshotBefore = fs.statSync(firstWrite.snapshotPath).mtimeMs;
+      const operationsBefore = fs.statSync(firstWrite.operationLogPath).mtimeMs;
 
       const secondWrite = writeProjectBackupFiles(result, { outputDir });
       assert.deepEqual(secondWrite.written, {
         manifest: false,
         canonical_snapshot: false,
+        operations: false,
       });
       assert.equal(fs.statSync(secondWrite.manifestPath).mtimeMs, manifestBefore);
       assert.equal(fs.statSync(secondWrite.snapshotPath).mtimeMs, snapshotBefore);
+      assert.equal(fs.statSync(secondWrite.operationLogPath).mtimeMs, operationsBefore);
     } finally {
       db.close();
       fs.rmSync(outputDir, { recursive: true, force: true });

--- a/src/test/unit/project-backup.test.mjs
+++ b/src/test/unit/project-backup.test.mjs
@@ -272,6 +272,10 @@ function seedProjectBackupFixture(db) {
     INSERT INTO reference_links (source_kind, source_project_id, source_id, target_doc_id, relation, origin)
     VALUES (?, ?, ?, ?, ?, ?)
   `).run("scene", "other-novel", "sc-other", "ref-law", "mentions", "explicit");
+  db.prepare(`
+    INSERT INTO reference_links (source_kind, source_project_id, source_id, target_doc_id, relation, origin)
+    VALUES (?, ?, ?, ?, ?, ?)
+  `).run("scene", "", "ref-law", "ref-other", "mentions", "explicit");
 
   db.prepare(`
     INSERT INTO async_jobs (job_id, kind, status, created_at)
@@ -368,6 +372,10 @@ describe("buildProjectBackup", () => {
       assert.equal(result.snapshot.places.some(row => row.place_id === "place-other"), false);
       assert.equal(result.snapshot.reference_docs.some(row => row.doc_id === "ref-other"), false);
       assert.equal(result.snapshot.reference_links.some(row => row.source_project_id === "other-novel"), false);
+      assert.equal(
+        result.snapshot.reference_links.some(row => row.source_kind === "scene" && row.source_project_id === ""),
+        false
+      );
       assert.equal(result.manifest.coverage.counts.external_character_references, 1);
     } finally {
       db.close();

--- a/src/test/unit/project-backup.test.mjs
+++ b/src/test/unit/project-backup.test.mjs
@@ -1,0 +1,380 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { openDb } from "../../core/db.js";
+import {
+  buildProjectBackup,
+  computeProjectBackupBundleChecksum,
+  computeProjectBackupSnapshotChecksum,
+  renderProjectBackupArtifact,
+} from "../../structure/project-backup.js";
+
+const SYNC_DIR = "/tmp/sync";
+const UPDATED_AT = "2026-05-23T12:00:00.000Z";
+
+function seedProjectBackupFixture(db) {
+  db.prepare(`
+    INSERT INTO universes (universe_id, name)
+    VALUES (?, ?)
+  `).run("shared-universe", "Shared Universe");
+  db.prepare(`
+    INSERT INTO projects (project_id, universe_id, name)
+    VALUES (?, ?, ?)
+  `).run("test-novel", "shared-universe", "Test Novel");
+  db.prepare(`
+    INSERT INTO projects (project_id, universe_id, name)
+    VALUES (?, ?, ?)
+  `).run("other-novel", "shared-universe", "Other Novel");
+
+  db.prepare(`
+    INSERT INTO chapters (
+      chapter_id, project_id, title, sort_index, logline, source_path, source_checksum, metadata_stale, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    "ch-02-second",
+    "test-novel",
+    "Second",
+    2,
+    "Second chapter.",
+    `${SYNC_DIR}/projects/test-novel/chapters/ch-02`,
+    "chapter-2-checksum",
+    0,
+    UPDATED_AT
+  );
+  db.prepare(`
+    INSERT INTO chapters (
+      chapter_id, project_id, title, sort_index, logline, source_path, source_checksum, metadata_stale, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    "ch-01-first",
+    "test-novel",
+    "First",
+    1,
+    "First chapter.",
+    `${SYNC_DIR}/projects/test-novel/chapters/ch-01`,
+    "chapter-1-checksum",
+    0,
+    UPDATED_AT
+  );
+
+  db.prepare(`
+    INSERT INTO scenes (
+      scene_id, project_id, chapter_id, title, part, chapter, chapter_title, pov, logline,
+      scene_change, causality, stakes, scene_functions, save_the_cat_beat, timeline_position,
+      story_time, word_count, file_path, prose_checksum, metadata_stale, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    "sc-second",
+    "test-novel",
+    "ch-02-second",
+    "Second Scene",
+    1,
+    2,
+    "Second",
+    "Elena",
+    "Second scene logline.",
+    "turn",
+    3,
+    4,
+    "reveal",
+    "Debate",
+    1,
+    "Day 2",
+    1200,
+    `${SYNC_DIR}/projects/test-novel/chapters/ch-02/sc-second.md`,
+    "scene-2-checksum",
+    0,
+    UPDATED_AT
+  );
+  db.prepare(`
+    INSERT INTO scenes (
+      scene_id, project_id, chapter_id, title, part, chapter, chapter_title, pov, logline,
+      scene_change, causality, stakes, scene_functions, save_the_cat_beat, timeline_position,
+      story_time, word_count, file_path, prose_checksum, metadata_stale, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    "sc-first",
+    "test-novel",
+    "ch-01-first",
+    "First Scene",
+    1,
+    1,
+    "First",
+    "Elena",
+    "First scene logline.",
+    "arrival",
+    1,
+    2,
+    "setup",
+    "Opening Image",
+    1,
+    "Day 1",
+    900,
+    `${SYNC_DIR}/projects/test-novel/chapters/ch-01/sc-first.md`,
+    "scene-1-checksum",
+    0,
+    UPDATED_AT
+  );
+
+  db.prepare(`
+    INSERT INTO epigraphs (
+      epigraph_id, project_id, chapter_id, body, file_path, prose_checksum, metadata_stale, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    "epi-first",
+    "test-novel",
+    "ch-01-first",
+    "This authored epigraph body must not enter the backup snapshot.",
+    `${SYNC_DIR}/projects/test-novel/chapters/ch-01/epigraph.md`,
+    "epigraph-checksum",
+    0,
+    UPDATED_AT
+  );
+  db.prepare(`
+    INSERT INTO epigraph_characters (epigraph_id, project_id, character_id)
+    VALUES (?, ?, ?)
+  `).run("epi-first", "test-novel", "char-elena");
+  db.prepare(`
+    INSERT INTO epigraph_tags (epigraph_id, project_id, tag)
+    VALUES (?, ?, ?)
+  `).run("epi-first", "test-novel", "omen");
+
+  db.prepare(`
+    INSERT INTO characters (character_id, project_id, universe_id, name, role, arc_summary, first_appearance, file_path)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    "char-elena",
+    "test-novel",
+    null,
+    "Elena",
+    "protagonist",
+    "Learns the truth.",
+    "sc-first",
+    `${SYNC_DIR}/projects/test-novel/world/characters/elena.md`
+  );
+  db.prepare(`
+    INSERT INTO characters (character_id, project_id, universe_id, name, role, arc_summary, first_appearance, file_path)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    "char-shared",
+    null,
+    "shared-universe",
+    "Shared Figure",
+    "mentor",
+    "Appears across books.",
+    null,
+    `${SYNC_DIR}/universes/shared-universe/world/characters/shared.md`
+  );
+  db.prepare(`
+    INSERT INTO characters (character_id, project_id, universe_id, name, role, arc_summary, first_appearance, file_path)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    "char-other",
+    "other-novel",
+    null,
+    "Other Book Character",
+    "foil",
+    null,
+    null,
+    `${SYNC_DIR}/projects/other-novel/world/characters/other.md`
+  );
+  db.prepare(`
+    INSERT INTO character_traits (character_id, trait)
+    VALUES (?, ?)
+  `).run("char-elena", "stubborn");
+  db.prepare(`
+    INSERT INTO character_relationships (from_character, to_character, relationship_type, strength, scene_id, note)
+    VALUES (?, ?, ?, ?, ?, ?)
+  `).run("char-elena", "char-other", "knows", "thin", "sc-first", "External reference stays diagnostic.");
+
+  db.prepare(`
+    INSERT INTO places (place_id, project_id, universe_id, name, file_path)
+    VALUES (?, ?, ?, ?, ?)
+  `).run(
+    "place-harbor",
+    "test-novel",
+    null,
+    "Harbor",
+    `${SYNC_DIR}/projects/test-novel/world/places/harbor.md`
+  );
+  db.prepare(`
+    INSERT INTO places (place_id, project_id, universe_id, name, file_path)
+    VALUES (?, ?, ?, ?, ?)
+  `).run(
+    "place-other",
+    "other-novel",
+    null,
+    "Other Place",
+    `${SYNC_DIR}/projects/other-novel/world/places/other.md`
+  );
+
+  db.prepare(`
+    INSERT INTO scene_characters (scene_id, project_id, character_id)
+    VALUES (?, ?, ?)
+  `).run("sc-first", "test-novel", "char-elena");
+  db.prepare(`
+    INSERT INTO scene_characters (scene_id, project_id, character_id)
+    VALUES (?, ?, ?)
+  `).run("sc-first", "test-novel", "char-other");
+  db.prepare(`
+    INSERT INTO scene_places (scene_id, project_id, place_id)
+    VALUES (?, ?, ?)
+  `).run("sc-first", "test-novel", "place-other");
+  db.prepare(`
+    INSERT INTO scene_tags (scene_id, project_id, tag)
+    VALUES (?, ?, ?)
+  `).run("sc-first", "test-novel", "harbor");
+  db.prepare(`
+    INSERT INTO threads (thread_id, project_id, name, status)
+    VALUES (?, ?, ?, ?)
+  `).run("thread-truth", "test-novel", "Truth", "active");
+  db.prepare(`
+    INSERT INTO scene_threads (scene_id, project_id, thread_id, beat)
+    VALUES (?, ?, ?, ?)
+  `).run("sc-first", "test-novel", "thread-truth", "seed");
+
+  db.prepare(`
+    INSERT INTO reference_docs (doc_id, project_id, universe_id, type, title, summary, file_path)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    "ref-law",
+    "test-novel",
+    null,
+    "rule",
+    "Harbor Law",
+    "Sensitive reference summary.",
+    `${SYNC_DIR}/projects/test-novel/world/reference/law.md`
+  );
+  db.prepare(`
+    INSERT INTO reference_docs (doc_id, project_id, universe_id, type, title, summary, file_path)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    "ref-other",
+    "other-novel",
+    null,
+    "rule",
+    "Other Law",
+    null,
+    `${SYNC_DIR}/projects/other-novel/world/reference/other.md`
+  );
+  db.prepare(`
+    INSERT INTO reference_doc_tags (doc_id, tag)
+    VALUES (?, ?)
+  `).run("ref-law", "legal");
+  db.prepare(`
+    INSERT INTO reference_links (source_kind, source_project_id, source_id, target_doc_id, relation, origin)
+    VALUES (?, ?, ?, ?, ?, ?)
+  `).run("scene", "test-novel", "sc-first", "ref-other", "mentions", "explicit");
+  db.prepare(`
+    INSERT INTO reference_links (source_kind, source_project_id, source_id, target_doc_id, relation, origin)
+    VALUES (?, ?, ?, ?, ?, ?)
+  `).run("scene", "other-novel", "sc-other", "ref-law", "mentions", "explicit");
+
+  db.prepare(`
+    INSERT INTO async_jobs (job_id, kind, status, created_at)
+    VALUES (?, ?, ?, ?)
+  `).run("job-secret", "test", "completed", UPDATED_AT);
+}
+
+describe("buildProjectBackup", () => {
+  test("builds deterministic snapshot-first project backups", () => {
+    const db = openDb(":memory:");
+    try {
+      seedProjectBackupFixture(db);
+
+      const first = buildProjectBackup(db, {
+        projectId: "test-novel",
+        syncDir: SYNC_DIR,
+        applicationVersion: "9.9.9",
+      });
+      const second = buildProjectBackup(db, {
+        projectId: "test-novel",
+        syncDir: SYNC_DIR,
+        applicationVersion: "9.9.9",
+      });
+
+      assert.equal(first.ok, true);
+      assert.equal(second.ok, true);
+      assert.equal(renderProjectBackupArtifact(first.snapshot), renderProjectBackupArtifact(second.snapshot));
+      assert.equal(first.manifest.checksums.canonical_snapshot_sha256, second.manifest.checksums.canonical_snapshot_sha256);
+      assert.equal(first.manifest.checksums.canonical_snapshot_sha256, computeProjectBackupSnapshotChecksum(first.snapshot));
+      assert.equal(first.manifest.checksums.bundle_sha256, computeProjectBackupBundleChecksum(first));
+
+      assert.equal(first.manifest.schema_version, 1);
+      assert.equal(first.manifest.compatibility.application_version, "9.9.9");
+      assert.equal(typeof first.manifest.compatibility.sqlite_schema_version, "number");
+      assert.equal(first.manifest.restore_policy.authority, "full_snapshot");
+      assert.equal(first.manifest.restore_policy.custom_delta_chains, false);
+      assert.equal(first.manifest.restore_policy.event_replay_required, false);
+      assert.equal(first.manifest.operation_history.supported, false);
+
+      assert.deepEqual(first.snapshot.chapters.map(row => row.chapter_id), ["ch-01-first", "ch-02-second"]);
+      assert.deepEqual(first.snapshot.scenes.map(row => row.scene_id), ["sc-first", "sc-second"]);
+      assert.equal(first.snapshot.chapters[0].source_path, "projects/test-novel/chapters/ch-01");
+      assert.equal(first.snapshot.scenes[0].file_path, "projects/test-novel/chapters/ch-01/sc-first.md");
+      assert.equal(first.snapshot.characters.find(row => row.character_id === "char-shared").file_path, "universes/shared-universe/world/characters/shared.md");
+    } finally {
+      db.close();
+    }
+  });
+
+  test("keeps prose bodies and excluded runtime state out of restore authority", () => {
+    const db = openDb(":memory:");
+    try {
+      seedProjectBackupFixture(db);
+
+      const result = buildProjectBackup(db, {
+        projectId: "test-novel",
+        syncDir: SYNC_DIR,
+      });
+
+      assert.equal(result.ok, true);
+      assert.equal(result.snapshot.epigraphs[0].body, undefined);
+      assert.equal(result.manifest.privacy.includes_authored_prose_bodies, false);
+      assert.ok(result.manifest.coverage.excluded_tables.includes("async_jobs"));
+      assert.ok(result.manifest.coverage.excluded_tables.includes("schema_version"));
+
+      const rendered = renderProjectBackupArtifact(result.snapshot);
+      assert.equal(rendered.includes("This authored epigraph body must not enter"), false);
+      assert.equal(rendered.includes("job-secret"), false);
+    } finally {
+      db.close();
+    }
+  });
+
+  test("represents cross-scope references without granting restore authority over other projects", () => {
+    const db = openDb(":memory:");
+    try {
+      seedProjectBackupFixture(db);
+
+      const result = buildProjectBackup(db, {
+        projectId: "test-novel",
+        syncDir: SYNC_DIR,
+      });
+
+      assert.equal(result.ok, true);
+      assert.deepEqual(result.snapshot.external_references.character_ids, ["char-other"]);
+      assert.deepEqual(result.snapshot.external_references.place_ids, ["place-other"]);
+      assert.deepEqual(result.snapshot.external_references.reference_doc_ids, ["ref-other"]);
+      assert.equal(result.snapshot.characters.some(row => row.character_id === "char-other"), false);
+      assert.equal(result.snapshot.places.some(row => row.place_id === "place-other"), false);
+      assert.equal(result.snapshot.reference_docs.some(row => row.doc_id === "ref-other"), false);
+      assert.equal(result.snapshot.reference_links.some(row => row.source_project_id === "other-novel"), false);
+      assert.equal(result.manifest.coverage.counts.external_character_references, 1);
+    } finally {
+      db.close();
+    }
+  });
+
+  test("returns a structured not-found result for unknown projects", () => {
+    const db = openDb(":memory:");
+    try {
+      const result = buildProjectBackup(db, { projectId: "missing" });
+
+      assert.equal(result.ok, false);
+      assert.equal(result.error.code, "NOT_FOUND");
+      assert.equal(result.error.details.project_id, "missing");
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/src/test/unit/project-backup.test.mjs
+++ b/src/test/unit/project-backup.test.mjs
@@ -172,6 +172,19 @@ function seedProjectBackupFixture(db) {
     INSERT INTO characters (character_id, project_id, universe_id, name, role, arc_summary, first_appearance, file_path)
     VALUES (?, ?, ?, ?, ?, ?, ?, ?)
   `).run(
+    "char-unreferenced",
+    null,
+    "shared-universe",
+    "Unreferenced Figure",
+    "background",
+    "Should not enter a project backup without a direct reference.",
+    null,
+    `${SYNC_DIR}/universes/shared-universe/world/characters/unreferenced.md`
+  );
+  db.prepare(`
+    INSERT INTO characters (character_id, project_id, universe_id, name, role, arc_summary, first_appearance, file_path)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
     "char-other",
     "other-novel",
     null,
@@ -210,6 +223,26 @@ function seedProjectBackupFixture(db) {
     "Other Place",
     `${SYNC_DIR}/projects/other-novel/world/places/other.md`
   );
+  db.prepare(`
+    INSERT INTO places (place_id, project_id, universe_id, name, file_path)
+    VALUES (?, ?, ?, ?, ?)
+  `).run(
+    "place-shared",
+    null,
+    "shared-universe",
+    "Shared Harbor",
+    `${SYNC_DIR}/universes/shared-universe/world/places/shared-harbor.md`
+  );
+  db.prepare(`
+    INSERT INTO places (place_id, project_id, universe_id, name, file_path)
+    VALUES (?, ?, ?, ?, ?)
+  `).run(
+    "place-unreferenced",
+    null,
+    "shared-universe",
+    "Unreferenced Place",
+    `${SYNC_DIR}/universes/shared-universe/world/places/unreferenced.md`
+  );
 
   db.prepare(`
     INSERT INTO scene_characters (scene_id, project_id, character_id)
@@ -218,11 +251,19 @@ function seedProjectBackupFixture(db) {
   db.prepare(`
     INSERT INTO scene_characters (scene_id, project_id, character_id)
     VALUES (?, ?, ?)
+  `).run("sc-first", "test-novel", "char-shared");
+  db.prepare(`
+    INSERT INTO scene_characters (scene_id, project_id, character_id)
+    VALUES (?, ?, ?)
   `).run("sc-first", "test-novel", "char-other");
   db.prepare(`
     INSERT INTO scene_places (scene_id, project_id, place_id)
     VALUES (?, ?, ?)
   `).run("sc-first", "test-novel", "place-other");
+  db.prepare(`
+    INSERT INTO scene_places (scene_id, project_id, place_id)
+    VALUES (?, ?, ?)
+  `).run("sc-first", "test-novel", "place-shared");
   db.prepare(`
     INSERT INTO scene_tags (scene_id, project_id, tag)
     VALUES (?, ?, ?)
@@ -261,13 +302,61 @@ function seedProjectBackupFixture(db) {
     `${SYNC_DIR}/projects/other-novel/world/reference/other.md`
   );
   db.prepare(`
+    INSERT INTO reference_docs (doc_id, project_id, universe_id, type, title, summary, file_path)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    "ref-shared",
+    null,
+    "shared-universe",
+    "lore",
+    "Shared Lore",
+    "Directly referenced universe lore.",
+    `${SYNC_DIR}/universes/shared-universe/world/reference/shared.md`
+  );
+  db.prepare(`
+    INSERT INTO reference_docs (doc_id, project_id, universe_id, type, title, summary, file_path)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    "ref-shared-chain",
+    null,
+    "shared-universe",
+    "lore",
+    "Shared Lore Chain",
+    "Referenced by another included reference doc.",
+    `${SYNC_DIR}/universes/shared-universe/world/reference/shared-chain.md`
+  );
+  db.prepare(`
+    INSERT INTO reference_docs (doc_id, project_id, universe_id, type, title, summary, file_path)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    "ref-unreferenced",
+    null,
+    "shared-universe",
+    "lore",
+    "Unreferenced Lore",
+    "Should not enter a project backup without a reference.",
+    `${SYNC_DIR}/universes/shared-universe/world/reference/unreferenced.md`
+  );
+  db.prepare(`
     INSERT INTO reference_doc_tags (doc_id, tag)
     VALUES (?, ?)
   `).run("ref-law", "legal");
   db.prepare(`
+    INSERT INTO reference_doc_tags (doc_id, tag)
+    VALUES (?, ?)
+  `).run("ref-shared", "shared");
+  db.prepare(`
     INSERT INTO reference_links (source_kind, source_project_id, source_id, target_doc_id, relation, origin)
     VALUES (?, ?, ?, ?, ?, ?)
   `).run("scene", "test-novel", "sc-first", "ref-other", "mentions", "explicit");
+  db.prepare(`
+    INSERT INTO reference_links (source_kind, source_project_id, source_id, target_doc_id, relation, origin)
+    VALUES (?, ?, ?, ?, ?, ?)
+  `).run("scene", "test-novel", "sc-first", "ref-shared", "mentions", "explicit");
+  db.prepare(`
+    INSERT INTO reference_links (source_kind, source_project_id, source_id, target_doc_id, relation, origin)
+    VALUES (?, ?, ?, ?, ?, ?)
+  `).run("reference", "", "ref-shared", "ref-shared-chain", "expands", "explicit");
   db.prepare(`
     INSERT INTO reference_links (source_kind, source_project_id, source_id, target_doc_id, relation, origin)
     VALUES (?, ?, ?, ?, ?, ?)
@@ -325,6 +414,13 @@ describe("buildProjectBackup", () => {
       assert.equal(first.snapshot.chapters[0].source_path, "projects/test-novel/chapters/ch-01");
       assert.equal(first.snapshot.scenes[0].file_path, "projects/test-novel/chapters/ch-01/sc-first.md");
       assert.equal(first.snapshot.characters.find(row => row.character_id === "char-shared").file_path, "universes/shared-universe/world/characters/shared.md");
+      assert.equal(first.snapshot.characters.some(row => row.character_id === "char-unreferenced"), false);
+      assert.equal(first.snapshot.places.some(row => row.place_id === "place-shared"), true);
+      assert.equal(first.snapshot.places.some(row => row.place_id === "place-unreferenced"), false);
+      assert.equal(first.snapshot.reference_docs.some(row => row.doc_id === "ref-shared"), true);
+      assert.equal(first.snapshot.reference_docs.some(row => row.doc_id === "ref-shared-chain"), true);
+      assert.equal(first.snapshot.reference_docs.some(row => row.doc_id === "ref-unreferenced"), false);
+      assert.equal(first.snapshot.reference_doc_tags.some(row => row.doc_id === "ref-shared"), true);
     } finally {
       db.close();
     }

--- a/src/test/unit/project-backup.test.mjs
+++ b/src/test/unit/project-backup.test.mjs
@@ -1,11 +1,15 @@
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { openDb } from "../../core/db.js";
 import {
   buildProjectBackup,
   computeProjectBackupBundleChecksum,
   computeProjectBackupSnapshotChecksum,
   renderProjectBackupArtifact,
+  writeProjectBackupFiles,
 } from "../../structure/project-backup.js";
 
 const SYNC_DIR = "/tmp/sync";
@@ -300,6 +304,7 @@ describe("buildProjectBackup", () => {
       assert.equal(first.manifest.checksums.bundle_sha256, computeProjectBackupBundleChecksum(first));
 
       assert.equal(first.manifest.schema_version, 1);
+      assert.equal(first.manifest.backup_location, "project-backups/test-novel/");
       assert.equal(first.manifest.compatibility.application_version, "9.9.9");
       assert.equal(typeof first.manifest.compatibility.sqlite_schema_version, "number");
       assert.equal(first.manifest.restore_policy.authority, "full_snapshot");
@@ -375,6 +380,41 @@ describe("buildProjectBackup", () => {
       assert.equal(result.error.details.project_id, "missing");
     } finally {
       db.close();
+    }
+  });
+
+  test("writes backup artifacts only when rendered content changes", () => {
+    const db = openDb(":memory:");
+    const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), "mcp-writing-project-backup-"));
+    try {
+      seedProjectBackupFixture(db);
+      const result = buildProjectBackup(db, {
+        projectId: "test-novel",
+        syncDir: SYNC_DIR,
+        backupLocation: "custom-backups/test-novel/",
+      });
+
+      assert.equal(result.ok, true);
+      assert.equal(result.manifest.backup_location, "custom-backups/test-novel/");
+
+      const firstWrite = writeProjectBackupFiles(result, { outputDir });
+      assert.deepEqual(firstWrite.written, {
+        manifest: true,
+        canonical_snapshot: true,
+      });
+      const manifestBefore = fs.statSync(firstWrite.manifestPath).mtimeMs;
+      const snapshotBefore = fs.statSync(firstWrite.snapshotPath).mtimeMs;
+
+      const secondWrite = writeProjectBackupFiles(result, { outputDir });
+      assert.deepEqual(secondWrite.written, {
+        manifest: false,
+        canonical_snapshot: false,
+      });
+      assert.equal(fs.statSync(secondWrite.manifestPath).mtimeMs, manifestBefore);
+      assert.equal(fs.statSync(secondWrite.snapshotPath).mtimeMs, snapshotBefore);
+    } finally {
+      db.close();
+      fs.rmSync(outputDir, { recursive: true, force: true });
     }
   });
 });

--- a/src/tools/editing.js
+++ b/src/tools/editing.js
@@ -19,6 +19,10 @@ import {
   PROSE_STYLEGUIDE_SKILL_DIRNAME,
 } from "../styleguide/prose-styleguide-skill.js";
 import { analyzeSceneStyleguideDrift } from "../styleguide/prose-styleguide-drift.js";
+import {
+  createToolActor,
+  refreshProjectBackupAfterMutation,
+} from "../structure/project-backup-refresh.js";
 
 function renderSceneContent(metadata, revisedProse) {
   const hasFrontmatter = metadata && Object.keys(metadata).length > 0;
@@ -217,6 +221,7 @@ function evaluateStyleguidePolicy({
 export function registerEditingTools(s, {
   db,
   SYNC_DIR,
+  MCP_SERVER_VERSION = "0.0.0",
   GIT_ENABLED,
   STYLEGUIDE_ENFORCEMENT_MODE,
   errorResponse,
@@ -224,6 +229,14 @@ export function registerEditingTools(s, {
   pendingProposals,
   generateProposalId,
 }) {
+  function backupMutationFields(backupResult) {
+    return {
+      operation_history: backupResult.operation_history,
+      backup_refresh: backupResult.backup_refresh,
+      backup_warnings: backupResult.backup_warnings,
+    };
+  }
+
   // ---- propose_edit --------------------------------------------------------
   s.tool(
     "propose_edit",
@@ -501,6 +514,25 @@ export function registerEditingTools(s, {
             managedStructure: isManagedStructureProject(db, proposal.project_id ?? project_id),
           });
           pendingProposals.delete(proposal_id);
+          const backupResult = refreshProjectBackupAfterMutation(db, {
+            syncDir: SYNC_DIR,
+            projectId: proposal.project_id ?? project_id,
+            applicationVersion: MCP_SERVER_VERSION,
+            operation: "commit_edit",
+            actor: createToolActor("commit_edit"),
+            affected: {
+              scenes: [scene_id],
+            },
+            summary: `Refreshed scene "${scene_id}" after no-op edit commit.`,
+            before: null,
+            after: {
+              scene: {
+                scene_id,
+                project_id: proposal.project_id ?? project_id,
+                noop: true,
+              },
+            },
+          });
 
           return jsonResponse({
             ok: true,
@@ -511,6 +543,7 @@ export function registerEditingTools(s, {
             noop: true,
             message: `Proposal for scene '${scene_id}' matches the current file. Nothing was written.`,
             next_step: "No changes were applied. If you still need edits, call propose_edit with revised prose.",
+            ...backupMutationFields(backupResult),
           });
         }
 
@@ -530,6 +563,27 @@ export function registerEditingTools(s, {
         });
 
         pendingProposals.delete(proposal_id);
+        const backupResult = refreshProjectBackupAfterMutation(db, {
+          syncDir: SYNC_DIR,
+          projectId: proposal.project_id ?? project_id,
+          applicationVersion: MCP_SERVER_VERSION,
+          operation: "commit_edit",
+          actor: createToolActor("commit_edit"),
+          affected: {
+            scenes: [scene_id],
+          },
+          summary: `Committed prose edit for scene "${scene_id}".`,
+          before: {
+            prose_digest: digestFor(proposal.original_prose),
+          },
+          after: {
+            scene: {
+              scene_id,
+              project_id: proposal.project_id ?? project_id,
+              snapshot_commit: snapshot.commit_hash,
+            },
+          },
+        });
 
         return jsonResponse({
           ok: true,
@@ -540,6 +594,7 @@ export function registerEditingTools(s, {
           noop: false,
           message: `Applied edit to scene '${scene_id}'${snapshot.commit_hash ? ` (snapshot: ${snapshot.commit_hash.substring(0, 7)})` : " (no pre-edit snapshot needed)"}`,
           next_step: "Edit applied. Run get_scene_prose to verify prose, then continue with additional targeted edits if needed.",
+          ...backupMutationFields(backupResult),
         });
       } catch (err) {
         if (err.code === "ENOENT") {

--- a/src/tools/metadata.js
+++ b/src/tools/metadata.js
@@ -545,6 +545,10 @@ export function registerMetadataTools(s, {
       if (!SYNC_DIR_WRITABLE) {
         return errorResponse("READ_ONLY", "Cannot write thread links: sync dir is read-only.");
       }
+      const projectIdCheck = validateProjectId(project_id);
+      if (!projectIdCheck.ok) {
+        return errorResponse("INVALID_PROJECT_ID", projectIdCheck.reason, { project_id });
+      }
 
       const existingThread = db.prepare(`SELECT thread_id, project_id FROM threads WHERE thread_id = ?`).get(thread_id);
       if (existingThread && existingThread.project_id !== project_id) {

--- a/src/tools/metadata.js
+++ b/src/tools/metadata.js
@@ -28,16 +28,12 @@ import {
   upsertExplicitReferenceLinkRow,
   upsertSerializedReferenceLinks,
 } from "./reference-link-persistence.js";
-import { refreshProjectBackupAfterMutation } from "../structure/project-backup-refresh.js";
+import {
+  createToolActor,
+  refreshProjectBackupAfterMutation,
+} from "../structure/project-backup-refresh.js";
 
 const STRUCTURAL_SCENE_METADATA_FIELDS = ["part", "chapter", "chapter_id", "timeline_position"];
-
-function createToolActor(id) {
-  return {
-    type: "tool",
-    id,
-  };
-}
 
 function emptyBackupMutationResult() {
   return {

--- a/src/tools/metadata.js
+++ b/src/tools/metadata.js
@@ -28,12 +28,16 @@ import {
   upsertExplicitReferenceLinkRow,
   upsertSerializedReferenceLinks,
 } from "./reference-link-persistence.js";
-import {
-  appendProjectBackupOperationRecord,
-  buildProjectBackupOperationRecord,
-} from "../structure/project-backup-operations.js";
+import { refreshProjectBackupAfterMutation } from "../structure/project-backup-refresh.js";
 
 const STRUCTURAL_SCENE_METADATA_FIELDS = ["part", "chapter", "chapter_id", "timeline_position"];
+
+function createToolActor(id) {
+  return {
+    type: "tool",
+    id,
+  };
+}
 
 function getProvidedStructuralSceneMetadataFields(fields) {
   return STRUCTURAL_SCENE_METADATA_FIELDS.filter((field) => Object.hasOwn(fields, field));
@@ -688,52 +692,28 @@ export function registerMetadataTools(s, {
         return errorResponse("IO_ERROR", `Failed to create chapter '${plan.chapter.chapter_id}': ${err.message}`);
       }
 
-      const backupWarnings = [];
-      let operationHistory = null;
-      try {
-        const backupDir = path.join(path.resolve(SYNC_DIR), "project-backups", project_id);
-        const operationRecord = buildProjectBackupOperationRecord({
-          operation: "create_chapter",
-          projectId: project_id,
-          applicationVersion: MCP_SERVER_VERSION,
-          actor: {
-            type: "tool",
-            id: "create_chapter",
-          },
-          affected: {
-            chapters: [plan.chapter.chapter_id],
-          },
-          summary: `Created chapter "${plan.chapter.title}" at sort_index ${plan.chapter.sort_index}.`,
-          before: null,
-          after: {
-            chapter: {
-              chapter_id: plan.chapter.chapter_id,
-              project_id: plan.chapter.project_id,
-              title: plan.chapter.title,
-              sort_index: plan.chapter.sort_index,
-              logline: plan.chapter.logline,
-              metadata_stale: plan.chapter.metadata_stale,
-            },
-          },
-        });
-        const appended = appendProjectBackupOperationRecord(operationRecord, { outputDir: backupDir });
-        operationHistory = {
-          appended: appended.appended,
-          path: appended.operationLogPath,
-          relative_path: path.relative(path.resolve(SYNC_DIR), appended.operationLogPath).split(path.sep).join("/"),
-          advisory: true,
-          restore_authority: false,
-        };
-      } catch (err) {
-        backupWarnings.push({
-          code: "OPERATION_LOG_APPEND_FAILED",
-          message: `Chapter was created, but the advisory backup operation log could not be updated: ${err.message}`,
-          details: {
-            project_id,
+      const backupResult = refreshProjectBackupAfterMutation(db, {
+        syncDir: SYNC_DIR,
+        projectId: project_id,
+        applicationVersion: MCP_SERVER_VERSION,
+        operation: "create_chapter",
+        actor: createToolActor("create_chapter"),
+        affected: {
+          chapters: [plan.chapter.chapter_id],
+        },
+        summary: `Created chapter "${plan.chapter.title}" at sort_index ${plan.chapter.sort_index}.`,
+        before: null,
+        after: {
+          chapter: {
             chapter_id: plan.chapter.chapter_id,
+            project_id: plan.chapter.project_id,
+            title: plan.chapter.title,
+            sort_index: plan.chapter.sort_index,
+            logline: plan.chapter.logline,
+            metadata_stale: plan.chapter.metadata_stale,
           },
-        });
-      }
+        },
+      });
 
       return jsonResponse({
         ok: true,
@@ -747,8 +727,9 @@ export function registerMetadataTools(s, {
           metadata_stale: plan.chapter.metadata_stale,
         },
         diagnostics: plan.diagnostics,
-        operation_history: operationHistory,
-        backup_warnings: backupWarnings,
+        operation_history: backupResult.operation_history,
+        backup_refresh: backupResult.backup_refresh,
+        backup_warnings: backupResult.backup_warnings,
         next_steps: [
           "Use assign_scene_to_chapter to place unchaptered scenes in this chapter.",
           "Run diagnose_structure if existing folders or sidecars may imply conflicting structure.",
@@ -835,6 +816,39 @@ export function registerMetadataTools(s, {
         failureCode: "SCENE_SIDECAR_UPDATE_FAILED",
         syncDir: SYNC_DIR,
       });
+      const backupResult = refreshProjectBackupAfterMutation(db, {
+        syncDir: SYNC_DIR,
+        projectId: project_id,
+        applicationVersion: MCP_SERVER_VERSION,
+        operation: "rename_chapter",
+        actor: createToolActor("rename_chapter"),
+        affected: {
+          chapters: [plan.chapter.chapter_id],
+          scenes: linkedScenes.map(scene => scene.scene_id),
+        },
+        summary: `Renamed chapter "${plan.previousChapter.title}" to "${plan.chapter.title}".`,
+        before: {
+          chapter: {
+            chapter_id: plan.previousChapter.chapter_id,
+            title: plan.previousChapter.title,
+            sort_index: plan.previousChapter.sort_index,
+          },
+        },
+        after: {
+          chapter: {
+            chapter_id: plan.chapter.chapter_id,
+            project_id: plan.chapter.project_id,
+            title: plan.chapter.title,
+            sort_index: plan.chapter.sort_index,
+            logline: plan.chapter.logline,
+            metadata_stale: plan.chapter.metadata_stale,
+          },
+        },
+        metadata: {
+          updated_scene_count: linkedScenes.length,
+          updated_sidecar_count: sidecarWriteResult.updatedCount,
+        },
+      });
 
       return jsonResponse({
         ok: true,
@@ -854,6 +868,9 @@ export function registerMetadataTools(s, {
           ...plan.diagnostics,
           ...sidecarWriteResult.diagnostics,
         ],
+        operation_history: backupResult.operation_history,
+        backup_refresh: backupResult.backup_refresh,
+        backup_warnings: backupResult.backup_warnings,
         next_steps: [
           "Use list_chapters to confirm the canonical title.",
           "Run diagnose_structure if folder-derived structure may still use the previous chapter title.",
@@ -941,6 +958,39 @@ export function registerMetadataTools(s, {
         failureCode: "SCENE_SIDECAR_UPDATE_FAILED",
         syncDir: SYNC_DIR,
       });
+      const backupResult = refreshProjectBackupAfterMutation(db, {
+        syncDir: SYNC_DIR,
+        projectId: project_id,
+        applicationVersion: MCP_SERVER_VERSION,
+        operation: "reorder_chapter",
+        actor: createToolActor("reorder_chapter"),
+        affected: {
+          chapters: [plan.chapter.chapter_id],
+          scenes: linkedScenes.map(scene => scene.scene_id),
+        },
+        summary: `Reordered chapter "${plan.chapter.title}" from ${plan.previousChapter.sort_index} to ${plan.chapter.sort_index}.`,
+        before: {
+          chapter: {
+            chapter_id: plan.previousChapter.chapter_id,
+            title: plan.previousChapter.title,
+            sort_index: plan.previousChapter.sort_index,
+          },
+        },
+        after: {
+          chapter: {
+            chapter_id: plan.chapter.chapter_id,
+            project_id: plan.chapter.project_id,
+            title: plan.chapter.title,
+            sort_index: plan.chapter.sort_index,
+            logline: plan.chapter.logline,
+            metadata_stale: plan.chapter.metadata_stale,
+          },
+        },
+        metadata: {
+          updated_scene_count: linkedScenes.length,
+          updated_sidecar_count: sidecarWriteResult.updatedCount,
+        },
+      });
 
       return jsonResponse({
         ok: true,
@@ -960,6 +1010,9 @@ export function registerMetadataTools(s, {
           ...plan.diagnostics,
           ...sidecarWriteResult.diagnostics,
         ],
+        operation_history: backupResult.operation_history,
+        backup_refresh: backupResult.backup_refresh,
+        backup_warnings: backupResult.backup_warnings,
         next_steps: [
           "Use list_chapters to confirm canonical order.",
           "Run diagnose_structure if folder-derived structure may still use the previous order.",
@@ -1023,6 +1076,40 @@ export function registerMetadataTools(s, {
           failureCode: "EPIGRAPH_SIDECAR_UPDATE_FAILED",
           syncDir: SYNC_DIR,
         });
+        const backupResult = refreshProjectBackupAfterMutation(db, {
+          syncDir: SYNC_DIR,
+          projectId: project_id,
+          applicationVersion: MCP_SERVER_VERSION,
+          operation: "attach_epigraph",
+          actor: createToolActor("attach_epigraph"),
+          affected: {
+            epigraphs: [plan.epigraph.epigraph_id],
+            chapters: [plan.chapter.chapter_id],
+          },
+          summary: `Attached epigraph "${plan.epigraph.epigraph_id}" to chapter "${plan.chapter.title}".`,
+          before: {
+            epigraph: {
+              epigraph_id: plan.epigraph.epigraph_id,
+              chapter_id: plan.previousChapter?.chapter_id ?? null,
+            },
+          },
+          after: {
+            epigraph: {
+              epigraph_id: plan.epigraph.epigraph_id,
+              project_id: plan.epigraph.project_id,
+              chapter_id: plan.epigraph.chapter_id,
+              metadata_stale: plan.epigraph.metadata_stale,
+            },
+            chapter: {
+              chapter_id: plan.chapter.chapter_id,
+              title: plan.chapter.title,
+              sort_index: plan.chapter.sort_index,
+            },
+          },
+          metadata: {
+            updated_sidecar_count: sidecarWriteResult.updatedCount,
+          },
+        });
 
         return jsonResponse({
           ok: true,
@@ -1050,6 +1137,9 @@ export function registerMetadataTools(s, {
             ...plan.diagnostics,
             ...sidecarWriteResult.diagnostics,
           ],
+          operation_history: backupResult.operation_history,
+          backup_refresh: backupResult.backup_refresh,
+          backup_warnings: backupResult.backup_warnings,
           next_steps: [
             "Use find_epigraphs to confirm the canonical epigraph attachment.",
             "Run diagnose_structure if folder-derived structure may still imply the previous chapter.",
@@ -1200,6 +1290,40 @@ export function registerMetadataTools(s, {
             managedStructure: isManagedStructureProject(db, project_id),
           });
         }
+        const backupResult = refreshProjectBackupAfterMutation(db, {
+          syncDir: SYNC_DIR,
+          projectId: project_id,
+          applicationVersion: MCP_SERVER_VERSION,
+          operation: "move_scene",
+          actor: createToolActor("move_scene"),
+          affected: {
+            scenes: [scene_id],
+            chapters: [
+              plan.previousChapterId ?? null,
+              plan.assignedChapter?.chapter_id ?? null,
+            ].filter(Boolean),
+          },
+          summary: `Moved scene "${scene_id}" to ${plan.assignedChapter?.chapter_id ?? "no chapter"} at timeline_position ${plan.timelinePosition ?? "unchanged"}.`,
+          before: {
+            scene: {
+              scene_id,
+              project_id,
+              chapter_id: plan.previousChapterId ?? null,
+              timeline_position: plan.previousTimelinePosition ?? null,
+            },
+          },
+          after: {
+            scene: {
+              scene_id,
+              project_id,
+              chapter_id: plan.assignedChapter?.chapter_id ?? null,
+              timeline_position: plan.timelinePosition ?? null,
+            },
+          },
+          metadata: {
+            updated_sidecar_count: sidecarMirror.updatedCount,
+          },
+        });
 
         return jsonResponse({
           ok: true,
@@ -1223,6 +1347,9 @@ export function registerMetadataTools(s, {
             },
             ...sidecarMirror.diagnostics,
           ],
+          operation_history: backupResult.operation_history,
+          backup_refresh: backupResult.backup_refresh,
+          backup_warnings: backupResult.backup_warnings,
           next_steps: [
             "Use find_scenes to confirm the scene's canonical chapter and timeline_position.",
             "Run diagnose_structure if folder-derived structure may still imply the previous placement.",
@@ -1318,6 +1445,40 @@ export function registerMetadataTools(s, {
             managedStructure: isManagedStructureProject(db, project_id),
           });
         }
+        const backupResult = refreshProjectBackupAfterMutation(db, {
+          syncDir: SYNC_DIR,
+          projectId: project_id,
+          applicationVersion: MCP_SERVER_VERSION,
+          operation: "assign_scene_to_chapter",
+          actor: createToolActor("assign_scene_to_chapter"),
+          affected: {
+            scenes: [scene_id],
+            chapters: [
+              plan.previousChapterId ?? scene.chapter_id ?? null,
+              plan.assignedChapter?.chapter_id ?? null,
+            ].filter(Boolean),
+          },
+          summary: chapter === null
+            ? `Cleared chapter assignment for scene "${scene_id}".`
+            : `Assigned scene "${scene_id}" to chapter "${plan.assignedChapter.chapter_id}".`,
+          before: {
+            scene: {
+              scene_id,
+              project_id,
+              chapter_id: plan.previousChapterId ?? scene.chapter_id ?? null,
+            },
+          },
+          after: {
+            scene: {
+              scene_id,
+              project_id,
+              chapter_id: plan.assignedChapter?.chapter_id ?? null,
+            },
+          },
+          metadata: {
+            updated_sidecar_count: sidecarMirror.updatedCount,
+          },
+        });
 
         return jsonResponse({
           ok: true,
@@ -1328,6 +1489,9 @@ export function registerMetadataTools(s, {
           chapter: plan.assignedChapter,
           updated_sidecar_count: sidecarMirror.updatedCount,
           diagnostics: sidecarMirror.diagnostics,
+          operation_history: backupResult.operation_history,
+          backup_refresh: backupResult.backup_refresh,
+          backup_warnings: backupResult.backup_warnings,
         });
       } catch (err) {
         if (err?.name === "CoreValidationError") {

--- a/src/tools/metadata.js
+++ b/src/tools/metadata.js
@@ -28,6 +28,10 @@ import {
   upsertExplicitReferenceLinkRow,
   upsertSerializedReferenceLinks,
 } from "./reference-link-persistence.js";
+import {
+  appendProjectBackupOperationRecord,
+  buildProjectBackupOperationRecord,
+} from "../structure/project-backup-operations.js";
 
 const STRUCTURAL_SCENE_METADATA_FIELDS = ["part", "chapter", "chapter_id", "timeline_position"];
 
@@ -317,6 +321,7 @@ export function registerMetadataTools(s, {
   db,
   SYNC_DIR,
   SYNC_DIR_WRITABLE,
+  MCP_SERVER_VERSION = "0.0.0",
   errorResponse,
   jsonResponse,
   createCanonicalWorldEntity,
@@ -683,6 +688,53 @@ export function registerMetadataTools(s, {
         return errorResponse("IO_ERROR", `Failed to create chapter '${plan.chapter.chapter_id}': ${err.message}`);
       }
 
+      const backupWarnings = [];
+      let operationHistory = null;
+      try {
+        const backupDir = path.join(path.resolve(SYNC_DIR), "project-backups", project_id);
+        const operationRecord = buildProjectBackupOperationRecord({
+          operation: "create_chapter",
+          projectId: project_id,
+          applicationVersion: MCP_SERVER_VERSION,
+          actor: {
+            type: "tool",
+            id: "create_chapter",
+          },
+          affected: {
+            chapters: [plan.chapter.chapter_id],
+          },
+          summary: `Created chapter "${plan.chapter.title}" at sort_index ${plan.chapter.sort_index}.`,
+          before: null,
+          after: {
+            chapter: {
+              chapter_id: plan.chapter.chapter_id,
+              project_id: plan.chapter.project_id,
+              title: plan.chapter.title,
+              sort_index: plan.chapter.sort_index,
+              logline: plan.chapter.logline,
+              metadata_stale: plan.chapter.metadata_stale,
+            },
+          },
+        });
+        const appended = appendProjectBackupOperationRecord(operationRecord, { outputDir: backupDir });
+        operationHistory = {
+          appended: appended.appended,
+          path: appended.operationLogPath,
+          relative_path: path.relative(path.resolve(SYNC_DIR), appended.operationLogPath).split(path.sep).join("/"),
+          advisory: true,
+          restore_authority: false,
+        };
+      } catch (err) {
+        backupWarnings.push({
+          code: "OPERATION_LOG_APPEND_FAILED",
+          message: `Chapter was created, but the advisory backup operation log could not be updated: ${err.message}`,
+          details: {
+            project_id,
+            chapter_id: plan.chapter.chapter_id,
+          },
+        });
+      }
+
       return jsonResponse({
         ok: true,
         action: "created",
@@ -695,6 +747,8 @@ export function registerMetadataTools(s, {
           metadata_stale: plan.chapter.metadata_stale,
         },
         diagnostics: plan.diagnostics,
+        operation_history: operationHistory,
+        backup_warnings: backupWarnings,
         next_steps: [
           "Use assign_scene_to_chapter to place unchaptered scenes in this chapter.",
           "Run diagnose_structure if existing folders or sidecars may imply conflicting structure.",

--- a/src/tools/metadata.js
+++ b/src/tools/metadata.js
@@ -39,6 +39,51 @@ function createToolActor(id) {
   };
 }
 
+function emptyBackupMutationResult() {
+  return {
+    operation_history: null,
+    backup_refresh: null,
+    backup_warnings: [],
+  };
+}
+
+function refreshProjectScopedBackupAfterMutation(db, {
+  syncDir,
+  projectId,
+  applicationVersion,
+  operation,
+  actor,
+  affected,
+  before,
+  after,
+  summary,
+  metadata,
+}) {
+  if (!projectId) {
+    return emptyBackupMutationResult();
+  }
+  return refreshProjectBackupAfterMutation(db, {
+    syncDir,
+    projectId,
+    applicationVersion,
+    operation,
+    actor,
+    affected,
+    before,
+    after,
+    summary,
+    metadata,
+  });
+}
+
+function backupMutationFields(backupResult) {
+  return {
+    operation_history: backupResult.operation_history,
+    backup_refresh: backupResult.backup_refresh,
+    backup_warnings: backupResult.backup_warnings,
+  };
+}
+
 function getProvidedStructuralSceneMetadataFields(fields) {
   return STRUCTURAL_SCENE_METADATA_FIELDS.filter((field) => Object.hasOwn(fields, field));
 }
@@ -373,8 +418,34 @@ export function registerMetadataTools(s, {
           universeId: universe_id,
           meta: fields ?? {},
         });
+        const backupResult = refreshProjectScopedBackupAfterMutation(db, {
+          syncDir: SYNC_DIR,
+          projectId: project_id,
+          applicationVersion: MCP_SERVER_VERSION,
+          operation: "create_character_sheet",
+          actor: createToolActor("create_character_sheet"),
+          affected: {
+            characters: [result.id],
+          },
+          summary: `${result.created ? "Created" : "Reused"} character sheet "${result.id}".`,
+          before: null,
+          after: {
+            character: {
+              character_id: result.id,
+              project_id: result.project_id,
+              universe_id: result.universe_id,
+              name,
+            },
+          },
+        });
 
-        return jsonResponse({ ok: true, action: result.created ? "created" : "exists", kind: "character", ...result });
+        return jsonResponse({
+          ok: true,
+          action: result.created ? "created" : "exists",
+          kind: "character",
+          ...result,
+          ...backupMutationFields(backupResult),
+        });
       } catch (err) {
         if (err?.name === "CoreValidationError") {
           return errorResponse(err.code, err.message, err.details);
@@ -425,8 +496,34 @@ export function registerMetadataTools(s, {
           universeId: universe_id,
           meta: fields ?? {},
         });
+        const backupResult = refreshProjectScopedBackupAfterMutation(db, {
+          syncDir: SYNC_DIR,
+          projectId: project_id,
+          applicationVersion: MCP_SERVER_VERSION,
+          operation: "create_place_sheet",
+          actor: createToolActor("create_place_sheet"),
+          affected: {
+            places: [result.id],
+          },
+          summary: `${result.created ? "Created" : "Reused"} place sheet "${result.id}".`,
+          before: null,
+          after: {
+            place: {
+              place_id: result.id,
+              project_id: result.project_id,
+              universe_id: result.universe_id,
+              name,
+            },
+          },
+        });
 
-        return jsonResponse({ ok: true, action: result.created ? "created" : "exists", kind: "place", ...result });
+        return jsonResponse({
+          ok: true,
+          action: result.created ? "created" : "exists",
+          kind: "place",
+          ...result,
+          ...backupMutationFields(backupResult),
+        });
       } catch (err) {
         if (err?.name === "CoreValidationError") {
           return errorResponse(err.code, err.message, err.details);
@@ -484,12 +581,30 @@ export function registerMetadataTools(s, {
       const thread = db.prepare(`SELECT * FROM threads WHERE thread_id = ?`).get(thread_id);
       const link = db.prepare(`SELECT scene_id, project_id, thread_id, beat FROM scene_threads WHERE scene_id = ? AND project_id = ? AND thread_id = ?`)
         .get(scene_id, project_id, thread_id);
+      const backupResult = refreshProjectScopedBackupAfterMutation(db, {
+        syncDir: SYNC_DIR,
+        projectId: project_id,
+        applicationVersion: MCP_SERVER_VERSION,
+        operation: "upsert_thread_link",
+        actor: createToolActor("upsert_thread_link"),
+        affected: {
+          threads: [thread_id],
+          scenes: [scene_id],
+        },
+        summary: `Upserted thread "${thread_id}" link for scene "${scene_id}".`,
+        before: null,
+        after: {
+          thread,
+          link,
+        },
+      });
 
       return jsonResponse({
         ok: true,
         action: "upserted",
         thread,
         link,
+        ...backupMutationFields(backupResult),
       });
     }
   );
@@ -520,7 +635,7 @@ export function registerMetadataTools(s, {
       }
 
       const targetDoc = db.prepare(`
-        SELECT doc_id
+        SELECT doc_id, project_id
         FROM reference_docs
         WHERE doc_id = ?
       `).get(target_doc_id);
@@ -632,11 +747,29 @@ export function registerMetadataTools(s, {
         FROM reference_links
         WHERE source_kind = ? AND source_project_id = ? AND source_id = ? AND target_doc_id = ? AND relation = ?
       `).get(source_kind, resolvedSourceProjectId, source_id, target_doc_id, normalizedRelation);
+      const backupProjectId = resolvedSourceProjectId || targetDoc.project_id || null;
+      const backupResult = refreshProjectScopedBackupAfterMutation(db, {
+        syncDir: SYNC_DIR,
+        projectId: backupProjectId,
+        applicationVersion: MCP_SERVER_VERSION,
+        operation: "upsert_reference_link",
+        actor: createToolActor("upsert_reference_link"),
+        affected: {
+          reference_docs: [target_doc_id],
+          sources: [`${source_kind}:${source_id}`],
+        },
+        summary: `Upserted ${source_kind} reference link from "${source_id}" to "${target_doc_id}".`,
+        before: null,
+        after: {
+          link,
+        },
+      });
 
       return jsonResponse({
         ok: true,
         action: "upserted",
         link,
+        ...backupMutationFields(backupResult),
       });
     }
   );
@@ -1559,8 +1692,46 @@ export function registerMetadataTools(s, {
         indexSceneFile(db, SYNC_DIR, scene.file_path, updated, prose, {
           managedStructure: isManagedStructureProject(db, project_id),
         });
+        const backupResult = refreshProjectScopedBackupAfterMutation(db, {
+          syncDir: SYNC_DIR,
+          projectId: project_id,
+          applicationVersion: MCP_SERVER_VERSION,
+          operation: "update_scene_metadata",
+          actor: createToolActor("update_scene_metadata"),
+          affected: {
+            scenes: [scene_id],
+          },
+          summary: `Updated metadata for scene "${scene_id}".`,
+          before: {
+            scene: {
+              scene_id,
+              project_id,
+              fields: Object.keys(fields).sort().reduce((acc, key) => {
+                acc[key] = meta[key] ?? null;
+                return acc;
+              }, {}),
+            },
+          },
+          after: {
+            scene: {
+              scene_id,
+              project_id,
+              fields: Object.keys(fields).sort().reduce((acc, key) => {
+                acc[key] = updated[key] ?? null;
+                return acc;
+              }, {}),
+            },
+          },
+        });
 
-        return { content: [{ type: "text", text: `Updated metadata for scene '${scene_id}'.` }] };
+        return jsonResponse({
+          ok: true,
+          action: "updated",
+          message: `Updated metadata for scene '${scene_id}'.`,
+          scene_id,
+          project_id,
+          ...backupMutationFields(backupResult),
+        });
       } catch (err) {
         if (err.code === "ENOENT") {
           return errorResponse("STALE_PATH", `Prose file for scene '${scene_id}' not found at indexed path — the file may have moved. Run sync() to refresh.`, { indexed_path: scene.file_path });
@@ -1588,7 +1759,7 @@ export function registerMetadataTools(s, {
       if (!SYNC_DIR_WRITABLE) {
         return errorResponse("READ_ONLY", "Cannot update character: sync dir is read-only.");
       }
-      const char = db.prepare(`SELECT file_path FROM characters WHERE character_id = ?`).get(character_id);
+      const char = db.prepare(`SELECT character_id, project_id, universe_id, file_path, name, role, arc_summary, first_appearance FROM characters WHERE character_id = ?`).get(character_id);
       if (!char) {
         return errorResponse("NOT_FOUND", `Character '${character_id}' not found.`);
       }
@@ -1611,8 +1782,47 @@ export function registerMetadataTools(s, {
             db.prepare(`INSERT OR IGNORE INTO character_traits (character_id, trait) VALUES (?, ?)`).run(character_id, t);
           }
         }
+        const backupResult = refreshProjectScopedBackupAfterMutation(db, {
+          syncDir: SYNC_DIR,
+          projectId: char.project_id,
+          applicationVersion: MCP_SERVER_VERSION,
+          operation: "update_character_sheet",
+          actor: createToolActor("update_character_sheet"),
+          affected: {
+            characters: [character_id],
+          },
+          summary: `Updated character sheet "${character_id}".`,
+          before: {
+            character: {
+              character_id,
+              project_id: char.project_id,
+              universe_id: char.universe_id,
+              name: char.name,
+              role: char.role,
+              arc_summary: char.arc_summary,
+              first_appearance: char.first_appearance,
+            },
+          },
+          after: {
+            character: {
+              character_id,
+              project_id: char.project_id,
+              universe_id: char.universe_id,
+              name: updated.name ?? meta.name ?? null,
+              role: updated.role ?? null,
+              arc_summary: updated.arc_summary ?? null,
+              first_appearance: updated.first_appearance ?? null,
+            },
+          },
+        });
 
-        return { content: [{ type: "text", text: `Updated character sheet for '${character_id}'.` }] };
+        return jsonResponse({
+          ok: true,
+          action: "updated",
+          message: `Updated character sheet for '${character_id}'.`,
+          character_id,
+          ...backupMutationFields(backupResult),
+        });
       } catch (err) {
         if (err?.name === "CoreValidationError") {
           return errorResponse(err.code, err.message, err.details);
@@ -1641,7 +1851,7 @@ export function registerMetadataTools(s, {
       if (!SYNC_DIR_WRITABLE) {
         return errorResponse("READ_ONLY", "Cannot update place: sync dir is read-only.");
       }
-      const place = db.prepare(`SELECT file_path FROM places WHERE place_id = ?`).get(place_id);
+      const place = db.prepare(`SELECT place_id, project_id, universe_id, file_path, name FROM places WHERE place_id = ?`).get(place_id);
       if (!place) {
         return errorResponse("NOT_FOUND", `Place '${place_id}' not found.`);
       }
@@ -1652,8 +1862,41 @@ export function registerMetadataTools(s, {
 
         db.prepare(`UPDATE places SET name = ? WHERE place_id = ?`)
           .run(updated.name ?? meta.name ?? place_id, place_id);
+        const backupResult = refreshProjectScopedBackupAfterMutation(db, {
+          syncDir: SYNC_DIR,
+          projectId: place.project_id,
+          applicationVersion: MCP_SERVER_VERSION,
+          operation: "update_place_sheet",
+          actor: createToolActor("update_place_sheet"),
+          affected: {
+            places: [place_id],
+          },
+          summary: `Updated place sheet "${place_id}".`,
+          before: {
+            place: {
+              place_id,
+              project_id: place.project_id,
+              universe_id: place.universe_id,
+              name: place.name,
+            },
+          },
+          after: {
+            place: {
+              place_id,
+              project_id: place.project_id,
+              universe_id: place.universe_id,
+              name: updated.name ?? meta.name ?? place_id,
+            },
+          },
+        });
 
-        return { content: [{ type: "text", text: `Updated place sheet for '${place_id}'.` }] };
+        return jsonResponse({
+          ok: true,
+          action: "updated",
+          message: `Updated place sheet for '${place_id}'.`,
+          place_id,
+          ...backupMutationFields(backupResult),
+        });
       } catch (err) {
         if (err?.name === "CoreValidationError") {
           return errorResponse(err.code, err.message, err.details);

--- a/src/tools/search.js
+++ b/src/tools/search.js
@@ -4,6 +4,7 @@ import matter from "gray-matter";
 import { readMeta } from "../sync/sync.js";
 import { persistSceneReferenceLink, upsertExplicitReferenceLinkRow } from "./reference-link-persistence.js";
 import { resolveValidatedChapterFilter } from "../core/chapter-resolution.js";
+import { refreshProjectBackupAfterMutation } from "../structure/project-backup-refresh.js";
 
 function accumulateSuggestionScore(scoreMap, rows, sourceLabel) {
   for (const row of rows) {
@@ -55,10 +56,18 @@ function selectApplyCandidates(enrichedCandidates, selectedDocIds, maxApply) {
   return uniqueCandidates.slice(0, maxApply ?? uniqueCandidates.length);
 }
 
+function createToolActor(id) {
+  return {
+    type: "tool",
+    id,
+  };
+}
+
 export function registerSearchTools(s, {
   db,
   SYNC_DIR,
   SYNC_DIR_WRITABLE,
+  MCP_SERVER_VERSION = "0.0.0",
   GIT_ENABLED,
   errorResponse,
   paginateRows,
@@ -1292,6 +1301,32 @@ export function registerSearchTools(s, {
           });
         }
 
+        const backupResult = appliedLinks.length
+          ? refreshProjectBackupAfterMutation(db, {
+              syncDir: SYNC_DIR,
+              projectId: resolvedProjectId,
+              applicationVersion: MCP_SERVER_VERSION,
+              operation: "suggest_scene_references",
+              actor: createToolActor("suggest_scene_references"),
+              affected: {
+                scenes: [scene_id],
+                reference_docs: appliedLinks.map(link => link.target_doc_id),
+              },
+              summary: `Applied ${appliedLinks.length} suggested reference link(s) for scene "${scene_id}".`,
+              before: null,
+              after: {
+                applied_links: appliedLinks,
+              },
+              metadata: {
+                failed_count: failedLinks.length,
+              },
+            })
+          : {
+              operation_history: null,
+              backup_refresh: null,
+              backup_warnings: [],
+            };
+
         return {
           content: [{
             type: "text",
@@ -1305,6 +1340,9 @@ export function registerSearchTools(s, {
               applied_links: appliedLinks,
               failed_count: failedLinks.length,
               failed_links: failedLinks,
+              operation_history: backupResult.operation_history,
+              backup_refresh: backupResult.backup_refresh,
+              backup_warnings: backupResult.backup_warnings,
               candidates: enriched,
             }, null, 2),
           }],

--- a/src/tools/search.js
+++ b/src/tools/search.js
@@ -4,7 +4,10 @@ import matter from "gray-matter";
 import { readMeta } from "../sync/sync.js";
 import { persistSceneReferenceLink, upsertExplicitReferenceLinkRow } from "./reference-link-persistence.js";
 import { resolveValidatedChapterFilter } from "../core/chapter-resolution.js";
-import { refreshProjectBackupAfterMutation } from "../structure/project-backup-refresh.js";
+import {
+  createToolActor,
+  refreshProjectBackupAfterMutation,
+} from "../structure/project-backup-refresh.js";
 
 function accumulateSuggestionScore(scoreMap, rows, sourceLabel) {
   for (const row of rows) {
@@ -54,13 +57,6 @@ function selectApplyCandidates(enrichedCandidates, selectedDocIds, maxApply) {
 
   const uniqueCandidates = Array.from(chosenByDocId.values());
   return uniqueCandidates.slice(0, maxApply ?? uniqueCandidates.length);
-}
-
-function createToolActor(id) {
-  return {
-    type: "tool",
-    id,
-  };
 }
 
 export function registerSearchTools(s, {

--- a/src/tools/sync.js
+++ b/src/tools/sync.js
@@ -23,7 +23,7 @@ export function registerSyncTools(s, {
   SYNC_DIR_ABS,
   SYNC_DIR_REAL,
   SYNC_DIR_WRITABLE,
-  MCP_SERVER_VERSION,
+  MCP_SERVER_VERSION = "0.0.0",
   asyncJobs,
   errorResponse,
   jsonResponse,

--- a/src/tools/sync.js
+++ b/src/tools/sync.js
@@ -10,6 +10,10 @@ import {
   defaultStructureExportFileName,
   writeStructureExportFile,
 } from "../structure/structure-export.js";
+import {
+  buildProjectBackup,
+  writeProjectBackupFiles,
+} from "../structure/project-backup.js";
 import { restoreStructureFromExport } from "../structure/structure-restore.js";
 
 export function registerSyncTools(s, {
@@ -18,6 +22,7 @@ export function registerSyncTools(s, {
   SYNC_DIR_ABS,
   SYNC_DIR_REAL,
   SYNC_DIR_WRITABLE,
+  MCP_SERVER_VERSION,
   asyncJobs,
   errorResponse,
   jsonResponse,
@@ -146,6 +151,96 @@ export function registerSyncTools(s, {
         return errorResponse(
           "EXPORT_STRUCTURE_FAILED",
           error instanceof Error ? error.message : "Failed to export structure snapshot."
+        );
+      }
+    }
+  );
+
+  s.tool(
+    "export_project_backup",
+    "Generate a deterministic project backup bundle from SQLite canonical state. Writes manifest.json and canonical.snapshot.json under WRITING_SYNC_DIR for explicit review and future restore workflows; this is generated transparency only and does not mutate canonical state.",
+    {
+      project_id: z.string().describe("Project ID to back up (e.g. 'test-novel' or 'universe-1/book-1-the-lamb')."),
+      output_dir: z.string().optional().describe("Directory under WRITING_SYNC_DIR where manifest.json and canonical.snapshot.json should be written. Defaults to project-backups/<project_id>."),
+    },
+    async ({ project_id, output_dir }) => {
+      if (!SYNC_DIR_WRITABLE) {
+        return errorResponse("READ_ONLY", "Cannot export project backup: sync dir is read-only.");
+      }
+
+      const projectIdCheck = validateProjectId(project_id);
+      if (!projectIdCheck.ok) {
+        return errorResponse("INVALID_PROJECT_ID", projectIdCheck.reason, { project_id });
+      }
+
+      try {
+        const requestedOutputDir = output_dir
+          ? (path.isAbsolute(output_dir) ? output_dir : path.join(SYNC_DIR_ABS, output_dir))
+          : path.join(SYNC_DIR_ABS, "project-backups", project_id);
+        const { resolvedOutputDir, relativeToSyncDir } = resolveOutputDirWithinSync(requestedOutputDir);
+        const outputDirSegments = relativeToSyncDir
+          .split(path.sep)
+          .filter(Boolean)
+          .map(segment => segment.toLowerCase());
+        if (outputDirSegments.includes("scenes")) {
+          return errorResponse(
+            "INVALID_OUTPUT_DIR",
+            "output_dir cannot be inside a scenes directory. Choose a dedicated generated backup folder under WRITING_SYNC_DIR.",
+            { output_dir: resolvedOutputDir }
+          );
+        }
+
+        const built = buildProjectBackup(db, {
+          projectId: project_id,
+          syncDir: SYNC_DIR_ABS,
+          applicationVersion: MCP_SERVER_VERSION,
+        });
+        if (!built.ok) {
+          return errorResponse(built.error.code, built.error.message, built.error.details);
+        }
+
+        const written = writeProjectBackupFiles(built, { outputDir: resolvedOutputDir });
+        const relativeBase = relativeToSyncDir.split(path.sep).filter(Boolean).join("/");
+        const relativePath = fileName => (relativeBase ? `${relativeBase}/${fileName}` : fileName);
+
+        return jsonResponse({
+          ok: true,
+          action: "exported",
+          project_id,
+          output_dir: resolvedOutputDir,
+          relative_output_dir: relativeBase,
+          files: {
+            manifest: written.manifestPath,
+            canonical_snapshot: written.snapshotPath,
+          },
+          relative_files: {
+            manifest: relativePath("manifest.json"),
+            canonical_snapshot: relativePath("canonical.snapshot.json"),
+          },
+          manifest: {
+            schema_version: built.manifest.schema_version,
+            canonical_source: built.manifest.canonical_source,
+            generated_transparency: built.manifest.generated_transparency,
+            mutation_surface: built.manifest.mutation_surface,
+            restore_policy: built.manifest.restore_policy,
+            privacy: built.manifest.privacy,
+            coverage: built.manifest.coverage,
+            checksums: built.manifest.checksums,
+          },
+          next_step: "Review or commit the generated project backup bundle. Do not edit it as a mutation surface; future restore tools will treat it as explicit recovery input.",
+        });
+      } catch (error) {
+        if (
+          error &&
+          typeof error === "object" &&
+          error.name === "CoreValidationError" &&
+          typeof error.code === "string"
+        ) {
+          return errorResponse(error.code, error.message ?? "Request failed.", error.details);
+        }
+        return errorResponse(
+          "EXPORT_PROJECT_BACKUP_FAILED",
+          error instanceof Error ? error.message : "Failed to export project backup."
         );
       }
     }

--- a/src/tools/sync.js
+++ b/src/tools/sync.js
@@ -159,10 +159,10 @@ export function registerSyncTools(s, {
 
   s.tool(
     "export_project_backup",
-    "Generate a deterministic project backup bundle from SQLite canonical state. Writes manifest.json and canonical.snapshot.json under WRITING_SYNC_DIR for explicit review and future restore workflows; this is generated transparency only and does not mutate canonical state.",
+    "Generate a deterministic project backup bundle from SQLite canonical state. Writes manifest.json, canonical.snapshot.json, and operations.jsonl under WRITING_SYNC_DIR for explicit review and future restore workflows; this is generated transparency only and does not mutate canonical state.",
     {
       project_id: z.string().describe("Project ID to back up (e.g. 'test-novel' or 'universe-1/book-1-the-lamb')."),
-      output_dir: z.string().optional().describe("Directory under WRITING_SYNC_DIR where manifest.json and canonical.snapshot.json should be written. Defaults to project-backups/<project_id>."),
+      output_dir: z.string().optional().describe("Directory under WRITING_SYNC_DIR where manifest.json, canonical.snapshot.json, and operations.jsonl should be written. Defaults to project-backups/<project_id>."),
     },
     async ({ project_id, output_dir }) => {
       if (!SYNC_DIR_WRITABLE) {
@@ -214,11 +214,13 @@ export function registerSyncTools(s, {
           files: {
             manifest: written.manifestPath,
             canonical_snapshot: written.snapshotPath,
+            operations: written.operationLogPath,
           },
           written: written.written,
           relative_files: {
             manifest: relativePath("manifest.json"),
             canonical_snapshot: relativePath("canonical.snapshot.json"),
+            operations: relativePath("operations.jsonl"),
           },
           manifest: {
             schema_version: built.manifest.schema_version,

--- a/src/tools/sync.js
+++ b/src/tools/sync.js
@@ -15,6 +15,10 @@ import {
   writeProjectBackupFiles,
 } from "../structure/project-backup.js";
 import { runProjectBackupDiagnostics } from "../structure/project-backup-diagnostics.js";
+import {
+  createToolActor,
+  refreshProjectBackupAfterMutation,
+} from "../structure/project-backup-refresh.js";
 import { restoreStructureFromExport } from "../structure/structure-restore.js";
 
 export function registerSyncTools(s, {
@@ -39,6 +43,14 @@ export function registerSyncTools(s, {
   deriveLoglineFromProse,
   inferCharacterIdsFromProse,
 }) {
+  function backupMutationFields(backupResult) {
+    return {
+      operation_history: backupResult.operation_history,
+      backup_refresh: backupResult.backup_refresh,
+      backup_warnings: backupResult.backup_warnings,
+    };
+  }
+
   s.tool("sync", "Re-scan the sync folder and update derived scene/character/place indexes from disk. For already managed projects, sync reports file-derived chapter or epigraph drift without adopting it as canonical structure; use explicit import, repair, or structure tools for structural changes.", {}, async () => {
     const result = syncAll(db, SYNC_DIR, { writable: SYNC_DIR_WRITABLE });
     const parts = [`Sync complete. ${result.indexed} scenes indexed. ${result.staleMarked} scenes marked stale.`];
@@ -716,6 +728,28 @@ export function registerSyncTools(s, {
             db.prepare(`UPDATE scenes SET metadata_stale = 0 WHERE scene_id = ? AND project_id = ?`)
               .run(sceneId, project_id);
           }
+
+          if (changedScenes.length > 0) {
+            const backupResult = refreshProjectBackupAfterMutation(db, {
+              syncDir: SYNC_DIR,
+              projectId: project_id,
+              applicationVersion: MCP_SERVER_VERSION,
+              operation: "enrich_scene_characters_batch",
+              actor: createToolActor("enrich_scene_characters_batch"),
+              affected: {
+                scenes: changedScenes,
+              },
+              summary: `Applied batch character enrichment to ${changedScenes.length} scene(s).`,
+              before: null,
+              after: {
+                scenes_changed: changedScenes.length,
+              },
+            });
+            completedJob.result = {
+              ...completedJob.result,
+              ...backupMutationFields(backupResult),
+            };
+          }
         },
       });
 
@@ -878,6 +912,28 @@ export function registerSyncTools(s, {
         });
         db.prepare(`UPDATE scenes SET metadata_stale = 0 WHERE scene_id = ? AND project_id = ?`)
           .run(scene.scene_id, scene.project_id);
+        const backupResult = refreshProjectBackupAfterMutation(db, {
+          syncDir: SYNC_DIR,
+          projectId: scene.project_id,
+          applicationVersion: MCP_SERVER_VERSION,
+          operation: "enrich_scene",
+          actor: createToolActor("enrich_scene"),
+          affected: {
+            scenes: [scene.scene_id],
+          },
+          summary: `Enriched scene "${scene.scene_id}".`,
+          before: null,
+          after: {
+            scene: {
+              scene_id: scene.scene_id,
+              project_id: scene.project_id,
+              updated_fields: {
+                logline: Boolean(inferredLogline),
+                characters: inferredCharacters.length,
+              },
+            },
+          },
+        });
 
         return jsonResponse({
           ok: true,
@@ -889,6 +945,7 @@ export function registerSyncTools(s, {
             characters: inferredCharacters.length,
           },
           metadata_stale: false,
+          ...backupMutationFields(backupResult),
         });
       } catch (err) {
         if (err?.name === "CoreValidationError") {

--- a/src/tools/sync.js
+++ b/src/tools/sync.js
@@ -14,6 +14,7 @@ import {
   buildProjectBackup,
   writeProjectBackupFiles,
 } from "../structure/project-backup.js";
+import { runProjectBackupDiagnostics } from "../structure/project-backup-diagnostics.js";
 import { restoreStructureFromExport } from "../structure/structure-restore.js";
 
 export function registerSyncTools(s, {
@@ -244,6 +245,48 @@ export function registerSyncTools(s, {
         return errorResponse(
           "EXPORT_PROJECT_BACKUP_FAILED",
           error instanceof Error ? error.message : "Failed to export project backup."
+        );
+      }
+    }
+  );
+
+  s.tool(
+    "diagnose_project_backups",
+    "Run read-only diagnostics for a generated project backup bundle. Reports missing, partial, wrong-project, incompatible-schema, tampered, unreadable, and stale backups without mutating SQLite or generated files.",
+    {
+      project_id: z.string().describe("Project ID whose backup bundle should be diagnosed (e.g. 'test-novel')."),
+      backup_dir: z.string().optional().describe("Directory under WRITING_SYNC_DIR containing manifest.json and canonical.snapshot.json. Defaults to project-backups/<project_id>."),
+    },
+    async ({ project_id, backup_dir } = {}) => {
+      const projectIdCheck = validateProjectId(project_id);
+      if (!projectIdCheck.ok) {
+        return errorResponse("INVALID_PROJECT_ID", projectIdCheck.reason, { project_id });
+      }
+
+      try {
+        const requestedBackupDir = backup_dir
+          ? (path.isAbsolute(backup_dir) ? backup_dir : path.join(SYNC_DIR_ABS, backup_dir))
+          : path.join(SYNC_DIR_ABS, "project-backups", project_id);
+        const { resolvedOutputDir } = resolveOutputDirWithinSync(requestedBackupDir);
+
+        return jsonResponse(runProjectBackupDiagnostics(db, {
+          syncDir: SYNC_DIR_ABS,
+          backupDir: resolvedOutputDir,
+          projectId: project_id,
+          applicationVersion: MCP_SERVER_VERSION,
+        }));
+      } catch (error) {
+        if (
+          error &&
+          typeof error === "object" &&
+          error.name === "CoreValidationError" &&
+          typeof error.code === "string"
+        ) {
+          return errorResponse(error.code, error.message ?? "Request failed.", error.details);
+        }
+        return errorResponse(
+          "DIAGNOSE_PROJECT_BACKUPS_FAILED",
+          error instanceof Error ? error.message : "Failed to diagnose project backup."
         );
       }
     }

--- a/src/tools/sync.js
+++ b/src/tools/sync.js
@@ -178,6 +178,7 @@ export function registerSyncTools(s, {
           ? (path.isAbsolute(output_dir) ? output_dir : path.join(SYNC_DIR_ABS, output_dir))
           : path.join(SYNC_DIR_ABS, "project-backups", project_id);
         const { resolvedOutputDir, relativeToSyncDir } = resolveOutputDirWithinSync(requestedOutputDir);
+        const relativeBase = relativeToSyncDir.split(path.sep).filter(Boolean).join("/");
         const outputDirSegments = relativeToSyncDir
           .split(path.sep)
           .filter(Boolean)
@@ -194,13 +195,13 @@ export function registerSyncTools(s, {
           projectId: project_id,
           syncDir: SYNC_DIR_ABS,
           applicationVersion: MCP_SERVER_VERSION,
+          backupLocation: relativeBase ? `${relativeBase}/` : "./",
         });
         if (!built.ok) {
           return errorResponse(built.error.code, built.error.message, built.error.details);
         }
 
         const written = writeProjectBackupFiles(built, { outputDir: resolvedOutputDir });
-        const relativeBase = relativeToSyncDir.split(path.sep).filter(Boolean).join("/");
         const relativePath = fileName => (relativeBase ? `${relativeBase}/${fileName}` : fileName);
 
         return jsonResponse({
@@ -213,6 +214,7 @@ export function registerSyncTools(s, {
             manifest: written.manifestPath,
             canonical_snapshot: written.snapshotPath,
           },
+          written: written.written,
           relative_files: {
             manifest: relativePath("manifest.json"),
             canonical_snapshot: relativePath("canonical.snapshot.json"),
@@ -222,6 +224,7 @@ export function registerSyncTools(s, {
             canonical_source: built.manifest.canonical_source,
             generated_transparency: built.manifest.generated_transparency,
             mutation_surface: built.manifest.mutation_surface,
+            backup_location: built.manifest.backup_location,
             restore_policy: built.manifest.restore_policy,
             privacy: built.manifest.privacy,
             coverage: built.manifest.coverage,

--- a/src/workflows/workflow-catalogue.js
+++ b/src/workflows/workflow-catalogue.js
@@ -92,6 +92,7 @@ export const WORKFLOW_CATALOGUE = [
       { tool: "restore_structure_from_export", note: "Use only as an explicit repair workflow after diagnostics show a trusted generated export can recover canonical SQLite structure." },
       { tool: "export_structure_snapshot", note: "Generate a deterministic SQLite-derived structure export for Git review after canonical structure changes; editing the export does not mutate structure." },
       { tool: "export_project_backup", note: "Generate the broader deterministic project backup bundle for Git review and future recovery input; editing it does not mutate canonical state." },
+      { tool: "diagnose_project_backups", note: "Check whether a generated project backup is present, trusted, and fresh before relying on it as recovery input." },
     ],
   },
   {

--- a/src/workflows/workflow-catalogue.js
+++ b/src/workflows/workflow-catalogue.js
@@ -89,10 +89,10 @@ export const WORKFLOW_CATALOGUE = [
       { tool: "move_scene", note: "Use when a scene should move to another canonical chapter and/or unused timeline_position; this does not move the scene source file." },
       { tool: "assign_scene_to_chapter", note: "Use this named structure workflow for chapter assignment or clearing instead of editing chapter fields through generic metadata updates." },
       { tool: "diagnose_structure", note: "Run when the assignment is part of a drift repair workflow, when folder-derived structure may disagree with the requested link, or before trusting an export for recovery." },
+      { tool: "diagnose_project_backups", note: "Structure mutation tools normally refresh the project backup automatically; run this if backup_warnings were returned or you need to verify backup freshness before recovery work." },
       { tool: "restore_structure_from_export", note: "Use only as an explicit repair workflow after diagnostics show a trusted generated export can recover canonical SQLite structure." },
       { tool: "export_structure_snapshot", note: "Generate a deterministic SQLite-derived structure export for Git review after canonical structure changes; editing the export does not mutate structure." },
-      { tool: "export_project_backup", note: "Generate the broader deterministic project backup bundle for Git review and future recovery input; editing it does not mutate canonical state." },
-      { tool: "diagnose_project_backups", note: "Check whether a generated project backup is present, trusted, and fresh before relying on it as recovery input." },
+      { tool: "export_project_backup", note: "Generate or repair the broader deterministic project backup bundle for Git review and future recovery input; editing it does not mutate canonical state." },
     ],
   },
   {

--- a/src/workflows/workflow-catalogue.js
+++ b/src/workflows/workflow-catalogue.js
@@ -91,6 +91,7 @@ export const WORKFLOW_CATALOGUE = [
       { tool: "diagnose_structure", note: "Run when the assignment is part of a drift repair workflow, when folder-derived structure may disagree with the requested link, or before trusting an export for recovery." },
       { tool: "restore_structure_from_export", note: "Use only as an explicit repair workflow after diagnostics show a trusted generated export can recover canonical SQLite structure." },
       { tool: "export_structure_snapshot", note: "Generate a deterministic SQLite-derived structure export for Git review after canonical structure changes; editing the export does not mutate structure." },
+      { tool: "export_project_backup", note: "Generate the broader deterministic project backup bundle for Git review and future recovery input; editing it does not mutate canonical state." },
     ],
   },
   {


### PR DESCRIPTION
## Summary

- Adds the project backup artifact model with deterministic canonical snapshots, manifests, hash checks, and generated backup output under the sync root.
- Adds explicit export and diagnostic tools for project backups, including freshness, tamper, wrong-project, schema, symlink, and non-regular file checks.
- Adds advisory operation history plus automatic backup refresh after sanctioned project-scoped canonical mutation tools.
- Updates product docs, generated tool docs, initiative milestones, README status, and the release log for the database backup initiative.

## Motivation

The active Database Backup and Recovery initiative needs a trusted restore foundation before any apply workflow exists. This PR gives project-scoped canonical database state a durable, inspectable backup bundle and keeps it fresh during normal sanctioned mutation flows.

## Implementation

- Introduces snapshot-first project backup generation in `src/structure/project-backup.js`, excluding prose bodies and runtime-only state from restore authority.
- Adds `export_project_backup` and `diagnose_project_backups` MCP tools plus workflow catalogue visibility.
- Adds backup diagnostics for missing, partial, unreadable, stale, tampered, wrong-project, incompatible, symlinked, and non-regular backup files.
- Adds append-only advisory `operations.jsonl` history and a shared post-mutation refresh helper.
- Wires refresh output into chapter structure, scene metadata, world-entity, thread, and reference-link mutation flows, returning `operation_history`, `backup_refresh`, and `backup_warnings` where relevant.

## Testing

- `node --experimental-sqlite --test src/test/unit/metadata-tools.test.mjs src/test/unit/project-backup-refresh.test.mjs`
- `node --experimental-sqlite --test --test-name-pattern "update_scene_metadata|update_character_sheet|update_place_sheet|create_character_sheet|upsert_thread_link|upsert_reference_link|suggest_scene_references" src/test/integration/metadata.test.mjs src/test/integration/search.test.mjs`
- `npm run lint`
- `npm run test:unit`
- `npm run check:docs`
- `git diff --check`
- `npm run check:pr`
- Rebased onto `origin/main` after `Release 3.18.1`, then reran `npm run check:pr`

## Risks and tradeoffs

- `operations.jsonl` is intentionally advisory history, not restore authority. Restore planning remains the next milestone.
- Automatic refresh is scoped to project-scoped sanctioned canonical mutations. Universe-only world entity calls do not refresh a project backup because there is no single project target.
- Backup refresh warnings are surfaced without rolling back the successful canonical mutation.

## Follow-up

- Implement M6 restore planning dry run against trusted backup bundles.