### PR TITLE
feat(backup): add project restore dry-run planning

### DIFF
--- a/docs/agents/tools.md
+++ b/docs/agents/tools.md
@@ -12,6 +12,7 @@
 - [`export_project_backup`](#export_project_backup)
 - [`diagnose_project_backups`](#diagnose_project_backups)
 - [`restore_structure_from_export`](#restore_structure_from_export)
+- [`restore_project_from_backup`](#restore_project_from_backup)
 - [`import_scrivener_sync`](#import_scrivener_sync)
 - [`import_scrivener_sync_async`](#import_scrivener_sync_async)
 - [`merge_scrivener_project_beta`](#merge_scrivener_project_beta)
@@ -141,6 +142,18 @@ Explicitly restore canonical SQLite chapter, scene-placement, and epigraph struc
 | `structure_export_path` | `string` | No | Path under WRITING_SYNC_DIR to the generated structure export JSON. Defaults to structure-exports/<project>.structure.json. |
 | `structure_export_dir` | `string` | No | Directory under WRITING_SYNC_DIR containing generated structure exports. Ignored when structure_export_path is provided. Defaults to structure-exports. |
 | `dry_run` | `boolean` | No | If true (default), validate and summarize planned repairs without writing SQLite state. |
+
+---
+
+## restore_project_from_backup
+
+Dry-run an explicit project restore from a trusted generated project backup bundle. Validates manifest, schema, checksums, project identity, and file references, then returns a deterministic create/update/delete/unchanged plan without mutating SQLite or generated files.
+
+| Parameter | Type | Required | Description |
+| --- | --- | :---: | --- |
+| `project_id` | `string` | Yes | Project ID to restore (e.g. 'test-novel' or 'universe-1/book-1-the-lamb'). |
+| `backup_path` | `string` | No | Path under WRITING_SYNC_DIR to a project backup directory, manifest.json, or canonical.snapshot.json. Defaults to project-backups/<project_id>. |
+| `dry_run` | `boolean` | No | If true (default), validate and summarize the restore plan without writing SQLite state. dry_run=false is reserved for a later transactional restore milestone. |
 
 ---
 

--- a/docs/initiatives/backlog/database-backup-recovery/milestones.md
+++ b/docs/initiatives/backlog/database-backup-recovery/milestones.md
@@ -283,7 +283,7 @@ Deliverables:
 - Add `restore_project_from_backup(project_id, backup_path?, dry_run=true)` in dry-run mode.
 - Validate manifest, schema compatibility, project identity, checksums, file references, and conflicts.
 - Produce a restore plan that summarizes rows/entities to create, update, delete, or leave unchanged.
-- Refuse tampered, stale, partial, wrong-project, or incompatible backup bundles.
+- Refuse tampered, partial, wrong-project, or incompatible backup bundles. In restore planning, `stale` means the backup differs from current SQLite state and should be surfaced as create/update/delete/unchanged plan output, not treated as invalid solely because it is older than the current database.
 - Treat records present in SQLite but absent from the backup as destructive restore candidates that require explicit dry-run reporting and later confirmation.
 - Preserve existing `restore_structure_from_export` behavior as a narrower structure repair workflow.
 

--- a/release-log.md
+++ b/release-log.md
@@ -6,6 +6,14 @@ This complements `CHANGELOG.md`:
 - `CHANGELOG.md` is technical and release-oriented.
 - This log is plain-language and outcome-oriented.
 
+### 2026-05-24 — Preview project backup restores before applying them
+
+- What changed: Added `restore_project_from_backup` in dry-run mode to validate trusted project backup bundles and preview the canonical SQLite changes that a future restore would make.
+- Why it matters: Authors, maintainers, and AI agents can inspect recovery impact before any transactional apply workflow exists, including creates, updates, deletes, checksum trust checks, file-reference issues, and duplicate identity conflicts.
+- Who is affected: Authors, maintainers, and AI agents preparing or reviewing SQLite-canonical project recovery from generated project backup bundles.
+- Action needed: Run `restore_project_from_backup` with the default dry-run behavior and review diagnostics and destructive candidates; regenerate or repair untrusted backups before relying on them.
+- PR: TBD
+
 ### 2026-05-24 — Refresh project backups after canonical mutations
 
 - What changed: Sanctioned project-scoped canonical mutation tools now append advisory operation history and refresh generated project backup artifacts after successful database changes.

--- a/release-log.md
+++ b/release-log.md
@@ -12,7 +12,7 @@ This complements `CHANGELOG.md`:
 - Why it matters: Authors, maintainers, and AI agents can inspect recovery impact before any transactional apply workflow exists, including creates, updates, deletes, checksum trust checks, file-reference issues, and duplicate identity conflicts.
 - Who is affected: Authors, maintainers, and AI agents preparing or reviewing SQLite-canonical project recovery from generated project backup bundles.
 - Action needed: Run `restore_project_from_backup` with the default dry-run behavior and review diagnostics and destructive candidates; regenerate or repair untrusted backups before relying on them.
-- PR: TBD
+- PR: [#220](https://github.com/hannasdev/mcp-writing/pull/220)
 
 ### 2026-05-24 — Refresh project backups after canonical mutations
 

--- a/src/structure/project-backup-restore.js
+++ b/src/structure/project-backup-restore.js
@@ -6,6 +6,10 @@ import {
   computeProjectBackupSnapshotChecksum,
   PROJECT_BACKUP_SCHEMA_VERSION,
 } from "./project-backup.js";
+import {
+  resolveBoundaryRootReal,
+  resolveCandidateInsideBoundary,
+} from "../core/filesystem-boundary.js";
 
 const MANIFEST_FILE = "manifest.json";
 const SNAPSHOT_FILE = "canonical.snapshot.json";
@@ -294,6 +298,7 @@ function collectCurrentSnapshot(db, {
 function validateFileReferences(snapshot, { syncDir }) {
   const diagnostics = [];
   const syncRoot = path.resolve(syncDir);
+  const syncRootReal = resolveBoundaryRootReal(syncRoot);
   for (const [domain, field, requirement] of FILE_REFERENCE_FIELDS) {
     for (const row of snapshot[domain] ?? []) {
       const value = row[field];
@@ -326,12 +331,27 @@ function validateFileReferences(snapshot, { syncDir }) {
       }
 
       const resolved = path.isAbsolute(value) ? path.resolve(value) : path.resolve(syncRoot, value);
-      const relative = path.relative(syncRoot, resolved);
-      if (relative.startsWith("..") || path.isAbsolute(relative)) {
+      let boundaryResolvedPath;
+      try {
+        boundaryResolvedPath = resolveCandidateInsideBoundary(resolved, {
+          boundaryRoot: syncRoot,
+          boundaryRootReal: syncRootReal,
+          errorCode: "project_restore_file_reference_invalid",
+          errorMessage: "Backup file reference must stay inside WRITING_SYNC_DIR.",
+          details: { domain, field, path: value },
+        }).resolvedPath;
+      } catch (error) {
         diagnostics.push(createDiagnostic(
           "project_restore_file_reference_invalid",
           `Backup ${domain} record points outside WRITING_SYNC_DIR.`,
-          { domain, field, path: value },
+          {
+            domain,
+            field,
+            path: value,
+            resolved_path: error?.details?.path ?? resolved,
+            reason: "outside_sync_root",
+            message: error instanceof Error ? error.message : String(error),
+          },
           { nextStep: "Use only trusted backups generated for this sync root." }
         ));
         continue;
@@ -349,14 +369,14 @@ function validateFileReferences(snapshot, { syncDir }) {
         diagnostics.push(createDiagnostic(
           "project_restore_file_reference_missing",
           `Backup ${domain} record points to a missing file.`,
-          { domain, field, path: value, resolved_path: resolved },
+          { domain, field, path: value, resolved_path: boundaryResolvedPath },
           { nextStep: "Restore the referenced prose file, then retry the dry run." }
         ));
       } else if (requirement === "required" && !state.regular) {
         diagnostics.push(createDiagnostic(
           "project_restore_file_reference_invalid",
           `Backup ${domain} record does not point to a regular file.`,
-          { domain, field, path: value, resolved_path: resolved, reason: state.error ?? "not_regular" },
+          { domain, field, path: value, resolved_path: boundaryResolvedPath, reason: state.error ?? "not_regular" },
           { nextStep: "Restore the referenced prose file as a regular file, then retry the dry run." }
         ));
       }

--- a/src/structure/project-backup-restore.js
+++ b/src/structure/project-backup-restore.js
@@ -50,6 +50,13 @@ const NULLABLE_IDENTITY_FIELDS = new Map([
   ["character_relationships", new Set(["scene_id", "note"])],
 ]);
 
+const PROJECT_SCOPE_FIELDS = new Map([
+  ["characters", ["project_id"]],
+  ["places", ["project_id"]],
+  ["reference_docs", ["project_id"]],
+  ["reference_links", ["source_project_id"]],
+]);
+
 function stableStringify(value) {
   if (value === null || typeof value !== "object") return JSON.stringify(value);
   if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
@@ -58,6 +65,14 @@ function stableStringify(value) {
 
 function isRecord(value) {
   return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function identityFieldIsInvalid(row, field, nullableFields) {
+  const hasField = Object.hasOwn(row, field);
+  const value = row[field];
+  return nullableFields.has(field)
+    ? !hasField || value === undefined
+    : !hasField || value === null || value === undefined || value === "";
 }
 
 function createDiagnostic(type, message, details = {}, {
@@ -412,6 +427,7 @@ function validateBundleShape({ manifest, snapshot, backupDir, projectId }) {
 
   for (const [domain, keyFields] of SNAPSHOT_ARRAY_DOMAINS) {
     const nullableFields = NULLABLE_IDENTITY_FIELDS.get(domain) ?? new Set();
+    const projectScopeFields = PROJECT_SCOPE_FIELDS.get(domain) ?? [];
     if (!(domain in snapshot)) {
       diagnostics.push(createDiagnostic(
         "project_restore_incomplete_snapshot",
@@ -431,6 +447,7 @@ function validateBundleShape({ manifest, snapshot, backupDir, projectId }) {
         { nextStep: "Regenerate the backup with export_project_backup before using it for recovery." }
       ));
     } else {
+      const seenKeys = new Set();
       snapshot[domain].forEach((row, index) => {
         if (!isRecord(row)) {
           diagnostics.push(createDiagnostic(
@@ -447,13 +464,10 @@ function validateBundleShape({ manifest, snapshot, backupDir, projectId }) {
           return;
         }
 
+        let hasValidIdentity = true;
         for (const field of keyFields) {
-          const hasField = Object.hasOwn(row, field);
-          const value = row[field];
-          const invalidIdentity = nullableFields.has(field)
-            ? !hasField || value === undefined
-            : !hasField || value === null || value === undefined || value === "";
-          if (invalidIdentity) {
+          if (identityFieldIsInvalid(row, field, nullableFields)) {
+            hasValidIdentity = false;
             diagnostics.push(createDiagnostic(
               "project_restore_invalid_snapshot",
               `Backup canonical snapshot row ${index} in domain "${domain}" is missing required identity field "${field}".`,
@@ -465,6 +479,25 @@ function validateBundleShape({ manifest, snapshot, backupDir, projectId }) {
               },
               { nextStep: "Regenerate the backup with export_project_backup before using it for recovery." }
             ));
+          }
+        }
+
+        if (hasValidIdentity) {
+          const key = rowKey(row, keyFields);
+          if (seenKeys.has(key)) {
+            diagnostics.push(createDiagnostic(
+              "project_restore_duplicate_identity",
+              `Backup canonical snapshot domain "${domain}" contains duplicate identity values.`,
+              {
+                backup_dir: backupDir,
+                domain,
+                index,
+                identity: Object.fromEntries(keyFields.map(field => [field, row[field] ?? null])),
+              },
+              { nextStep: "Regenerate the backup with export_project_backup before using it for recovery." }
+            ));
+          } else {
+            seenKeys.add(key);
           }
         }
 
@@ -488,6 +521,26 @@ function validateBundleShape({ manifest, snapshot, backupDir, projectId }) {
             },
             { nextStep: "Choose the backup directory for the requested project or regenerate the backup." }
           ));
+        }
+
+        for (const field of projectScopeFields) {
+          if (!Object.hasOwn(row, field)) continue;
+          const value = row[field];
+          if (value !== null && value !== undefined && value !== "" && value !== projectId) {
+            diagnostics.push(createDiagnostic(
+              "project_restore_wrong_project",
+              `Backup canonical snapshot row ${index} in domain "${domain}" has ${field} "${value}", not "${projectId}".`,
+              {
+                backup_dir: backupDir,
+                domain,
+                index,
+                field,
+                row_project_id: value,
+                expected_project_id: projectId,
+              },
+              { nextStep: "Choose the backup directory for the requested project or regenerate the backup." }
+            ));
+          }
         }
       });
     }

--- a/src/structure/project-backup-restore.js
+++ b/src/structure/project-backup-restore.js
@@ -484,7 +484,7 @@ function validateBundleShape({ manifest, snapshot, backupDir, projectId }) {
         {
           backup_dir: backupDir,
           domain,
-          actual_type: typeof snapshot[domain],
+          actual_type: snapshot[domain] === null ? "null" : typeof snapshot[domain],
         },
         { nextStep: "Regenerate the backup with export_project_backup before using it for recovery." }
       ));
@@ -756,7 +756,7 @@ export function restoreProjectFromBackup(db, {
   return {
     ok: true,
     action: "planned",
-    dry_run: true,
+    dry_run: Boolean(dryRun),
     project_id: projectId,
     backup_dir: resolvedBackupDir,
     backup: {

--- a/src/structure/project-backup-restore.js
+++ b/src/structure/project-backup-restore.js
@@ -81,6 +81,39 @@ function jsonType(value) {
   return typeof value;
 }
 
+function fileReferenceBoundaryFailure(error, fallbackResolvedPath) {
+  const errorDetails = isRecord(error?.details) ? error.details : {};
+  const message = error instanceof Error ? error.message : String(error);
+  const resolvedPath = typeof errorDetails.path === "string" ? errorDetails.path : fallbackResolvedPath;
+  const ancestorResolutionFailed =
+    Object.hasOwn(errorDetails, "existing_ancestor") ||
+    Object.hasOwn(errorDetails, "cause") ||
+    message === "Path ancestor could not be resolved: path may be inaccessible.";
+
+  if (ancestorResolutionFailed) {
+    return {
+      message: "file reference could not be resolved inside WRITING_SYNC_DIR.",
+      reason: "ancestor_resolution_failed",
+      resolvedPath,
+      nextStep: "Ensure the referenced path is accessible, then retry the dry run.",
+      details: {
+        existing_ancestor: errorDetails.existing_ancestor,
+        cause: errorDetails.cause,
+      },
+      errorMessage: message,
+    };
+  }
+
+  return {
+    message: "file reference points outside WRITING_SYNC_DIR.",
+    reason: "outside_sync_root",
+    resolvedPath,
+    nextStep: "Use only trusted backups generated for this sync root.",
+    details: {},
+    errorMessage: message,
+  };
+}
+
 function identityFieldError(row, field, nullableFields, emptyStringFields) {
   const hasField = Object.hasOwn(row, field);
   const value = row[field];
@@ -341,18 +374,20 @@ function validateFileReferences(snapshot, { syncDir }) {
           details: { domain, field, path: value },
         }).resolvedPath;
       } catch (error) {
+        const boundaryFailure = fileReferenceBoundaryFailure(error, resolved);
         diagnostics.push(createDiagnostic(
           "project_restore_file_reference_invalid",
-          `Backup ${domain} record points outside WRITING_SYNC_DIR.`,
+          `Backup ${domain} record ${boundaryFailure.message}`,
           {
             domain,
             field,
             path: value,
-            resolved_path: error?.details?.path ?? resolved,
-            reason: "outside_sync_root",
-            message: error instanceof Error ? error.message : String(error),
+            resolved_path: boundaryFailure.resolvedPath,
+            reason: boundaryFailure.reason,
+            message: boundaryFailure.errorMessage,
+            ...boundaryFailure.details,
           },
-          { nextStep: "Use only trusted backups generated for this sync root." }
+          { nextStep: boundaryFailure.nextStep }
         ));
         continue;
       }

--- a/src/structure/project-backup-restore.js
+++ b/src/structure/project-backup-restore.js
@@ -46,6 +46,10 @@ const SNAPSHOT_SINGLETON_DOMAINS = [
   ["operation_history", "object"],
 ];
 
+const NULLABLE_IDENTITY_FIELDS = new Map([
+  ["character_relationships", new Set(["scene_id", "note"])],
+]);
+
 function stableStringify(value) {
   if (value === null || typeof value !== "object") return JSON.stringify(value);
   if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
@@ -358,7 +362,7 @@ function validateBundle({ manifest, snapshot, projectId, backupDir }) {
   return diagnostics;
 }
 
-function validateBundleShape({ manifest, snapshot, backupDir }) {
+function validateBundleShape({ manifest, snapshot, backupDir, projectId }) {
   const diagnostics = [];
   if (!isRecord(manifest)) {
     diagnostics.push(createDiagnostic(
@@ -407,6 +411,7 @@ function validateBundleShape({ manifest, snapshot, backupDir }) {
   }
 
   for (const [domain, keyFields] of SNAPSHOT_ARRAY_DOMAINS) {
+    const nullableFields = NULLABLE_IDENTITY_FIELDS.get(domain) ?? new Set();
     if (!(domain in snapshot)) {
       diagnostics.push(createDiagnostic(
         "project_restore_incomplete_snapshot",
@@ -443,7 +448,12 @@ function validateBundleShape({ manifest, snapshot, backupDir }) {
         }
 
         for (const field of keyFields) {
-          if (row[field] === null || row[field] === undefined || row[field] === "") {
+          const hasField = Object.hasOwn(row, field);
+          const value = row[field];
+          const invalidIdentity = nullableFields.has(field)
+            ? !hasField || value === undefined
+            : !hasField || value === null || value === undefined || value === "";
+          if (invalidIdentity) {
             diagnostics.push(createDiagnostic(
               "project_restore_invalid_snapshot",
               `Backup canonical snapshot row ${index} in domain "${domain}" is missing required identity field "${field}".`,
@@ -456,6 +466,28 @@ function validateBundleShape({ manifest, snapshot, backupDir }) {
               { nextStep: "Regenerate the backup with export_project_backup before using it for recovery." }
             ));
           }
+        }
+
+        if (
+          keyFields.includes("project_id") &&
+          Object.hasOwn(row, "project_id") &&
+          row.project_id !== null &&
+          row.project_id !== undefined &&
+          row.project_id !== "" &&
+          row.project_id !== projectId
+        ) {
+          diagnostics.push(createDiagnostic(
+            "project_restore_wrong_project",
+            `Backup canonical snapshot row ${index} in domain "${domain}" belongs to project "${row.project_id}", not "${projectId}".`,
+            {
+              backup_dir: backupDir,
+              domain,
+              index,
+              row_project_id: row.project_id,
+              expected_project_id: projectId,
+            },
+            { nextStep: "Choose the backup directory for the requested project or regenerate the backup." }
+          ));
         }
       });
     }
@@ -516,7 +548,12 @@ export function restoreProjectFromBackup(db, {
   const manifest = manifestRead.ok ? manifestRead.value : null;
   const snapshot = snapshotRead.ok ? snapshotRead.value : null;
   if (manifestRead.ok && snapshotRead.ok) {
-    const shapeDiagnostics = validateBundleShape({ manifest, snapshot, backupDir: resolvedBackupDir });
+    const shapeDiagnostics = validateBundleShape({
+      manifest,
+      snapshot,
+      backupDir: resolvedBackupDir,
+      projectId,
+    });
     diagnostics.push(...shapeDiagnostics);
     if (shapeDiagnostics.length === 0) {
       diagnostics.push(...validateBundle({ manifest, snapshot, projectId, backupDir: resolvedBackupDir }));

--- a/src/structure/project-backup-restore.js
+++ b/src/structure/project-backup-restore.js
@@ -71,6 +71,12 @@ function isRecord(value) {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
+function jsonType(value) {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  return typeof value;
+}
+
 function identityFieldError(row, field, nullableFields, emptyStringFields) {
   const hasField = Object.hasOwn(row, field);
   const value = row[field];
@@ -81,7 +87,7 @@ function identityFieldError(row, field, nullableFields, emptyStringFields) {
   if (typeof value !== "string") {
     return {
       reason: "non_string_identity",
-      actual_type: Array.isArray(value) ? "array" : typeof value,
+      actual_type: jsonType(value),
     };
   }
   if (value === "" && !nullableFields.has(field) && !emptyStringFields.has(field)) {
@@ -311,7 +317,7 @@ function validateFileReferences(snapshot, { syncDir }) {
           {
             domain,
             field,
-            actual_type: Array.isArray(value) ? "array" : typeof value,
+            actual_type: jsonType(value),
             reason: "non_string_file_reference",
           },
           { nextStep: "Regenerate the backup before using it for recovery." }
@@ -424,7 +430,7 @@ function validateBundleShape({ manifest, snapshot, backupDir, projectId }) {
     diagnostics.push(createDiagnostic(
       "project_restore_invalid_manifest",
       "Backup manifest must be a JSON object.",
-      { backup_dir: backupDir, actual_type: Array.isArray(manifest) ? "array" : typeof manifest },
+      { backup_dir: backupDir, actual_type: jsonType(manifest) },
       { nextStep: "Regenerate the backup with export_project_backup before using it for recovery." }
     ));
   } else if (!isRecord(manifest.checksums)) {
@@ -440,7 +446,7 @@ function validateBundleShape({ manifest, snapshot, backupDir, projectId }) {
     diagnostics.push(createDiagnostic(
       "project_restore_invalid_snapshot",
       "Backup canonical snapshot must be a JSON object.",
-      { backup_dir: backupDir, actual_type: Array.isArray(snapshot) ? "array" : typeof snapshot },
+      { backup_dir: backupDir, actual_type: jsonType(snapshot) },
       { nextStep: "Regenerate the backup with export_project_backup before using it for recovery." }
     ));
     return diagnostics;
@@ -459,7 +465,7 @@ function validateBundleShape({ manifest, snapshot, backupDir, projectId }) {
           backup_dir: backupDir,
           domain,
           expected,
-          actual_type: Array.isArray(value) ? "array" : typeof value,
+          actual_type: jsonType(value),
         },
         { nextStep: "Regenerate the backup with export_project_backup before using it for recovery." }
       ));
@@ -484,7 +490,7 @@ function validateBundleShape({ manifest, snapshot, backupDir, projectId }) {
         {
           backup_dir: backupDir,
           domain,
-          actual_type: snapshot[domain] === null ? "null" : typeof snapshot[domain],
+          actual_type: jsonType(snapshot[domain]),
         },
         { nextStep: "Regenerate the backup with export_project_backup before using it for recovery." }
       ));
@@ -499,7 +505,7 @@ function validateBundleShape({ manifest, snapshot, backupDir, projectId }) {
               backup_dir: backupDir,
               domain,
               index,
-              actual_type: Array.isArray(row) ? "array" : typeof row,
+              actual_type: jsonType(row),
             },
             { nextStep: "Regenerate the backup with export_project_backup before using it for recovery." }
           ));

--- a/src/structure/project-backup-restore.js
+++ b/src/structure/project-backup-restore.js
@@ -160,8 +160,18 @@ function backupLocation(syncDir, backupDir) {
   return relative ? `${relative}/` : "./";
 }
 
+function encodeIdentityValue(value) {
+  if (value === null) return "null:";
+  if (value === undefined) return "undefined:";
+  return `${typeof value}:${String(value)}`;
+}
+
 function rowKey(row, keyFields) {
-  return keyFields.map(field => String(row?.[field] ?? "")).join("\u0000");
+  return keyFields.map(field => encodeIdentityValue(row?.[field])).join("\u0000");
+}
+
+function rowIdentity(row, keyFields) {
+  return Object.fromEntries(keyFields.map(field => [field, row?.[field] ?? null]));
 }
 
 function compareRows(currentRows = [], backupRows = [], keyFields) {
@@ -173,7 +183,7 @@ function compareRows(currentRows = [], backupRows = [], keyFields) {
   for (const key of keys) {
     const current = currentByKey.get(key) ?? null;
     const backup = backupByKey.get(key) ?? null;
-    const identity = Object.fromEntries(keyFields.map((field, index) => [field, key.split("\u0000")[index] ?? ""]));
+    const identity = rowIdentity(backup ?? current, keyFields);
     if (!current) {
       changes.push({ action: "create", identity, backup });
     } else if (!backup) {
@@ -549,6 +559,35 @@ function validateBundleShape({ manifest, snapshot, backupDir, projectId }) {
   return diagnostics;
 }
 
+function validateCurrentSnapshotForPlanning(snapshot, { backupDir }) {
+  const diagnostics = [];
+  for (const [domain, keyFields] of SNAPSHOT_ARRAY_DOMAINS) {
+    const seenKeys = new Set();
+    for (const [index, row] of (snapshot[domain] ?? []).entries()) {
+      const key = rowKey(row, keyFields);
+      if (seenKeys.has(key)) {
+        diagnostics.push(createDiagnostic(
+          "project_restore_current_duplicate_identity",
+          `Current SQLite canonical snapshot domain "${domain}" contains duplicate identity values.`,
+          {
+            backup_dir: backupDir,
+            domain,
+            index,
+            identity: rowIdentity(row, keyFields),
+          },
+          {
+            severity: "error",
+            nextStep: "Fix duplicate current SQLite identity rows before retrying restore planning.",
+          }
+        ));
+      } else {
+        seenKeys.add(key);
+      }
+    }
+  }
+  return diagnostics;
+}
+
 function buildRestorePlan(currentSnapshot, backupSnapshot) {
   const changes = [
     ...compareSingleton("projects", currentSnapshot.project, backupSnapshot.project, ["project_id"]),
@@ -655,6 +694,27 @@ export function restoreProjectFromBackup(db, {
       )],
       plan: null,
       next_step: "Resolve restore diagnostics before using this backup as recovery input.",
+    };
+  }
+
+  const currentShapeDiagnostics = validateCurrentSnapshotForPlanning(current.snapshot, {
+    backupDir: resolvedBackupDir,
+  });
+  if (currentShapeDiagnostics.length) {
+    currentShapeDiagnostics.sort((a, b) => {
+      const typeCompare = a.type.localeCompare(b.type);
+      if (typeCompare) return typeCompare;
+      return a.message.localeCompare(b.message);
+    });
+    return {
+      ok: false,
+      action: "restore_refused",
+      dry_run: Boolean(dryRun),
+      project_id: projectId,
+      backup_dir: resolvedBackupDir,
+      diagnostics: currentShapeDiagnostics,
+      plan: null,
+      next_step: "Fix duplicate current SQLite identity rows before retrying restore planning.",
     };
   }
 

--- a/src/structure/project-backup-restore.js
+++ b/src/structure/project-backup-restore.js
@@ -1,0 +1,471 @@
+import fs from "node:fs";
+import path from "node:path";
+import {
+  buildProjectBackup,
+  computeProjectBackupBundleChecksum,
+  computeProjectBackupSnapshotChecksum,
+  PROJECT_BACKUP_SCHEMA_VERSION,
+} from "./project-backup.js";
+
+const MANIFEST_FILE = "manifest.json";
+const SNAPSHOT_FILE = "canonical.snapshot.json";
+
+const SNAPSHOT_ARRAY_DOMAINS = [
+  ["chapters", ["project_id", "chapter_id"]],
+  ["scenes", ["project_id", "scene_id"]],
+  ["epigraphs", ["project_id", "epigraph_id"]],
+  ["epigraph_characters", ["project_id", "epigraph_id", "character_id"]],
+  ["epigraph_tags", ["project_id", "epigraph_id", "tag"]],
+  ["scene_characters", ["project_id", "scene_id", "character_id"]],
+  ["scene_places", ["project_id", "scene_id", "place_id"]],
+  ["scene_tags", ["project_id", "scene_id", "tag"]],
+  ["scene_threads", ["project_id", "scene_id", "thread_id"]],
+  ["characters", ["character_id"]],
+  ["character_traits", ["character_id", "trait"]],
+  ["character_relationships", ["from_character", "to_character", "relationship_type", "scene_id", "note"]],
+  ["places", ["place_id"]],
+  ["threads", ["thread_id"]],
+  ["reference_docs", ["doc_id"]],
+  ["reference_doc_tags", ["doc_id", "tag"]],
+  ["reference_links", ["source_kind", "source_project_id", "source_id", "target_doc_id", "relation"]],
+];
+
+const FILE_REFERENCE_FIELDS = [
+  ["chapters", "source_path", "optional"],
+  ["scenes", "file_path", "required"],
+  ["epigraphs", "file_path", "required"],
+  ["characters", "file_path", "optional"],
+  ["places", "file_path", "optional"],
+  ["reference_docs", "file_path", "required"],
+];
+
+function stableStringify(value) {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+  return `{${Object.keys(value).sort().map(key => `${JSON.stringify(key)}:${stableStringify(value[key])}`).join(",")}}`;
+}
+
+function createDiagnostic(type, message, details = {}, {
+  severity = "warning",
+  nextStep = null,
+} = {}) {
+  return {
+    type,
+    severity,
+    message,
+    details,
+    ...(nextStep ? { next_step: nextStep } : {}),
+  };
+}
+
+function fileState(filePath) {
+  if (!fs.existsSync(filePath)) {
+    return { exists: false, readable: false, regular: false, symlink: false };
+  }
+  let stat;
+  try {
+    stat = fs.lstatSync(filePath);
+  } catch (error) {
+    return {
+      exists: true,
+      readable: false,
+      regular: false,
+      symlink: false,
+      error: "lstat_failed",
+      message: error instanceof Error ? error.message : String(error),
+    };
+  }
+  return {
+    exists: true,
+    readable: true,
+    regular: stat.isFile(),
+    directory: stat.isDirectory(),
+    symlink: stat.isSymbolicLink(),
+  };
+}
+
+function readJsonFile(filePath, label) {
+  const state = fileState(filePath);
+  if (!state.exists) {
+    return { ok: false, state, diagnostic: createDiagnostic(
+      "project_restore_backup_partial",
+      `Project backup ${label} is missing.`,
+      { file: filePath, reason: "missing" },
+      { nextStep: "Regenerate the backup with export_project_backup before using it for recovery." }
+    ) };
+  }
+  if (state.symlink || !state.regular) {
+    return { ok: false, state, diagnostic: createDiagnostic(
+      "project_restore_backup_unreadable",
+      `Project backup ${label} is not readable as trusted JSON.`,
+      { file: filePath, reason: state.error ?? (state.symlink ? "symlink" : "not_regular"), message: state.message ?? null },
+      { nextStep: "Use a regular generated backup file from export_project_backup." }
+    ) };
+  }
+  try {
+    return {
+      ok: true,
+      state,
+      value: JSON.parse(fs.readFileSync(filePath, "utf8")),
+    };
+  } catch (error) {
+    return { ok: false, state, diagnostic: createDiagnostic(
+      "project_restore_backup_unreadable",
+      `Project backup ${label} is not readable as trusted JSON.`,
+      { file: filePath, reason: "unreadable_json", message: error instanceof Error ? error.message : String(error) },
+      { nextStep: "Regenerate the backup with export_project_backup before using it for recovery." }
+    ) };
+  }
+}
+
+function resolveBackupDir(backupPath) {
+  const resolved = path.resolve(backupPath);
+  const base = path.basename(resolved);
+  if (base === MANIFEST_FILE || base === SNAPSHOT_FILE) return path.dirname(resolved);
+  return resolved;
+}
+
+function backupLocation(syncDir, backupDir) {
+  const relative = path.relative(syncDir, backupDir).split(path.sep).filter(Boolean).join("/");
+  return relative ? `${relative}/` : "./";
+}
+
+function rowKey(row, keyFields) {
+  return keyFields.map(field => String(row?.[field] ?? "")).join("\u0000");
+}
+
+function compareRows(currentRows = [], backupRows = [], keyFields) {
+  const currentByKey = new Map(currentRows.map(row => [rowKey(row, keyFields), row]));
+  const backupByKey = new Map(backupRows.map(row => [rowKey(row, keyFields), row]));
+  const keys = [...new Set([...currentByKey.keys(), ...backupByKey.keys()])].sort();
+  const changes = [];
+
+  for (const key of keys) {
+    const current = currentByKey.get(key) ?? null;
+    const backup = backupByKey.get(key) ?? null;
+    const identity = Object.fromEntries(keyFields.map((field, index) => [field, key.split("\u0000")[index] ?? ""]));
+    if (!current) {
+      changes.push({ action: "create", identity, backup });
+    } else if (!backup) {
+      changes.push({ action: "delete", identity, current, destructive: true });
+    } else if (stableStringify(current) === stableStringify(backup)) {
+      changes.push({ action: "unchanged", identity });
+    } else {
+      changes.push({ action: "update", identity, current, backup });
+    }
+  }
+
+  return changes;
+}
+
+function compareSingleton(domain, current, backup, keyFields) {
+  return compareRows(
+    current ? [current] : [],
+    backup ? [backup] : [],
+    keyFields
+  ).map(change => ({ domain, ...change }));
+}
+
+function countActions(changes) {
+  const counts = { create: 0, update: 0, delete: 0, unchanged: 0, refused: 0, conflict: 0 };
+  for (const change of changes) {
+    counts[change.action] = (counts[change.action] ?? 0) + 1;
+  }
+  return counts;
+}
+
+function buildEmptyCurrentSnapshot(db, backupSnapshot) {
+  const universeId = backupSnapshot.universe?.universe_id ?? null;
+  const universe = universeId
+    ? db.prepare(`
+      SELECT universe_id, name
+      FROM universes
+      WHERE universe_id = ?
+    `).get(universeId) ?? null
+    : null;
+
+  return {
+    project: null,
+    universe,
+    chapters: [],
+    scenes: [],
+    epigraphs: [],
+    epigraph_characters: [],
+    epigraph_tags: [],
+    scene_characters: [],
+    scene_places: [],
+    scene_tags: [],
+    scene_threads: [],
+    characters: [],
+    character_traits: [],
+    character_relationships: [],
+    places: [],
+    threads: [],
+    reference_docs: [],
+    reference_doc_tags: [],
+    reference_links: [],
+    external_references: { character_ids: [], place_ids: [], reference_doc_ids: [] },
+    operation_history: backupSnapshot.operation_history ?? null,
+  };
+}
+
+function collectCurrentSnapshot(db, {
+  projectId,
+  syncDir,
+  applicationVersion,
+  backupLocationValue,
+  backupSnapshot,
+}) {
+  const built = buildProjectBackup(db, {
+    projectId,
+    syncDir,
+    applicationVersion,
+    backupLocation: backupLocationValue,
+  });
+  if (built.ok) return { ok: true, snapshot: built.snapshot, checksum: built.manifest.checksums.canonical_snapshot_sha256 };
+  if (built.error?.code === "NOT_FOUND") {
+    const snapshot = buildEmptyCurrentSnapshot(db, backupSnapshot);
+    return { ok: true, snapshot, checksum: null };
+  }
+  return built;
+}
+
+function validateFileReferences(snapshot, { syncDir }) {
+  const diagnostics = [];
+  const syncRoot = path.resolve(syncDir);
+  for (const [domain, field, requirement] of FILE_REFERENCE_FIELDS) {
+    for (const row of snapshot[domain] ?? []) {
+      const value = row[field];
+      if (!value) {
+        if (requirement === "required") {
+          diagnostics.push(createDiagnostic(
+            "project_restore_file_reference_invalid",
+            `Backup ${domain} record is missing required ${field}.`,
+            { domain, field, identity: row },
+            { nextStep: "Regenerate the backup before using it for recovery." }
+          ));
+        }
+        continue;
+      }
+
+      const resolved = path.isAbsolute(value) ? path.resolve(value) : path.resolve(syncRoot, value);
+      const relative = path.relative(syncRoot, resolved);
+      if (relative.startsWith("..") || path.isAbsolute(relative)) {
+        diagnostics.push(createDiagnostic(
+          "project_restore_file_reference_invalid",
+          `Backup ${domain} record points outside WRITING_SYNC_DIR.`,
+          { domain, field, path: value },
+          { nextStep: "Use only trusted backups generated for this sync root." }
+        ));
+        continue;
+      }
+
+      const state = fileState(resolved);
+      if (state.symlink) {
+        diagnostics.push(createDiagnostic(
+          "project_restore_file_reference_invalid",
+          `Backup ${domain} record points to a symlink, which is not trusted restore input.`,
+          { domain, field, path: value, resolved_path: resolved, reason: "symlink" },
+          { nextStep: "Restore the referenced prose file as a regular file, then retry the dry run." }
+        ));
+      } else if (requirement === "required" && !state.exists) {
+        diagnostics.push(createDiagnostic(
+          "project_restore_file_reference_missing",
+          `Backup ${domain} record points to a missing file.`,
+          { domain, field, path: value, resolved_path: resolved },
+          { nextStep: "Restore the referenced prose file, then retry the dry run." }
+        ));
+      } else if (requirement === "required" && !state.regular) {
+        diagnostics.push(createDiagnostic(
+          "project_restore_file_reference_invalid",
+          `Backup ${domain} record does not point to a regular file.`,
+          { domain, field, path: value, resolved_path: resolved, reason: state.error ?? "not_regular" },
+          { nextStep: "Restore the referenced prose file as a regular file, then retry the dry run." }
+        ));
+      }
+    }
+  }
+  return diagnostics;
+}
+
+function validateBundle({ manifest, snapshot, projectId, backupDir }) {
+  const diagnostics = [];
+  if (manifest.artifact_kind !== "project_backup") {
+    diagnostics.push(createDiagnostic(
+      "project_restore_wrong_artifact",
+      "Backup manifest is not a project backup artifact.",
+      { backup_dir: backupDir, artifact_kind: manifest.artifact_kind ?? null },
+      { nextStep: "Choose a generated project backup bundle." }
+    ));
+  }
+  if (manifest.project_id !== projectId || snapshot.project?.project_id !== projectId) {
+    diagnostics.push(createDiagnostic(
+      "project_restore_wrong_project",
+      `Backup bundle does not belong to project "${projectId}".`,
+      {
+        backup_dir: backupDir,
+        manifest_project_id: manifest.project_id ?? null,
+        snapshot_project_id: snapshot.project?.project_id ?? null,
+      },
+      { nextStep: "Choose the backup directory for the requested project." }
+    ));
+  }
+  if (manifest.schema_version !== PROJECT_BACKUP_SCHEMA_VERSION) {
+    diagnostics.push(createDiagnostic(
+      "project_restore_incompatible_schema",
+      `Backup schema version "${manifest.schema_version ?? "unknown"}" is not compatible with this server.`,
+      {
+        backup_dir: backupDir,
+        backup_schema_version: manifest.schema_version ?? null,
+        expected_schema_version: PROJECT_BACKUP_SCHEMA_VERSION,
+      },
+      { nextStep: "Regenerate the backup with a compatible server version before restoring." }
+    ));
+  }
+
+  const exportedSnapshotChecksum = manifest.checksums?.canonical_snapshot_sha256 ?? null;
+  const computedSnapshotChecksum = computeProjectBackupSnapshotChecksum(snapshot);
+  if (!exportedSnapshotChecksum || exportedSnapshotChecksum !== computedSnapshotChecksum) {
+    diagnostics.push(createDiagnostic(
+      "project_restore_checksum_mismatch",
+      "Backup snapshot checksum does not match manifest.",
+      { backup_dir: backupDir, exported_checksum: exportedSnapshotChecksum, computed_checksum: computedSnapshotChecksum },
+      { nextStep: "Regenerate the backup before using it for recovery." }
+    ));
+  }
+
+  const exportedBundleChecksum = manifest.checksums?.bundle_sha256 ?? null;
+  const computedBundleChecksum = computeProjectBackupBundleChecksum({ manifest, snapshot });
+  if (!exportedBundleChecksum || exportedBundleChecksum !== computedBundleChecksum) {
+    diagnostics.push(createDiagnostic(
+      "project_restore_bundle_checksum_mismatch",
+      "Backup bundle checksum does not match manifest.",
+      { backup_dir: backupDir, exported_checksum: exportedBundleChecksum, computed_checksum: computedBundleChecksum },
+      { nextStep: "Regenerate the backup before using it for recovery." }
+    ));
+  }
+  return diagnostics;
+}
+
+function buildRestorePlan(currentSnapshot, backupSnapshot) {
+  const changes = [
+    ...compareSingleton("projects", currentSnapshot.project, backupSnapshot.project, ["project_id"]),
+    ...compareSingleton("universes", currentSnapshot.universe, backupSnapshot.universe, ["universe_id"]),
+  ];
+
+  for (const [domain, keyFields] of SNAPSHOT_ARRAY_DOMAINS) {
+    for (const change of compareRows(currentSnapshot[domain] ?? [], backupSnapshot[domain] ?? [], keyFields)) {
+      changes.push({ domain, ...change });
+    }
+  }
+
+  const byDomain = {};
+  for (const change of changes) {
+    byDomain[change.domain] ??= { create: 0, update: 0, delete: 0, unchanged: 0, refused: 0, conflict: 0 };
+    byDomain[change.domain][change.action] = (byDomain[change.domain][change.action] ?? 0) + 1;
+  }
+
+  return {
+    totals: countActions(changes),
+    by_domain: byDomain,
+    destructive_change_count: changes.filter(change => change.action === "delete").length,
+    changes,
+  };
+}
+
+export function restoreProjectFromBackup(db, {
+  syncDir,
+  projectId,
+  backupPath = null,
+  dryRun = true,
+  applicationVersion = "0.0.0",
+} = {}) {
+  const resolvedBackupDir = resolveBackupDir(backupPath ?? path.join(syncDir, "project-backups", projectId));
+  const manifestPath = path.join(resolvedBackupDir, MANIFEST_FILE);
+  const snapshotPath = path.join(resolvedBackupDir, SNAPSHOT_FILE);
+  const manifestRead = readJsonFile(manifestPath, "manifest");
+  const snapshotRead = readJsonFile(snapshotPath, "canonical snapshot");
+  const diagnostics = [manifestRead.diagnostic, snapshotRead.diagnostic].filter(Boolean);
+
+  if (dryRun === false) {
+    diagnostics.push(createDiagnostic(
+      "project_restore_apply_not_implemented",
+      "Project backup restore apply is not implemented in this milestone.",
+      { project_id: projectId },
+      { severity: "error", nextStep: "Run with dry_run=true to inspect the restore plan. Apply support is planned for M7." }
+    ));
+  }
+
+  const manifest = manifestRead.ok ? manifestRead.value : null;
+  const snapshot = snapshotRead.ok ? snapshotRead.value : null;
+  if (manifest && snapshot) {
+    diagnostics.push(...validateBundle({ manifest, snapshot, projectId, backupDir: resolvedBackupDir }));
+    diagnostics.push(...validateFileReferences(snapshot, { syncDir }));
+  }
+
+  diagnostics.sort((a, b) => {
+    const typeCompare = a.type.localeCompare(b.type);
+    if (typeCompare) return typeCompare;
+    return a.message.localeCompare(b.message);
+  });
+
+  if (diagnostics.length || !manifest || !snapshot) {
+    return {
+      ok: false,
+      action: "restore_refused",
+      dry_run: Boolean(dryRun),
+      project_id: projectId,
+      backup_dir: resolvedBackupDir,
+      diagnostics,
+      plan: null,
+      next_step: "Resolve restore diagnostics before using this backup as recovery input.",
+    };
+  }
+
+  const current = collectCurrentSnapshot(db, {
+    projectId,
+    syncDir,
+    applicationVersion,
+    backupLocationValue: backupLocation(syncDir, resolvedBackupDir),
+    backupSnapshot: snapshot,
+  });
+  if (!current.ok) {
+    return {
+      ok: false,
+      action: "restore_refused",
+      dry_run: Boolean(dryRun),
+      project_id: projectId,
+      backup_dir: resolvedBackupDir,
+      diagnostics: [createDiagnostic(
+        "project_restore_current_snapshot_failed",
+        current.error?.message ?? "Current SQLite canonical state could not be inspected.",
+        current.error?.details ?? { project_id: projectId },
+        { severity: "error", nextStep: "Fix the current project database state before retrying restore planning." }
+      )],
+      plan: null,
+      next_step: "Resolve restore diagnostics before using this backup as recovery input.",
+    };
+  }
+
+  const plan = buildRestorePlan(current.snapshot, snapshot);
+  return {
+    ok: true,
+    action: "planned",
+    dry_run: true,
+    project_id: projectId,
+    backup_dir: resolvedBackupDir,
+    backup: {
+      manifest: manifestPath,
+      canonical_snapshot: snapshotPath,
+      schema_version: manifest.schema_version,
+      checksums: manifest.checksums,
+    },
+    current_snapshot_checksum: current.checksum,
+    backup_snapshot_checksum: manifest.checksums.canonical_snapshot_sha256,
+    plan,
+    diagnostics: [],
+    next_step: plan.destructive_change_count > 0
+      ? "Review destructive delete candidates carefully. Apply support will require explicit confirmation in a later milestone."
+      : "Review the dry-run plan. Apply support is intentionally not available until the transactional restore milestone.",
+  };
+}

--- a/src/structure/project-backup-restore.js
+++ b/src/structure/project-backup-restore.js
@@ -50,6 +50,10 @@ const NULLABLE_IDENTITY_FIELDS = new Map([
   ["character_relationships", new Set(["scene_id", "note"])],
 ]);
 
+const EMPTY_STRING_IDENTITY_FIELDS = new Map([
+  ["reference_links", new Set(["source_project_id"])],
+]);
+
 const PROJECT_SCOPE_FIELDS = new Map([
   ["characters", ["project_id"]],
   ["places", ["project_id"]],
@@ -67,12 +71,23 @@ function isRecord(value) {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
-function identityFieldIsInvalid(row, field, nullableFields) {
+function identityFieldError(row, field, nullableFields, emptyStringFields) {
   const hasField = Object.hasOwn(row, field);
   const value = row[field];
-  return nullableFields.has(field)
-    ? !hasField || value === undefined
-    : !hasField || value === null || value === undefined || value === "";
+  if (!hasField || value === undefined) return { reason: "missing_identity" };
+  if (value === null) {
+    return nullableFields.has(field) ? null : { reason: "missing_identity" };
+  }
+  if (typeof value !== "string") {
+    return {
+      reason: "non_string_identity",
+      actual_type: Array.isArray(value) ? "array" : typeof value,
+    };
+  }
+  if (value === "" && !nullableFields.has(field) && !emptyStringFields.has(field)) {
+    return { reason: "empty_identity" };
+  }
+  return null;
 }
 
 function createDiagnostic(type, message, details = {}, {
@@ -453,6 +468,7 @@ function validateBundleShape({ manifest, snapshot, backupDir, projectId }) {
 
   for (const [domain, keyFields] of SNAPSHOT_ARRAY_DOMAINS) {
     const nullableFields = NULLABLE_IDENTITY_FIELDS.get(domain) ?? new Set();
+    const emptyStringFields = EMPTY_STRING_IDENTITY_FIELDS.get(domain) ?? new Set();
     const projectScopeFields = PROJECT_SCOPE_FIELDS.get(domain) ?? [];
     if (!(domain in snapshot)) {
       diagnostics.push(createDiagnostic(
@@ -492,16 +508,18 @@ function validateBundleShape({ manifest, snapshot, backupDir, projectId }) {
 
         let hasValidIdentity = true;
         for (const field of keyFields) {
-          if (identityFieldIsInvalid(row, field, nullableFields)) {
+          const identityError = identityFieldError(row, field, nullableFields, emptyStringFields);
+          if (identityError) {
             hasValidIdentity = false;
             diagnostics.push(createDiagnostic(
               "project_restore_invalid_snapshot",
-              `Backup canonical snapshot row ${index} in domain "${domain}" is missing required identity field "${field}".`,
+              `Backup canonical snapshot row ${index} in domain "${domain}" has invalid identity field "${field}".`,
               {
                 backup_dir: backupDir,
                 domain,
                 index,
                 field,
+                ...identityError,
               },
               { nextStep: "Regenerate the backup with export_project_backup before using it for recovery." }
             ));

--- a/src/structure/project-backup-restore.js
+++ b/src/structure/project-backup-restore.js
@@ -39,10 +39,21 @@ const FILE_REFERENCE_FIELDS = [
   ["reference_docs", "file_path", "required"],
 ];
 
+const SNAPSHOT_SINGLETON_DOMAINS = [
+  ["project", "object"],
+  ["universe", "nullable_object"],
+  ["external_references", "object"],
+  ["operation_history", "object"],
+];
+
 function stableStringify(value) {
   if (value === null || typeof value !== "object") return JSON.stringify(value);
   if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
   return `{${Object.keys(value).sort().map(key => `${JSON.stringify(key)}:${stableStringify(value[key])}`).join(",")}}`;
+}
+
+function isRecord(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
 function createDiagnostic(type, message, details = {}, {
@@ -347,6 +358,79 @@ function validateBundle({ manifest, snapshot, projectId, backupDir }) {
   return diagnostics;
 }
 
+function validateBundleShape({ manifest, snapshot, backupDir }) {
+  const diagnostics = [];
+  if (!isRecord(manifest)) {
+    diagnostics.push(createDiagnostic(
+      "project_restore_invalid_manifest",
+      "Backup manifest must be a JSON object.",
+      { backup_dir: backupDir, actual_type: Array.isArray(manifest) ? "array" : typeof manifest },
+      { nextStep: "Regenerate the backup with export_project_backup before using it for recovery." }
+    ));
+  } else if (!isRecord(manifest.checksums)) {
+    diagnostics.push(createDiagnostic(
+      "project_restore_invalid_manifest",
+      "Backup manifest is missing its checksum object.",
+      { backup_dir: backupDir, field: "checksums" },
+      { nextStep: "Regenerate the backup with export_project_backup before using it for recovery." }
+    ));
+  }
+
+  if (!isRecord(snapshot)) {
+    diagnostics.push(createDiagnostic(
+      "project_restore_invalid_snapshot",
+      "Backup canonical snapshot must be a JSON object.",
+      { backup_dir: backupDir, actual_type: Array.isArray(snapshot) ? "array" : typeof snapshot },
+      { nextStep: "Regenerate the backup with export_project_backup before using it for recovery." }
+    ));
+    return diagnostics;
+  }
+
+  for (const [domain, expected] of SNAPSHOT_SINGLETON_DOMAINS) {
+    const value = snapshot[domain];
+    const valid = expected === "nullable_object"
+      ? value === null || isRecord(value)
+      : isRecord(value);
+    if (!valid) {
+      diagnostics.push(createDiagnostic(
+        "project_restore_invalid_snapshot",
+        `Backup canonical snapshot field "${domain}" has an invalid shape.`,
+        {
+          backup_dir: backupDir,
+          domain,
+          expected,
+          actual_type: Array.isArray(value) ? "array" : typeof value,
+        },
+        { nextStep: "Regenerate the backup with export_project_backup before using it for recovery." }
+      ));
+    }
+  }
+
+  for (const [domain] of SNAPSHOT_ARRAY_DOMAINS) {
+    if (!(domain in snapshot)) {
+      diagnostics.push(createDiagnostic(
+        "project_restore_incomplete_snapshot",
+        `Backup canonical snapshot is missing required domain "${domain}".`,
+        { backup_dir: backupDir, domain },
+        { nextStep: "Regenerate the backup with export_project_backup before using it for recovery." }
+      ));
+    } else if (!Array.isArray(snapshot[domain])) {
+      diagnostics.push(createDiagnostic(
+        "project_restore_invalid_snapshot",
+        `Backup canonical snapshot domain "${domain}" must be an array.`,
+        {
+          backup_dir: backupDir,
+          domain,
+          actual_type: typeof snapshot[domain],
+        },
+        { nextStep: "Regenerate the backup with export_project_backup before using it for recovery." }
+      ));
+    }
+  }
+
+  return diagnostics;
+}
+
 function buildRestorePlan(currentSnapshot, backupSnapshot) {
   const changes = [
     ...compareSingleton("projects", currentSnapshot.project, backupSnapshot.project, ["project_id"]),
@@ -398,9 +482,13 @@ export function restoreProjectFromBackup(db, {
 
   const manifest = manifestRead.ok ? manifestRead.value : null;
   const snapshot = snapshotRead.ok ? snapshotRead.value : null;
-  if (manifest && snapshot) {
-    diagnostics.push(...validateBundle({ manifest, snapshot, projectId, backupDir: resolvedBackupDir }));
-    diagnostics.push(...validateFileReferences(snapshot, { syncDir }));
+  if (manifestRead.ok && snapshotRead.ok) {
+    const shapeDiagnostics = validateBundleShape({ manifest, snapshot, backupDir: resolvedBackupDir });
+    diagnostics.push(...shapeDiagnostics);
+    if (shapeDiagnostics.length === 0) {
+      diagnostics.push(...validateBundle({ manifest, snapshot, projectId, backupDir: resolvedBackupDir }));
+      diagnostics.push(...validateFileReferences(snapshot, { syncDir }));
+    }
   }
 
   diagnostics.sort((a, b) => {

--- a/src/structure/project-backup-restore.js
+++ b/src/structure/project-backup-restore.js
@@ -276,7 +276,8 @@ function validateFileReferences(snapshot, { syncDir }) {
   for (const [domain, field, requirement] of FILE_REFERENCE_FIELDS) {
     for (const row of snapshot[domain] ?? []) {
       const value = row[field];
-      if (!value) {
+      const hasValue = value !== null && value !== undefined && value !== "";
+      if (!hasValue) {
         if (requirement === "required") {
           diagnostics.push(createDiagnostic(
             "project_restore_file_reference_invalid",
@@ -285,6 +286,21 @@ function validateFileReferences(snapshot, { syncDir }) {
             { nextStep: "Regenerate the backup before using it for recovery." }
           ));
         }
+        continue;
+      }
+
+      if (typeof value !== "string") {
+        diagnostics.push(createDiagnostic(
+          "project_restore_file_reference_invalid",
+          `Backup ${domain} record has non-string ${field}.`,
+          {
+            domain,
+            field,
+            actual_type: Array.isArray(value) ? "array" : typeof value,
+            reason: "non_string_file_reference",
+          },
+          { nextStep: "Regenerate the backup before using it for recovery." }
+        ));
         continue;
       }
 

--- a/src/structure/project-backup-restore.js
+++ b/src/structure/project-backup-restore.js
@@ -35,12 +35,12 @@ const SNAPSHOT_ARRAY_DOMAINS = [
 ];
 
 const FILE_REFERENCE_FIELDS = [
-  ["chapters", "source_path", "optional"],
-  ["scenes", "file_path", "required"],
-  ["epigraphs", "file_path", "required"],
-  ["characters", "file_path", "optional"],
-  ["places", "file_path", "optional"],
-  ["reference_docs", "file_path", "required"],
+  ["chapters", "source_path", "optional", "directory"],
+  ["scenes", "file_path", "required", "file"],
+  ["epigraphs", "file_path", "required", "file"],
+  ["characters", "file_path", "optional", "file"],
+  ["places", "file_path", "optional", "file"],
+  ["reference_docs", "file_path", "required", "file"],
 ];
 
 const SNAPSHOT_SINGLETON_DOMAINS = [
@@ -299,7 +299,7 @@ function validateFileReferences(snapshot, { syncDir }) {
   const diagnostics = [];
   const syncRoot = path.resolve(syncDir);
   const syncRootReal = resolveBoundaryRootReal(syncRoot);
-  for (const [domain, field, requirement] of FILE_REFERENCE_FIELDS) {
+  for (const [domain, field, requirement, expectedKind] of FILE_REFERENCE_FIELDS) {
     for (const row of snapshot[domain] ?? []) {
       const value = row[field];
       const hasValue = value !== null && value !== undefined && value !== "";
@@ -365,19 +365,22 @@ function validateFileReferences(snapshot, { syncDir }) {
           { domain, field, path: value, resolved_path: resolved, reason: "symlink" },
           { nextStep: "Restore the referenced prose file as a regular file, then retry the dry run." }
         ));
-      } else if (requirement === "required" && !state.exists) {
+      } else if (!state.exists) {
         diagnostics.push(createDiagnostic(
           "project_restore_file_reference_missing",
-          `Backup ${domain} record points to a missing file.`,
+          `Backup ${domain} record points to a missing ${expectedKind}.`,
           { domain, field, path: value, resolved_path: boundaryResolvedPath },
-          { nextStep: "Restore the referenced prose file, then retry the dry run." }
+          { nextStep: "Restore the referenced path, then retry the dry run." }
         ));
-      } else if (requirement === "required" && !state.regular) {
+      } else if (
+        (expectedKind === "file" && !state.regular) ||
+        (expectedKind === "directory" && !state.directory)
+      ) {
         diagnostics.push(createDiagnostic(
           "project_restore_file_reference_invalid",
-          `Backup ${domain} record does not point to a regular file.`,
-          { domain, field, path: value, resolved_path: boundaryResolvedPath, reason: state.error ?? "not_regular" },
-          { nextStep: "Restore the referenced prose file as a regular file, then retry the dry run." }
+          `Backup ${domain} record does not point to a ${expectedKind}.`,
+          { domain, field, path: value, resolved_path: boundaryResolvedPath, expected_kind: expectedKind, reason: state.error ?? `not_${expectedKind}` },
+          { nextStep: "Restore the referenced path with the expected kind, then retry the dry run." }
         ));
       }
     }
@@ -594,7 +597,21 @@ function validateBundleShape({ manifest, snapshot, backupDir, projectId }) {
         }
 
         for (const field of projectScopeFields) {
-          if (!Object.hasOwn(row, field)) continue;
+          if (!Object.hasOwn(row, field)) {
+            diagnostics.push(createDiagnostic(
+              "project_restore_invalid_snapshot",
+              `Backup canonical snapshot row ${index} in domain "${domain}" is missing required project scope field "${field}".`,
+              {
+                backup_dir: backupDir,
+                domain,
+                index,
+                field,
+                reason: "missing_project_scope",
+              },
+              { nextStep: "Regenerate the backup with export_project_backup before using it for recovery." }
+            ));
+            continue;
+          }
           const value = row[field];
           if (value !== null && value !== undefined && value !== "" && value !== projectId) {
             diagnostics.push(createDiagnostic(

--- a/src/structure/project-backup-restore.js
+++ b/src/structure/project-backup-restore.js
@@ -406,7 +406,7 @@ function validateBundleShape({ manifest, snapshot, backupDir }) {
     }
   }
 
-  for (const [domain] of SNAPSHOT_ARRAY_DOMAINS) {
+  for (const [domain, keyFields] of SNAPSHOT_ARRAY_DOMAINS) {
     if (!(domain in snapshot)) {
       diagnostics.push(createDiagnostic(
         "project_restore_incomplete_snapshot",
@@ -425,6 +425,39 @@ function validateBundleShape({ manifest, snapshot, backupDir }) {
         },
         { nextStep: "Regenerate the backup with export_project_backup before using it for recovery." }
       ));
+    } else {
+      snapshot[domain].forEach((row, index) => {
+        if (!isRecord(row)) {
+          diagnostics.push(createDiagnostic(
+            "project_restore_invalid_snapshot",
+            `Backup canonical snapshot row ${index} in domain "${domain}" must be an object.`,
+            {
+              backup_dir: backupDir,
+              domain,
+              index,
+              actual_type: Array.isArray(row) ? "array" : typeof row,
+            },
+            { nextStep: "Regenerate the backup with export_project_backup before using it for recovery." }
+          ));
+          return;
+        }
+
+        for (const field of keyFields) {
+          if (row[field] === null || row[field] === undefined || row[field] === "") {
+            diagnostics.push(createDiagnostic(
+              "project_restore_invalid_snapshot",
+              `Backup canonical snapshot row ${index} in domain "${domain}" is missing required identity field "${field}".`,
+              {
+                backup_dir: backupDir,
+                domain,
+                index,
+                field,
+              },
+              { nextStep: "Regenerate the backup with export_project_backup before using it for recovery." }
+            ));
+          }
+        }
+      });
     }
   }
 

--- a/src/test/integration/sync.test.mjs
+++ b/src/test/integration/sync.test.mjs
@@ -228,6 +228,42 @@ describe("sync tool", () => {
     assert.match(parsed.diagnostics[0].next_step, /export_project_backup/);
   });
 
+  test("restore_project_from_backup dry-run reports restore plan without applying it", async () => {
+    await callWriteTool("export_project_backup", {
+      project_id: "test-novel",
+      output_dir: "restore-backups/test-novel",
+    });
+
+    await callWriteTool("create_chapter", {
+      project_id: "test-novel",
+      title: "Restore Dry Run Extra Chapter",
+      sort_index: 100,
+      chapter_id: "ch-100-restore-dry-run-extra",
+    });
+
+    const text = await callWriteTool("restore_project_from_backup", {
+      project_id: "test-novel",
+      backup_path: "restore-backups/test-novel",
+    });
+    const parsed = JSON.parse(text);
+
+    assert.equal(parsed.ok, true);
+    assert.equal(parsed.action, "planned");
+    assert.equal(parsed.dry_run, true);
+    assert.equal(parsed.plan.destructive_change_count >= 1, true);
+    assert.ok(parsed.plan.changes.some(change => (
+      change.domain === "chapters" &&
+      change.action === "delete" &&
+      change.identity.chapter_id === "ch-100-restore-dry-run-extra"
+    )));
+
+    const chaptersText = await callWriteTool("list_chapters", {
+      project_id: "test-novel",
+    });
+    const chapters = JSON.parse(chaptersText);
+    assert.ok(chapters.results.some(chapter => chapter.chapter_id === "ch-100-restore-dry-run-extra"));
+  });
+
   test("export_project_backup refuses output outside the sync directory", async () => {
     const text = await callWriteTool("export_project_backup", {
       project_id: "test-novel",

--- a/src/test/unit/project-backup-restore.test.mjs
+++ b/src/test/unit/project-backup-restore.test.mjs
@@ -399,6 +399,64 @@ describe("restoreProjectFromBackup", () => {
     assert.equal(result.plan, null);
   }));
 
+  test("allows empty source_project_id identity for universe-scoped reference links", () => withFixture(({ db, syncDir, backupDir }) => {
+    const built = exportBackup(db, syncDir, backupDir);
+    writeMalformedSnapshotWithValidChecksums(backupDir, {
+      ...built.snapshot,
+      reference_links: [
+        {
+          source_kind: "reference",
+          source_project_id: "",
+          source_id: "ref-universe",
+          target_doc_id: "ref-target",
+          relation: "mentions",
+          origin: "explicit",
+        },
+      ],
+    });
+
+    const result = restorePlan(db, syncDir, backupDir);
+
+    assert.equal(result.ok, true);
+    assert.ok(result.plan.changes.some(change => (
+      change.domain === "reference_links" &&
+      change.action === "create" &&
+      change.identity.source_project_id === ""
+    )));
+  }));
+
+  test("refuses non-string identity field values before planning", () => withFixture(({ db, syncDir, backupDir }) => {
+    const built = exportBackup(db, syncDir, backupDir);
+    writeMalformedSnapshotWithValidChecksums(backupDir, {
+      ...built.snapshot,
+      scene_tags: [
+        {
+          ...built.snapshot.scene_tags[0],
+          tag: {},
+        },
+      ],
+      character_relationships: [
+        {
+          ...built.snapshot.character_relationships[0],
+          note: {},
+        },
+      ],
+    });
+
+    const result = restorePlan(db, syncDir, backupDir);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.action, "restore_refused");
+    assert.deepEqual(
+      result.diagnostics.map(diagnostic => [diagnostic.details.domain, diagnostic.details.field, diagnostic.details.reason]),
+      [
+        ["character_relationships", "note", "non_string_identity"],
+        ["scene_tags", "tag", "non_string_identity"],
+      ]
+    );
+    assert.equal(result.plan, null);
+  }));
+
   test("refuses project-scoped rows whose project_id does not match the backup project", () => withFixture(({ db, syncDir, backupDir }) => {
     const built = exportBackup(db, syncDir, backupDir);
     writeMalformedSnapshotWithValidChecksums(backupDir, {

--- a/src/test/unit/project-backup-restore.test.mjs
+++ b/src/test/unit/project-backup-restore.test.mjs
@@ -72,6 +72,36 @@ function seedFixture(db, syncDir) {
     INSERT INTO scene_tags (scene_id, project_id, tag)
     VALUES (?, ?, ?)
   `).run("sc-first", "test-novel", "opening");
+  db.prepare(`
+    INSERT INTO characters (character_id, project_id, universe_id, name, role, arc_summary, first_appearance, file_path)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    "char-elena",
+    "test-novel",
+    null,
+    "Elena",
+    "protagonist",
+    null,
+    null,
+    null
+  );
+  db.prepare(`
+    INSERT INTO characters (character_id, project_id, universe_id, name, role, arc_summary, first_appearance, file_path)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    "char-marcus",
+    "test-novel",
+    null,
+    "Marcus",
+    "ally",
+    null,
+    null,
+    null
+  );
+  db.prepare(`
+    INSERT INTO character_relationships (from_character, to_character, relationship_type, strength, scene_id, note)
+    VALUES (?, ?, ?, ?, ?, ?)
+  `).run("char-elena", "char-marcus", "trusts", "strong", null, null);
 }
 
 function withFixture(fn) {
@@ -137,7 +167,7 @@ function restorePlan(db, syncDir, backupDir, options = {}) {
 
 describe("restoreProjectFromBackup", () => {
   test("plans a trusted current backup without mutating SQLite", () => withFixture(({ db, syncDir, backupDir }) => {
-    exportBackup(db, syncDir, backupDir);
+    const built = exportBackup(db, syncDir, backupDir);
 
     const result = restorePlan(db, syncDir, backupDir);
 
@@ -149,6 +179,10 @@ describe("restoreProjectFromBackup", () => {
     assert.equal(result.plan.totals.delete, 0);
     assert.ok(result.plan.totals.unchanged > 0);
     assert.deepEqual(result.diagnostics, []);
+    assert.deepEqual(
+      built.snapshot.character_relationships.map(row => [row.from_character, row.to_character, row.scene_id, row.note]),
+      [["char-elena", "char-marcus", null, null]]
+    );
   }));
 
   test("distinguishes create, update, delete, and unchanged candidates", () => withFixture(({ db, syncDir, backupDir }) => {
@@ -339,6 +373,28 @@ describe("restoreProjectFromBackup", () => {
     assert.deepEqual(result.diagnostics.map(diagnostic => diagnostic.type), ["project_restore_invalid_snapshot"]);
     assert.equal(result.diagnostics[0].details.domain, "scene_tags");
     assert.equal(result.diagnostics[0].details.field, "scene_id");
+    assert.equal(result.plan, null);
+  }));
+
+  test("refuses project-scoped rows whose project_id does not match the backup project", () => withFixture(({ db, syncDir, backupDir }) => {
+    const built = exportBackup(db, syncDir, backupDir);
+    writeMalformedSnapshotWithValidChecksums(backupDir, {
+      ...built.snapshot,
+      scenes: [
+        {
+          ...built.snapshot.scenes[0],
+          project_id: "other-project",
+        },
+      ],
+    });
+
+    const result = restorePlan(db, syncDir, backupDir);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.action, "restore_refused");
+    assert.deepEqual(result.diagnostics.map(diagnostic => diagnostic.type), ["project_restore_wrong_project"]);
+    assert.equal(result.diagnostics[0].details.domain, "scenes");
+    assert.equal(result.diagnostics[0].details.row_project_id, "other-project");
     assert.equal(result.plan, null);
   }));
 

--- a/src/test/unit/project-backup-restore.test.mjs
+++ b/src/test/unit/project-backup-restore.test.mjs
@@ -274,6 +274,74 @@ describe("restoreProjectFromBackup", () => {
     assert.equal(result.plan, null);
   }));
 
+  test("refuses non-object rows in file-reference domains before file-reference validation", () => withFixture(({ db, syncDir, backupDir }) => {
+    const built = exportBackup(db, syncDir, backupDir);
+    writeMalformedSnapshotWithValidChecksums(backupDir, {
+      ...built.snapshot,
+      scenes: [null],
+    });
+
+    const result = restorePlan(db, syncDir, backupDir);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.action, "restore_refused");
+    assert.deepEqual(result.diagnostics.map(diagnostic => diagnostic.type), ["project_restore_invalid_snapshot"]);
+    assert.equal(result.diagnostics[0].details.domain, "scenes");
+    assert.equal(result.diagnostics[0].details.index, 0);
+    assert.equal(result.plan, null);
+  }));
+
+  test("refuses rows missing identity fields before planning", () => withFixture(({ db, syncDir, backupDir }) => {
+    const built = exportBackup(db, syncDir, backupDir);
+    writeMalformedSnapshotWithValidChecksums(backupDir, {
+      ...built.snapshot,
+      scenes: [{}],
+    });
+
+    const result = restorePlan(db, syncDir, backupDir);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.action, "restore_refused");
+    assert.deepEqual(
+      result.diagnostics.map(diagnostic => [diagnostic.details.domain, diagnostic.details.field]),
+      [["scenes", "project_id"], ["scenes", "scene_id"]]
+    );
+    assert.equal(result.plan, null);
+  }));
+
+  test("refuses non-object rows in non-file domains before planning", () => withFixture(({ db, syncDir, backupDir }) => {
+    const built = exportBackup(db, syncDir, backupDir);
+    writeMalformedSnapshotWithValidChecksums(backupDir, {
+      ...built.snapshot,
+      scene_tags: [null],
+    });
+
+    const result = restorePlan(db, syncDir, backupDir);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.action, "restore_refused");
+    assert.deepEqual(result.diagnostics.map(diagnostic => diagnostic.type), ["project_restore_invalid_snapshot"]);
+    assert.equal(result.diagnostics[0].details.domain, "scene_tags");
+    assert.equal(result.plan, null);
+  }));
+
+  test("refuses join rows missing one required identity key", () => withFixture(({ db, syncDir, backupDir }) => {
+    const built = exportBackup(db, syncDir, backupDir);
+    writeMalformedSnapshotWithValidChecksums(backupDir, {
+      ...built.snapshot,
+      scene_tags: [{ project_id: "test-novel", tag: "opening" }],
+    });
+
+    const result = restorePlan(db, syncDir, backupDir);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.action, "restore_refused");
+    assert.deepEqual(result.diagnostics.map(diagnostic => diagnostic.type), ["project_restore_invalid_snapshot"]);
+    assert.equal(result.diagnostics[0].details.domain, "scene_tags");
+    assert.equal(result.diagnostics[0].details.field, "scene_id");
+    assert.equal(result.plan, null);
+  }));
+
   test("keeps apply mode unavailable until the transactional restore milestone", () => withFixture(({ db, syncDir, backupDir }) => {
     exportBackup(db, syncDir, backupDir);
 

--- a/src/test/unit/project-backup-restore.test.mjs
+++ b/src/test/unit/project-backup-restore.test.mjs
@@ -504,6 +504,57 @@ describe("restoreProjectFromBackup", () => {
     assert.equal(result.plan, null);
   }));
 
+  test("treats null and empty-string nullable identity fields as distinct", () => withFixture(({ db, syncDir, backupDir }) => {
+    const built = exportBackup(db, syncDir, backupDir);
+    writeMalformedSnapshotWithValidChecksums(backupDir, {
+      ...built.snapshot,
+      character_relationships: [
+        ...built.snapshot.character_relationships,
+        {
+          ...built.snapshot.character_relationships[0],
+          note: "",
+        },
+      ],
+    });
+
+    const result = restorePlan(db, syncDir, backupDir);
+
+    assert.equal(result.ok, true);
+    assert.ok(result.plan.changes.some(change => (
+      change.domain === "character_relationships" &&
+      change.action === "create" &&
+      change.identity.note === ""
+    )));
+    assert.ok(result.plan.changes.some(change => (
+      change.domain === "character_relationships" &&
+      change.action === "unchanged" &&
+      change.identity.note === null
+    )));
+  }));
+
+  test("refuses current SQLite duplicate identities before planning can collapse rows", () => withFixture(({ db, syncDir, backupDir }) => {
+    exportBackup(db, syncDir, backupDir);
+    db.prepare(`
+      INSERT INTO character_relationships (from_character, to_character, relationship_type, strength, scene_id, note)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `).run("char-elena", "char-marcus", "trusts", "strong", null, null);
+
+    const result = restorePlan(db, syncDir, backupDir);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.action, "restore_refused");
+    assert.deepEqual(result.diagnostics.map(diagnostic => diagnostic.type), ["project_restore_current_duplicate_identity"]);
+    assert.equal(result.diagnostics[0].details.domain, "character_relationships");
+    assert.deepEqual(result.diagnostics[0].details.identity, {
+      from_character: "char-elena",
+      to_character: "char-marcus",
+      relationship_type: "trusts",
+      scene_id: null,
+      note: null,
+    });
+    assert.equal(result.plan, null);
+  }));
+
   test("keeps apply mode unavailable until the transactional restore milestone", () => withFixture(({ db, syncDir, backupDir }) => {
     exportBackup(db, syncDir, backupDir);
 

--- a/src/test/unit/project-backup-restore.test.mjs
+++ b/src/test/unit/project-backup-restore.test.mjs
@@ -398,6 +398,112 @@ describe("restoreProjectFromBackup", () => {
     assert.equal(result.plan, null);
   }));
 
+  test("refuses nullable-scope world rows that belong to another project", () => withFixture(({ db, syncDir, backupDir }) => {
+    const built = exportBackup(db, syncDir, backupDir);
+    writeMalformedSnapshotWithValidChecksums(backupDir, {
+      ...built.snapshot,
+      characters: [
+        ...built.snapshot.characters,
+        {
+          character_id: "char-other",
+          project_id: "other-project",
+          universe_id: null,
+          name: "Other",
+          role: null,
+          arc_summary: null,
+          first_appearance: null,
+          file_path: null,
+        },
+      ],
+      places: [
+        {
+          place_id: "place-other",
+          project_id: "other-project",
+          universe_id: null,
+          name: "Other Place",
+          file_path: null,
+        },
+      ],
+    });
+
+    const result = restorePlan(db, syncDir, backupDir);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.action, "restore_refused");
+    assert.deepEqual(
+      result.diagnostics
+        .map(diagnostic => [diagnostic.details.domain, diagnostic.details.row_project_id])
+        .sort((a, b) => a[0].localeCompare(b[0])),
+      [["characters", "other-project"], ["places", "other-project"]]
+    );
+    assert.equal(result.plan, null);
+  }));
+
+  test("refuses nullable-scope reference rows that belong to another project", () => withFixture(({ db, syncDir, backupDir }) => {
+    const built = exportBackup(db, syncDir, backupDir);
+    writeMalformedSnapshotWithValidChecksums(backupDir, {
+      ...built.snapshot,
+      reference_docs: [
+        {
+          doc_id: "ref-other",
+          project_id: "other-project",
+          universe_id: null,
+          type: "note",
+          title: "Other Reference",
+          summary: null,
+          file_path: "projects/other-project/world/reference/other.md",
+        },
+      ],
+      reference_links: [
+        {
+          source_kind: "scene",
+          source_project_id: "other-project",
+          source_id: "sc-first",
+          target_doc_id: "ref-other",
+          relation: "mentions",
+          origin: "explicit",
+        },
+      ],
+    });
+
+    const result = restorePlan(db, syncDir, backupDir);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.action, "restore_refused");
+    assert.deepEqual(
+      result.diagnostics.map(diagnostic => [diagnostic.details.domain, diagnostic.details.field, diagnostic.details.row_project_id]),
+      [["reference_docs", "project_id", "other-project"], ["reference_links", "source_project_id", "other-project"]]
+    );
+    assert.equal(result.plan, null);
+  }));
+
+  test("refuses duplicate identities before planning can collapse rows", () => withFixture(({ db, syncDir, backupDir }) => {
+    const built = exportBackup(db, syncDir, backupDir);
+    writeMalformedSnapshotWithValidChecksums(backupDir, {
+      ...built.snapshot,
+      scenes: [built.snapshot.scenes[0], built.snapshot.scenes[0]],
+      scene_tags: [built.snapshot.scene_tags[0], built.snapshot.scene_tags[0]],
+      character_relationships: [
+        built.snapshot.character_relationships[0],
+        built.snapshot.character_relationships[0],
+      ],
+    });
+
+    const result = restorePlan(db, syncDir, backupDir);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.action, "restore_refused");
+    assert.deepEqual(
+      result.diagnostics.map(diagnostic => diagnostic.details.domain),
+      ["character_relationships", "scene_tags", "scenes"]
+    );
+    assert.deepEqual(
+      new Set(result.diagnostics.map(diagnostic => diagnostic.type)),
+      new Set(["project_restore_duplicate_identity"])
+    );
+    assert.equal(result.plan, null);
+  }));
+
   test("keeps apply mode unavailable until the transactional restore milestone", () => withFixture(({ db, syncDir, backupDir }) => {
     exportBackup(db, syncDir, backupDir);
 

--- a/src/test/unit/project-backup-restore.test.mjs
+++ b/src/test/unit/project-backup-restore.test.mjs
@@ -276,6 +276,40 @@ describe("restoreProjectFromBackup", () => {
     assert.equal(result.plan, null);
   }));
 
+  test("refuses file references that escape through symlinked directories", () => withFixture(({ db, syncDir, backupDir }) => {
+    const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), "mcp-writing-restore-file-escape-"));
+    try {
+      const outsideScenePath = path.join(outsideDir, "sc-first.md");
+      fs.writeFileSync(outsideScenePath, "# Outside Scene\n", "utf8");
+      const linkDir = path.join(syncDir, "projects/test-novel/symlink-scenes");
+      fs.symlinkSync(outsideDir, linkDir, "dir");
+
+      const built = exportBackup(db, syncDir, backupDir);
+      writeMalformedSnapshotWithValidChecksums(backupDir, {
+        ...built.snapshot,
+        scenes: [
+          {
+            ...built.snapshot.scenes[0],
+            file_path: "projects/test-novel/symlink-scenes/sc-first.md",
+          },
+        ],
+      });
+
+      const result = restorePlan(db, syncDir, backupDir);
+
+      assert.equal(result.ok, false);
+      assert.equal(result.action, "restore_refused");
+      assert.deepEqual(result.diagnostics.map(diagnostic => diagnostic.type), ["project_restore_file_reference_invalid"]);
+      assert.equal(result.diagnostics[0].details.domain, "scenes");
+      assert.equal(result.diagnostics[0].details.field, "file_path");
+      assert.equal(result.diagnostics[0].details.reason, "outside_sync_root");
+      assert.equal(result.diagnostics[0].details.resolved_path, fs.realpathSync.native(outsideScenePath));
+      assert.equal(result.plan, null);
+    } finally {
+      fs.rmSync(outsideDir, { recursive: true, force: true });
+    }
+  }));
+
   test("refuses non-object manifests with restore diagnostics", () => withFixture(({ db, syncDir, backupDir }) => {
     exportBackup(db, syncDir, backupDir);
     const snapshot = JSON.parse(fs.readFileSync(path.join(backupDir, "canonical.snapshot.json"), "utf8"));

--- a/src/test/unit/project-backup-restore.test.mjs
+++ b/src/test/unit/project-backup-restore.test.mjs
@@ -6,6 +6,8 @@ import path from "node:path";
 import { openDb } from "../../core/db.js";
 import {
   buildProjectBackup,
+  computeProjectBackupBundleChecksum,
+  computeProjectBackupSnapshotChecksum,
   renderProjectBackupArtifact,
   writeProjectBackupFiles,
 } from "../../structure/project-backup.js";
@@ -97,6 +99,30 @@ function exportBackup(db, syncDir, backupDir) {
   assert.equal(built.ok, true);
   writeProjectBackupFiles(built, { outputDir: backupDir });
   return built;
+}
+
+function writeBundle(backupDir, { manifest, snapshot }) {
+  fs.writeFileSync(path.join(backupDir, "manifest.json"), renderProjectBackupArtifact(manifest), "utf8");
+  fs.writeFileSync(path.join(backupDir, "canonical.snapshot.json"), renderProjectBackupArtifact(snapshot), "utf8");
+}
+
+function writeMalformedSnapshotWithValidChecksums(backupDir, snapshot) {
+  const manifest = JSON.parse(fs.readFileSync(path.join(backupDir, "manifest.json"), "utf8"));
+  const nextManifestBase = {
+    ...manifest,
+    checksums: {
+      ...manifest.checksums,
+      canonical_snapshot_sha256: computeProjectBackupSnapshotChecksum(snapshot),
+    },
+  };
+  const nextManifest = {
+    ...nextManifestBase,
+    checksums: {
+      ...nextManifestBase.checksums,
+      bundle_sha256: computeProjectBackupBundleChecksum({ manifest: nextManifestBase, snapshot }),
+    },
+  };
+  writeBundle(backupDir, { manifest: nextManifest, snapshot });
 }
 
 function restorePlan(db, syncDir, backupDir, options = {}) {
@@ -191,6 +217,61 @@ describe("restoreProjectFromBackup", () => {
 
     assert.equal(result.ok, false);
     assert.deepEqual(result.diagnostics.map(diagnostic => diagnostic.type), ["project_restore_file_reference_missing"]);
+  }));
+
+  test("refuses non-object manifests with restore diagnostics", () => withFixture(({ db, syncDir, backupDir }) => {
+    exportBackup(db, syncDir, backupDir);
+    const snapshot = JSON.parse(fs.readFileSync(path.join(backupDir, "canonical.snapshot.json"), "utf8"));
+    writeBundle(backupDir, { manifest: null, snapshot });
+
+    const result = restorePlan(db, syncDir, backupDir);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.action, "restore_refused");
+    assert.deepEqual(result.diagnostics.map(diagnostic => diagnostic.type), ["project_restore_invalid_manifest"]);
+    assert.equal(result.plan, null);
+  }));
+
+  test("refuses non-object canonical snapshots before planning", () => withFixture(({ db, syncDir, backupDir }) => {
+    exportBackup(db, syncDir, backupDir);
+    writeMalformedSnapshotWithValidChecksums(backupDir, []);
+
+    const result = restorePlan(db, syncDir, backupDir);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.action, "restore_refused");
+    assert.deepEqual(result.diagnostics.map(diagnostic => diagnostic.type), ["project_restore_invalid_snapshot"]);
+    assert.equal(result.plan, null);
+  }));
+
+  test("refuses incomplete canonical snapshots before treating missing domains as deletes", () => withFixture(({ db, syncDir, backupDir }) => {
+    const built = exportBackup(db, syncDir, backupDir);
+    const { scenes: _scenes, ...incompleteSnapshot } = built.snapshot;
+    writeMalformedSnapshotWithValidChecksums(backupDir, incompleteSnapshot);
+
+    const result = restorePlan(db, syncDir, backupDir);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.action, "restore_refused");
+    assert.deepEqual(result.diagnostics.map(diagnostic => diagnostic.type), ["project_restore_incomplete_snapshot"]);
+    assert.equal(result.diagnostics[0].details.domain, "scenes");
+    assert.equal(result.plan, null);
+  }));
+
+  test("refuses wrong-type canonical snapshot domains before file-reference validation", () => withFixture(({ db, syncDir, backupDir }) => {
+    const built = exportBackup(db, syncDir, backupDir);
+    writeMalformedSnapshotWithValidChecksums(backupDir, {
+      ...built.snapshot,
+      scenes: {},
+    });
+
+    const result = restorePlan(db, syncDir, backupDir);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.action, "restore_refused");
+    assert.deepEqual(result.diagnostics.map(diagnostic => diagnostic.type), ["project_restore_invalid_snapshot"]);
+    assert.equal(result.diagnostics[0].details.domain, "scenes");
+    assert.equal(result.plan, null);
   }));
 
   test("keeps apply mode unavailable until the transactional restore milestone", () => withFixture(({ db, syncDir, backupDir }) => {

--- a/src/test/unit/project-backup-restore.test.mjs
+++ b/src/test/unit/project-backup-restore.test.mjs
@@ -312,42 +312,38 @@ describe("restoreProjectFromBackup", () => {
     }
   }));
 
-  test("reports inaccessible file reference ancestors separately from sync root escapes", () => withFixture(({ db, syncDir, backupDir }) => {
+  test("reports inaccessible file reference ancestors separately from sync root escapes", t => withFixture(({ db, syncDir, backupDir }) => {
     const built = exportBackup(db, syncDir, backupDir);
     const backupScenePath = built.snapshot.scenes[0].file_path;
     const scenePath = path.isAbsolute(backupScenePath)
       ? path.resolve(backupScenePath)
       : path.resolve(syncDir, backupScenePath);
     const originalRealpathNative = fs.realpathSync.native;
-    fs.realpathSync.native = targetPath => {
+    t.mock.method(fs.realpathSync, "native", targetPath => {
       if (path.resolve(targetPath) === scenePath) {
         throw new Error("EACCES: permission denied, realpath");
       }
       return originalRealpathNative(targetPath);
-    };
+    });
 
-    try {
-      const result = restorePlan(db, syncDir, backupDir);
+    const result = restorePlan(db, syncDir, backupDir);
 
-      assert.equal(result.ok, false);
-      assert.equal(result.action, "restore_refused");
-      assert.deepEqual(result.diagnostics.map(diagnostic => diagnostic.type), ["project_restore_file_reference_invalid"]);
-      assert.equal(
-        result.diagnostics[0].message,
-        "Backup scenes record file reference could not be resolved inside WRITING_SYNC_DIR."
-      );
-      assert.equal(result.diagnostics[0].details.domain, "scenes");
-      assert.equal(result.diagnostics[0].details.field, "file_path");
-      assert.equal(result.diagnostics[0].details.reason, "ancestor_resolution_failed");
-      assert.equal(result.diagnostics[0].details.resolved_path, scenePath);
-      assert.equal(result.diagnostics[0].details.existing_ancestor, scenePath);
-      assert.match(result.diagnostics[0].details.message, /Path ancestor could not be resolved/);
-      assert.match(result.diagnostics[0].details.cause, /EACCES/);
-      assert.equal(result.diagnostics[0].next_step, "Ensure the referenced path is accessible, then retry the dry run.");
-      assert.equal(result.plan, null);
-    } finally {
-      fs.realpathSync.native = originalRealpathNative;
-    }
+    assert.equal(result.ok, false);
+    assert.equal(result.action, "restore_refused");
+    assert.deepEqual(result.diagnostics.map(diagnostic => diagnostic.type), ["project_restore_file_reference_invalid"]);
+    assert.equal(
+      result.diagnostics[0].message,
+      "Backup scenes record file reference could not be resolved inside WRITING_SYNC_DIR."
+    );
+    assert.equal(result.diagnostics[0].details.domain, "scenes");
+    assert.equal(result.diagnostics[0].details.field, "file_path");
+    assert.equal(result.diagnostics[0].details.reason, "ancestor_resolution_failed");
+    assert.equal(result.diagnostics[0].details.resolved_path, scenePath);
+    assert.equal(result.diagnostics[0].details.existing_ancestor, scenePath);
+    assert.match(result.diagnostics[0].details.message, /Path ancestor could not be resolved/);
+    assert.match(result.diagnostics[0].details.cause, /EACCES/);
+    assert.equal(result.diagnostics[0].next_step, "Ensure the referenced path is accessible, then retry the dry run.");
+    assert.equal(result.plan, null);
   }));
 
   test("refuses optional file references when present but missing", () => withFixture(({ db, syncDir, backupDir }) => {

--- a/src/test/unit/project-backup-restore.test.mjs
+++ b/src/test/unit/project-backup-restore.test.mjs
@@ -331,6 +331,23 @@ describe("restoreProjectFromBackup", () => {
     assert.equal(result.plan, null);
   }));
 
+  test("reports null canonical snapshot array domains with a clear actual type", () => withFixture(({ db, syncDir, backupDir }) => {
+    const built = exportBackup(db, syncDir, backupDir);
+    writeMalformedSnapshotWithValidChecksums(backupDir, {
+      ...built.snapshot,
+      scenes: null,
+    });
+
+    const result = restorePlan(db, syncDir, backupDir);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.action, "restore_refused");
+    assert.deepEqual(result.diagnostics.map(diagnostic => diagnostic.type), ["project_restore_invalid_snapshot"]);
+    assert.equal(result.diagnostics[0].details.domain, "scenes");
+    assert.equal(result.diagnostics[0].details.actual_type, "null");
+    assert.equal(result.plan, null);
+  }));
+
   test("refuses non-object rows in file-reference domains before file-reference validation", () => withFixture(({ db, syncDir, backupDir }) => {
     const built = exportBackup(db, syncDir, backupDir);
     writeMalformedSnapshotWithValidChecksums(backupDir, {

--- a/src/test/unit/project-backup-restore.test.mjs
+++ b/src/test/unit/project-backup-restore.test.mjs
@@ -17,7 +17,9 @@ const UPDATED_AT = "2026-05-24T12:00:00.000Z";
 
 function seedFixture(db, syncDir) {
   const scenePath = path.join(syncDir, "projects/test-novel/scenes/sc-first.md");
+  const chapterPath = path.join(syncDir, "projects/test-novel/chapters/ch-01");
   fs.mkdirSync(path.dirname(scenePath), { recursive: true });
+  fs.mkdirSync(chapterPath, { recursive: true });
   fs.writeFileSync(scenePath, "# First Scene\n", "utf8");
 
   db.prepare(`
@@ -310,6 +312,28 @@ describe("restoreProjectFromBackup", () => {
     }
   }));
 
+  test("refuses optional file references when present but missing", () => withFixture(({ db, syncDir, backupDir }) => {
+    const built = exportBackup(db, syncDir, backupDir);
+    writeMalformedSnapshotWithValidChecksums(backupDir, {
+      ...built.snapshot,
+      characters: built.snapshot.characters.map(row => row.character_id === "char-elena"
+        ? {
+            ...row,
+            file_path: "projects/test-novel/world/characters/elena.md",
+          }
+        : row),
+    });
+
+    const result = restorePlan(db, syncDir, backupDir);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.action, "restore_refused");
+    assert.deepEqual(result.diagnostics.map(diagnostic => diagnostic.type), ["project_restore_file_reference_missing"]);
+    assert.equal(result.diagnostics[0].details.domain, "characters");
+    assert.equal(result.diagnostics[0].details.field, "file_path");
+    assert.equal(result.plan, null);
+  }));
+
   test("refuses non-object manifests with restore diagnostics", () => withFixture(({ db, syncDir, backupDir }) => {
     exportBackup(db, syncDir, backupDir);
     const snapshot = JSON.parse(fs.readFileSync(path.join(backupDir, "canonical.snapshot.json"), "utf8"));
@@ -587,6 +611,31 @@ describe("restoreProjectFromBackup", () => {
         .sort((a, b) => a[0].localeCompare(b[0])),
       [["characters", "other-project"], ["places", "other-project"]]
     );
+    assert.equal(result.plan, null);
+  }));
+
+  test("refuses scoped world rows missing project scope fields", () => withFixture(({ db, syncDir, backupDir }) => {
+    const built = exportBackup(db, syncDir, backupDir);
+    const scopedCharacter = {
+      ...built.snapshot.characters.find(row => row.character_id === "char-elena"),
+    };
+    delete scopedCharacter.project_id;
+    writeMalformedSnapshotWithValidChecksums(backupDir, {
+      ...built.snapshot,
+      characters: [
+        scopedCharacter,
+        ...built.snapshot.characters.filter(row => row.character_id !== "char-elena"),
+      ],
+    });
+
+    const result = restorePlan(db, syncDir, backupDir);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.action, "restore_refused");
+    assert.deepEqual(result.diagnostics.map(diagnostic => diagnostic.type), ["project_restore_invalid_snapshot"]);
+    assert.equal(result.diagnostics[0].details.domain, "characters");
+    assert.equal(result.diagnostics[0].details.field, "project_id");
+    assert.equal(result.diagnostics[0].details.reason, "missing_project_scope");
     assert.equal(result.plan, null);
   }));
 

--- a/src/test/unit/project-backup-restore.test.mjs
+++ b/src/test/unit/project-backup-restore.test.mjs
@@ -312,6 +312,44 @@ describe("restoreProjectFromBackup", () => {
     }
   }));
 
+  test("reports inaccessible file reference ancestors separately from sync root escapes", () => withFixture(({ db, syncDir, backupDir }) => {
+    const built = exportBackup(db, syncDir, backupDir);
+    const backupScenePath = built.snapshot.scenes[0].file_path;
+    const scenePath = path.isAbsolute(backupScenePath)
+      ? path.resolve(backupScenePath)
+      : path.resolve(syncDir, backupScenePath);
+    const originalRealpathNative = fs.realpathSync.native;
+    fs.realpathSync.native = targetPath => {
+      if (path.resolve(targetPath) === scenePath) {
+        throw new Error("EACCES: permission denied, realpath");
+      }
+      return originalRealpathNative(targetPath);
+    };
+
+    try {
+      const result = restorePlan(db, syncDir, backupDir);
+
+      assert.equal(result.ok, false);
+      assert.equal(result.action, "restore_refused");
+      assert.deepEqual(result.diagnostics.map(diagnostic => diagnostic.type), ["project_restore_file_reference_invalid"]);
+      assert.equal(
+        result.diagnostics[0].message,
+        "Backup scenes record file reference could not be resolved inside WRITING_SYNC_DIR."
+      );
+      assert.equal(result.diagnostics[0].details.domain, "scenes");
+      assert.equal(result.diagnostics[0].details.field, "file_path");
+      assert.equal(result.diagnostics[0].details.reason, "ancestor_resolution_failed");
+      assert.equal(result.diagnostics[0].details.resolved_path, scenePath);
+      assert.equal(result.diagnostics[0].details.existing_ancestor, scenePath);
+      assert.match(result.diagnostics[0].details.message, /Path ancestor could not be resolved/);
+      assert.match(result.diagnostics[0].details.cause, /EACCES/);
+      assert.equal(result.diagnostics[0].next_step, "Ensure the referenced path is accessible, then retry the dry run.");
+      assert.equal(result.plan, null);
+    } finally {
+      fs.realpathSync.native = originalRealpathNative;
+    }
+  }));
+
   test("refuses optional file references when present but missing", () => withFixture(({ db, syncDir, backupDir }) => {
     const built = exportBackup(db, syncDir, backupDir);
     writeMalformedSnapshotWithValidChecksums(backupDir, {

--- a/src/test/unit/project-backup-restore.test.mjs
+++ b/src/test/unit/project-backup-restore.test.mjs
@@ -286,18 +286,37 @@ describe("restoreProjectFromBackup", () => {
     assert.equal(result.ok, false);
     assert.equal(result.action, "restore_refused");
     assert.deepEqual(result.diagnostics.map(diagnostic => diagnostic.type), ["project_restore_invalid_manifest"]);
+    assert.equal(result.diagnostics[0].details.actual_type, "null");
     assert.equal(result.plan, null);
   }));
 
   test("refuses non-object canonical snapshots before planning", () => withFixture(({ db, syncDir, backupDir }) => {
     exportBackup(db, syncDir, backupDir);
-    writeMalformedSnapshotWithValidChecksums(backupDir, []);
+    writeMalformedSnapshotWithValidChecksums(backupDir, null);
 
     const result = restorePlan(db, syncDir, backupDir);
 
     assert.equal(result.ok, false);
     assert.equal(result.action, "restore_refused");
     assert.deepEqual(result.diagnostics.map(diagnostic => diagnostic.type), ["project_restore_invalid_snapshot"]);
+    assert.equal(result.diagnostics[0].details.actual_type, "null");
+    assert.equal(result.plan, null);
+  }));
+
+  test("reports null singleton snapshot fields with a clear actual type", () => withFixture(({ db, syncDir, backupDir }) => {
+    const built = exportBackup(db, syncDir, backupDir);
+    writeMalformedSnapshotWithValidChecksums(backupDir, {
+      ...built.snapshot,
+      project: null,
+    });
+
+    const result = restorePlan(db, syncDir, backupDir);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.action, "restore_refused");
+    assert.deepEqual(result.diagnostics.map(diagnostic => diagnostic.type), ["project_restore_invalid_snapshot"]);
+    assert.equal(result.diagnostics[0].details.domain, "project");
+    assert.equal(result.diagnostics[0].details.actual_type, "null");
     assert.equal(result.plan, null);
   }));
 

--- a/src/test/unit/project-backup-restore.test.mjs
+++ b/src/test/unit/project-backup-restore.test.mjs
@@ -253,6 +253,29 @@ describe("restoreProjectFromBackup", () => {
     assert.deepEqual(result.diagnostics.map(diagnostic => diagnostic.type), ["project_restore_file_reference_missing"]);
   }));
 
+  test("refuses non-string file reference fields without throwing", () => withFixture(({ db, syncDir, backupDir }) => {
+    const built = exportBackup(db, syncDir, backupDir);
+    writeMalformedSnapshotWithValidChecksums(backupDir, {
+      ...built.snapshot,
+      scenes: [
+        {
+          ...built.snapshot.scenes[0],
+          file_path: {},
+        },
+      ],
+    });
+
+    const result = restorePlan(db, syncDir, backupDir);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.action, "restore_refused");
+    assert.deepEqual(result.diagnostics.map(diagnostic => diagnostic.type), ["project_restore_file_reference_invalid"]);
+    assert.equal(result.diagnostics[0].details.domain, "scenes");
+    assert.equal(result.diagnostics[0].details.field, "file_path");
+    assert.equal(result.diagnostics[0].details.reason, "non_string_file_reference");
+    assert.equal(result.plan, null);
+  }));
+
   test("refuses non-object manifests with restore diagnostics", () => withFixture(({ db, syncDir, backupDir }) => {
     exportBackup(db, syncDir, backupDir);
     const snapshot = JSON.parse(fs.readFileSync(path.join(backupDir, "canonical.snapshot.json"), "utf8"));

--- a/src/test/unit/project-backup-restore.test.mjs
+++ b/src/test/unit/project-backup-restore.test.mjs
@@ -1,0 +1,205 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { openDb } from "../../core/db.js";
+import {
+  buildProjectBackup,
+  renderProjectBackupArtifact,
+  writeProjectBackupFiles,
+} from "../../structure/project-backup.js";
+import { restoreProjectFromBackup } from "../../structure/project-backup-restore.js";
+
+const UPDATED_AT = "2026-05-24T12:00:00.000Z";
+
+function seedFixture(db, syncDir) {
+  const scenePath = path.join(syncDir, "projects/test-novel/scenes/sc-first.md");
+  fs.mkdirSync(path.dirname(scenePath), { recursive: true });
+  fs.writeFileSync(scenePath, "# First Scene\n", "utf8");
+
+  db.prepare(`
+    INSERT INTO projects (project_id, universe_id, name)
+    VALUES (?, ?, ?)
+  `).run("test-novel", null, "Test Novel");
+  db.prepare(`
+    INSERT INTO chapters (
+      chapter_id, project_id, title, sort_index, logline, source_path, source_checksum, metadata_stale, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    "ch-01-first",
+    "test-novel",
+    "First",
+    1,
+    "Opening chapter.",
+    "projects/test-novel/chapters/ch-01",
+    null,
+    0,
+    UPDATED_AT
+  );
+  db.prepare(`
+    INSERT INTO scenes (
+      scene_id, project_id, chapter_id, title, part, chapter, chapter_title, pov, logline,
+      scene_change, causality, stakes, scene_functions, save_the_cat_beat, timeline_position,
+      story_time, word_count, file_path, prose_checksum, metadata_stale, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    "sc-first",
+    "test-novel",
+    "ch-01-first",
+    "First Scene",
+    1,
+    1,
+    "First",
+    "Elena",
+    "First scene logline.",
+    null,
+    null,
+    null,
+    null,
+    null,
+    1,
+    null,
+    1000,
+    scenePath,
+    "scene-checksum",
+    0,
+    UPDATED_AT
+  );
+  db.prepare(`
+    INSERT INTO scene_tags (scene_id, project_id, tag)
+    VALUES (?, ?, ?)
+  `).run("sc-first", "test-novel", "opening");
+}
+
+function withFixture(fn) {
+  const db = openDb(":memory:");
+  const syncDir = fs.mkdtempSync(path.join(os.tmpdir(), "mcp-writing-project-restore-sync-"));
+  const backupDir = path.join(syncDir, "project-backups", "test-novel");
+  try {
+    seedFixture(db, syncDir);
+    fs.mkdirSync(backupDir, { recursive: true });
+    return fn({ db, syncDir, backupDir });
+  } finally {
+    db.close();
+    fs.rmSync(syncDir, { recursive: true, force: true });
+  }
+}
+
+function exportBackup(db, syncDir, backupDir) {
+  const relativeBackupDir = path.relative(syncDir, backupDir).split(path.sep).join("/");
+  const built = buildProjectBackup(db, {
+    projectId: "test-novel",
+    syncDir,
+    applicationVersion: "9.9.9",
+    backupLocation: `${relativeBackupDir}/`,
+  });
+  assert.equal(built.ok, true);
+  writeProjectBackupFiles(built, { outputDir: backupDir });
+  return built;
+}
+
+function restorePlan(db, syncDir, backupDir, options = {}) {
+  return restoreProjectFromBackup(db, {
+    syncDir,
+    projectId: "test-novel",
+    backupPath: backupDir,
+    applicationVersion: "9.9.9",
+    ...options,
+  });
+}
+
+describe("restoreProjectFromBackup", () => {
+  test("plans a trusted current backup without mutating SQLite", () => withFixture(({ db, syncDir, backupDir }) => {
+    exportBackup(db, syncDir, backupDir);
+
+    const result = restorePlan(db, syncDir, backupDir);
+
+    assert.equal(result.ok, true);
+    assert.equal(result.action, "planned");
+    assert.equal(result.dry_run, true);
+    assert.equal(result.plan.totals.create, 0);
+    assert.equal(result.plan.totals.update, 0);
+    assert.equal(result.plan.totals.delete, 0);
+    assert.ok(result.plan.totals.unchanged > 0);
+    assert.deepEqual(result.diagnostics, []);
+  }));
+
+  test("distinguishes create, update, delete, and unchanged candidates", () => withFixture(({ db, syncDir, backupDir }) => {
+    exportBackup(db, syncDir, backupDir);
+    db.prepare(`
+      UPDATE scenes
+      SET title = ?
+      WHERE project_id = ? AND scene_id = ?
+    `).run("Changed Scene", "test-novel", "sc-first");
+    db.prepare(`
+      INSERT INTO scene_tags (scene_id, project_id, tag)
+      VALUES (?, ?, ?)
+    `).run("sc-first", "test-novel", "extra-current-tag");
+    db.prepare(`
+      DELETE FROM chapters
+      WHERE project_id = ? AND chapter_id = ?
+    `).run("test-novel", "ch-01-first");
+
+    const result = restorePlan(db, syncDir, backupDir);
+
+    assert.equal(result.ok, true);
+    assert.equal(result.plan.totals.create, 1);
+    assert.equal(result.plan.totals.update, 1);
+    assert.equal(result.plan.totals.delete, 1);
+    assert.ok(result.plan.totals.unchanged > 0);
+    assert.equal(result.plan.destructive_change_count, 1);
+    assert.ok(result.plan.changes.some(change => change.domain === "chapters" && change.action === "create"));
+    assert.ok(result.plan.changes.some(change => change.domain === "scenes" && change.action === "update"));
+    assert.ok(result.plan.changes.some(change => change.domain === "scene_tags" && change.action === "delete"));
+  }));
+
+  test("plans project creation when current SQLite state is missing the project", () => withFixture(({ db, syncDir, backupDir }) => {
+    exportBackup(db, syncDir, backupDir);
+    db.prepare(`DELETE FROM scene_tags WHERE project_id = ?`).run("test-novel");
+    db.prepare(`DELETE FROM scenes WHERE project_id = ?`).run("test-novel");
+    db.prepare(`DELETE FROM chapters WHERE project_id = ?`).run("test-novel");
+    db.prepare(`DELETE FROM projects WHERE project_id = ?`).run("test-novel");
+
+    const result = restorePlan(db, syncDir, backupDir);
+
+    assert.equal(result.ok, true);
+    assert.ok(result.plan.changes.some(change => change.domain === "projects" && change.action === "create"));
+    assert.ok(result.plan.changes.some(change => change.domain === "scenes" && change.action === "create"));
+  }));
+
+  test("refuses tampered backup snapshots", () => withFixture(({ db, syncDir, backupDir }) => {
+    exportBackup(db, syncDir, backupDir);
+    const snapshotPath = path.join(backupDir, "canonical.snapshot.json");
+    const snapshot = JSON.parse(fs.readFileSync(snapshotPath, "utf8"));
+    snapshot.project.name = "Tampered";
+    fs.writeFileSync(snapshotPath, renderProjectBackupArtifact(snapshot), "utf8");
+
+    const result = restorePlan(db, syncDir, backupDir);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.action, "restore_refused");
+    assert.ok(result.diagnostics.some(diagnostic => diagnostic.type === "project_restore_checksum_mismatch"));
+    assert.equal(result.plan, null);
+  }));
+
+  test("refuses missing required file references", () => withFixture(({ db, syncDir, backupDir }) => {
+    exportBackup(db, syncDir, backupDir);
+    fs.rmSync(path.join(syncDir, "projects/test-novel/scenes/sc-first.md"));
+
+    const result = restorePlan(db, syncDir, backupDir);
+
+    assert.equal(result.ok, false);
+    assert.deepEqual(result.diagnostics.map(diagnostic => diagnostic.type), ["project_restore_file_reference_missing"]);
+  }));
+
+  test("keeps apply mode unavailable until the transactional restore milestone", () => withFixture(({ db, syncDir, backupDir }) => {
+    exportBackup(db, syncDir, backupDir);
+
+    const result = restorePlan(db, syncDir, backupDir, { dryRun: false });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.action, "restore_refused");
+    assert.deepEqual(result.diagnostics.map(diagnostic => diagnostic.type), ["project_restore_apply_not_implemented"]);
+  }));
+});

--- a/src/tools/sync.js
+++ b/src/tools/sync.js
@@ -19,6 +19,7 @@ import {
   createToolActor,
   refreshProjectBackupAfterMutation,
 } from "../structure/project-backup-refresh.js";
+import { restoreProjectFromBackup } from "../structure/project-backup-restore.js";
 import { restoreStructureFromExport } from "../structure/structure-restore.js";
 
 export function registerSyncTools(s, {
@@ -332,6 +333,57 @@ export function registerSyncTools(s, {
         structureExportDir: structure_export_dir ?? null,
         dryRun: dry_run,
       }));
+    }
+  );
+
+  s.tool(
+    "restore_project_from_backup",
+    "Dry-run an explicit project restore from a trusted generated project backup bundle. Validates manifest, schema, checksums, project identity, and file references, then returns a deterministic create/update/delete/unchanged plan without mutating SQLite or generated files.",
+    {
+      project_id: z.string().describe("Project ID to restore (e.g. 'test-novel' or 'universe-1/book-1-the-lamb')."),
+      backup_path: z.string().optional().describe("Path under WRITING_SYNC_DIR to a project backup directory, manifest.json, or canonical.snapshot.json. Defaults to project-backups/<project_id>."),
+      dry_run: z.boolean().optional().describe("If true (default), validate and summarize the restore plan without writing SQLite state. dry_run=false is reserved for a later transactional restore milestone."),
+    },
+    async ({ project_id, backup_path, dry_run = true } = {}) => {
+      if (!SYNC_DIR_WRITABLE && dry_run === false) {
+        return errorResponse("READ_ONLY", "Cannot restore project from backup: server is in read-only mode for canonical structure mutations.");
+      }
+
+      const projectIdCheck = validateProjectId(project_id);
+      if (!projectIdCheck.ok) {
+        return errorResponse("INVALID_PROJECT_ID", projectIdCheck.reason, { project_id });
+      }
+
+      try {
+        const requestedBackupPath = backup_path
+          ? (path.isAbsolute(backup_path) ? backup_path : path.join(SYNC_DIR_ABS, backup_path))
+          : path.join(SYNC_DIR_ABS, "project-backups", project_id);
+        const backupPathForBoundary = ["manifest.json", "canonical.snapshot.json"].includes(path.basename(requestedBackupPath))
+          ? path.dirname(requestedBackupPath)
+          : requestedBackupPath;
+        resolveOutputDirWithinSync(backupPathForBoundary);
+
+        return jsonResponse(restoreProjectFromBackup(db, {
+          syncDir: SYNC_DIR_ABS,
+          projectId: project_id,
+          backupPath: requestedBackupPath,
+          dryRun: dry_run,
+          applicationVersion: MCP_SERVER_VERSION,
+        }));
+      } catch (error) {
+        if (
+          error &&
+          typeof error === "object" &&
+          error.name === "CoreValidationError" &&
+          typeof error.code === "string"
+        ) {
+          return errorResponse(error.code, error.message ?? "Request failed.", error.details);
+        }
+        return errorResponse(
+          "RESTORE_PROJECT_FROM_BACKUP_FAILED",
+          error instanceof Error ? error.message : "Failed to plan project restore from backup."
+        );
+      }
     }
   );
 


### PR DESCRIPTION
## Summary

- Adds `restore_project_from_backup` in dry-run mode for trusted project backup bundles.
- Validates restore inputs before planning, including checksums, bundle shape, project ownership, file references, duplicate identities, and malformed nullable identity values.
- Reports create, update, delete, and unchanged candidates without mutating SQLite, and wires the tool into MCP docs and integration coverage.
- Adds a release-log entry for the new restore planning workflow.

## Motivation

Database Backup and Recovery M6 needs a deliberate recovery preview before any transactional restore apply workflow exists. Authors, maintainers, and AI agents need to inspect whether a generated backup is trusted and what canonical state changes it would imply before relying on it for recovery.

## Implementation

- Added a restore planner that reads generated project backup manifests and canonical snapshots, validates trust and shape, and compares them against the current SQLite-canonical snapshot.
- Kept apply mode unavailable with a structured diagnostic; `dry_run=false` is intentionally reserved for the later transactional restore milestone.
- Added strict validation for row identity fields, project-scoped rows, nullable identity distinctions, current duplicate identity conflicts, and malformed file reference values.
- Exposed the workflow through `restore_project_from_backup` and updated generated tool docs, milestone notes, and the human release log.

## Testing

- `node --experimental-sqlite --test src/test/unit/project-backup-restore.test.mjs`
- `npm run lint`
- `node --experimental-sqlite --test --test-concurrency=1 src/test/integration/sync.test.mjs`
- `git diff --check`
- Delegated code review after the latest fix: ready after minor changes; release-log suggestion addressed.

## Risks and tradeoffs

- Restore apply remains intentionally unavailable, so this PR previews recovery impact but does not yet repair SQLite state.
- Validation is strict for trusted generated backups; malformed or hand-edited bundles may be refused and require regeneration.
- The planner compares deterministic snapshot rows and refuses duplicate identities rather than guessing how to reconcile ambiguous current or backup state.

## Follow-up

- Implement transactional `restore_project_from_backup(..., dry_run=false)` in the later restore apply milestone.