### PR TITLE
fix(sync): preserve managed canonical structure

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -26,7 +26,7 @@ Add optional project-scoped Parts, Acts, or other larger structural sections abo
 
 Track target-architecture alignment gaps found during reviews, including managed-sync canonical deletion risks and structural sidecar mirror drift from generic metadata updates.
 
-**Status:** Deferred backlog (not active). Initial findings are logged for future prioritization; no behavior changes are active yet.
+**Status:** Backlog initiative in progress by milestone. M0–M2 are accepted, including managed sync preservation behavior; M3–M5 remain deferred for future prioritization.
 
 ### 📊 [Embedding-Based Search](docs/initiatives/backlog/embeddings-search/prd.md) 📋
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -22,6 +22,12 @@ Add optional project-scoped Parts, Acts, or other larger structural sections abo
 
 **Status:** Deferred backlog (not active). Chapter and epigraph structure is complete; this follow-up captures the optional division layer without reopening shipped chapter behavior.
 
+### 🧭 [Architecture Alignment Follow-up](docs/initiatives/backlog/architecture-alignment-follow-up/prd.md) 📋
+
+Track target-architecture alignment gaps found during reviews, including managed-sync canonical deletion risks and structural sidecar mirror drift from generic metadata updates.
+
+**Status:** Deferred backlog (not active). Initial findings are logged for future prioritization; no behavior changes are active yet.
+
 ### 📊 [Embedding-Based Search](docs/initiatives/backlog/embeddings-search/prd.md) 📋
 
 Semantic search for queries that require understanding meaning, not just keywords.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -40,6 +40,7 @@ See [BACKLOG.md](BACKLOG.md) for deferred product work that is not currently act
 6. **Separated artifact ownership:** prose, canonical structure, derived views, and migration inputs have distinct read/write rules.
 7. **Generated transparency:** reports, outlines, bundles, and indexes explain state but do not become authority.
 8. **Import is a special mode:** setup/import may infer cautiously, but daily work should use explicit operations.
+9. **Outcome-oriented tools:** MCP tools should express writing, revision, review, recovery, and reasoning outcomes rather than exposing raw storage CRUD or table-shaped APIs.
 
 For structural manuscript state, use [Managed Structure Contract](docs/foundations/managed-structure-contract.md) as the detailed arbiter for trusted mutation paths, generated views, import boundaries, and AI/human workflow guardrails.
 

--- a/docs/foundations/managed-structure-contract.md
+++ b/docs/foundations/managed-structure-contract.md
@@ -46,6 +46,10 @@ They may be useful, inspectable, portable, and Git-friendly, but they should not
    Human-readable folder names, numeric chapter labels, and Scrivener ordering can be useful views or migration hints.
    They should not be long-term identity, ordering, or relationship authority once the domain model has first-class concepts.
 
+9. **Tools express outcomes, not storage internals**
+   MCP tools should be shaped around author, reviewer, maintainer, and AI-agent outcomes.
+   They should not expose raw CRUD wrappers for tables or files when a workflow-level operation can preserve intent, validation, diagnostics, and next-step guidance.
+
 ## Numeric Chapter Compatibility
 
 Numeric `chapter` and `chapters` inputs are retained as compatibility aliases for read-scoped workflows such as scene discovery, chapter prose retrieval, styleguide analysis, batch enrichment, and review bundle planning.
@@ -121,7 +125,8 @@ When adding or changing a workflow, ask:
 2. Is this setup/import, daily work, or maintenance?
 3. Is the operation reading, generating, or mutating?
 4. If it mutates structure, what sanctioned MCP command owns it?
-5. If no command exists, is that a product gap rather than something an AI agent should patch directly?
+5. Does the public tool express the user's intended outcome rather than storage CRUD?
+6. If no command exists, is that a product gap rather than something an AI agent should patch directly?
 
 ## Relationship to Current Design
 

--- a/docs/foundations/managed-structure-contract.md
+++ b/docs/foundations/managed-structure-contract.md
@@ -68,6 +68,32 @@ Daily chapter creation, chapter rename/reorder, scene placement, and epigraph at
 | Derived views | Outline, chapter index, reports, bundles, search index | Regenerated from canonical state |
 | Migration inputs | Legacy folders, Scrivener markers, numeric chapters | Interpreted during setup/import only |
 
+## Snapshot and Sidecar Roles
+
+Writable sidecars are not a target daily-work authority for structured
+metadata. Where sidecar-shaped data remains useful, it should have one of these
+explicit roles:
+
+- **Import compatibility input:** legacy sidecars, Scrivener-derived metadata,
+  and frontmatter may seed or reconcile canonical state during setup, import, or
+  named migration workflows.
+- **Generated compatibility output:** a sidecar-shaped file may be regenerated
+  from canonical state for external tools or transitional compatibility, but
+  editing it must not become a structural mutation path.
+- **Review snapshot:** proposed before/after material for dry runs, Git review,
+  and AI/human inspection. Review snapshots are advisory and expire when the
+  proposed operation is discarded or committed through an MCP workflow.
+- **Recovery snapshot:** durable rollback or rebuild input tied to backup and
+  restore workflows. Recovery snapshots can be explicit restore inputs, but only
+  through dry-run-first, validated restore workflows.
+- **Deprecated compatibility artifact:** sidecar-shaped state with no retained
+  product role should be migrated, ignored, or removed through a named follow-up
+  decision.
+
+Review snapshots and recovery snapshots must not be treated as competing daily
+sources of truth. Daily work reads and mutates canonical SQLite state through
+outcome-oriented MCP workflows, while prose remains authored file content.
+
 ## Workflow Zones
 
 ### Setup and Import

--- a/docs/foundations/target-architecture.md
+++ b/docs/foundations/target-architecture.md
@@ -157,6 +157,29 @@ Exports should read canonical state and prose, but they should not redefine eith
 | Derived views | Reports, indexes, bundles, generated docs | Regenerated from canonical state |
 | Migration inputs | Scrivener output, legacy folders, old numbering | Interpreted during import only |
 
+## Snapshot and Sidecar Roles
+
+The target architecture does not depend on writable metadata sidecars as a
+parallel source of truth. Sidecar-shaped data can still exist, but only with an
+explicit role:
+
+- **Import compatibility input:** legacy sidecars, frontmatter, and
+  Scrivener-derived metadata can help translate existing material into
+  canonical state.
+- **Generated compatibility output:** sidecar-shaped files can be regenerated
+  from canonical state when an external workflow still needs them.
+- **Review snapshot:** temporary before/after material can make dry runs,
+  proposed changes, and Git review inspectable without becoming authority.
+- **Recovery snapshot:** durable backup/restore material can rebuild or roll
+  back canonical state through explicit restore workflows.
+- **Deprecated compatibility artifact:** sidecar-shaped files with no retained
+  role should be migrated or removed through a named product decision.
+
+The important boundary is not the file extension. It is whether an artifact is
+allowed to define current manuscript state. Review snapshots explain proposed
+state. Recovery snapshots support explicit recovery. Canonical SQLite state and
+authored prose remain the daily-work authority.
+
 ## Workflow Zones
 
 ### Setup and Import

--- a/docs/initiatives/backlog/architecture-alignment-follow-up/inventory.md
+++ b/docs/initiatives/backlog/architecture-alignment-follow-up/inventory.md
@@ -1,0 +1,122 @@
+# Architecture Alignment Follow-up — Metadata Ownership Inventory
+
+**Status:** Accepted for M1 sequencing
+
+This inventory names the current owner, compatibility role, and follow-up
+decision for metadata families touched by the sidecar and snapshot alignment
+work. It is implementation-backed by the current SQLite schema, metadata lint
+schemas, sync indexers, and MCP write tools.
+
+## Ownership Categories
+
+- **SQLite-canonical:** durable structured state is stored in SQLite and should
+  be mutated through sanctioned workflows.
+- **Prose-authored:** authored manuscript or notes content remains file-based.
+- **Generated view:** derived output for transparency, review, or diagnostics.
+- **Import-only compatibility input:** accepted during setup, import, or legacy
+  migration; not daily-work authority.
+- **Review snapshot:** proposed before/after material for dry runs and review.
+- **Recovery snapshot:** durable rollback or rebuild input tied to backup and
+  restore workflows.
+- **Deprecated:** retained only until migration/removal is explicitly planned.
+
+## Current Ownership Matrix
+
+| Metadata family | Current implementation | Current owner | Compatibility role | M0 decision |
+| --- | --- | --- | --- | --- |
+| Project and universe identity | `projects`, `universes` | SQLite-canonical | Path inference and import may seed records | Keep SQLite-canonical; path inference remains import/sync support. |
+| Scene identity and core metadata | `scenes.scene_id`, `project_id`, `title`, `pov`, `logline`, `scene_change`, `causality`, `stakes`, `scene_functions`, `save_the_cat_beat`, `story_time`, `word_count`, `metadata_stale` | SQLite-canonical after sync/tool writes | Sidecar/frontmatter remains compatibility input | Keep SQLite-canonical; M3 decides how generic metadata tools stop treating sidecars as active authority. |
+| Scene structural placement | `scenes.chapter_id`, `scene_role`, `part`, `chapter`, `chapter_title`, `timeline_position`; `chapters` | SQLite-canonical | Folder names and numeric chapter fields are compatibility hints/read aliases | Keep SQLite-canonical; M2/M3 preserve structure unless explicit workflows mutate it. |
+| Scene prose | Markdown/text scene files | Prose-authored | Sync computes checksum and stale state | Keep prose-authored and file-based. |
+| Scene workflow status | Accepted by scene sidecar schema and `update_scene_metadata`; no SQLite column | Sidecar-only today | Daily metadata field, not import-only | Needs decision: migrate-to-schema or intentionally deprecated/replaced by review workflow status. |
+| Scene source identifiers | `external_source`, `external_id` accepted by scene sidecar schema; Scrivener import/merge uses them | Import-only compatibility input today | Scrivener/import reconciliation | Mark import-only unless a future provenance model adds SQLite columns. |
+| Scene flags/review notes | `flag_scene` appends `flags` to sidecar; not in lint schema or SQLite | Sidecar-only today | Review note scratchpad | Needs decision: migrate to outcome workflow/review snapshot or deprecate sidecar flag authority. |
+| Scene characters | `scene_characters`; populated by sync from sidecar and by enrichment apply/sync | SQLite-canonical index, sidecar-first writes in some workflows | Sidecar `characters` is compatibility input and current write surface | M4 should move active relationship changes to SQLite-first outcome workflows. |
+| Scene places | `scene_places`; populated by sync from sidecar | SQLite-canonical index, sidecar-first writes in generic metadata | Sidecar `places` is compatibility input and current write surface | M4 should define outcome workflow or deprecation path for active place associations. |
+| Scene tags | `scene_tags`; populated by sync from sidecar `tags` and `versions` | SQLite-canonical index, sidecar-first writes in generic metadata | Sidecar `tags` remains current write surface | Needs schema/semantics decision for tags as canonical metadata rather than sidecar authority. |
+| Scene versions | Sidecar `versions`; indexed into `scene_tags`; legacy script splits version markers out of characters | Generated/import compatibility today | Search keyword continuity and legacy cleanup | Decide whether versions become first-class schema, ordinary tags, or deprecated import cleanup. |
+| Threads and scene-thread beats | `threads`, `scene_threads`; `upsert_thread_link` writes SQLite-first | SQLite-canonical | Sidecar `threads` is lint-accepted but not active authority | Keep SQLite-canonical; treat sidecar `threads` as deprecated/import-only unless M4 defines migration. |
+| Chapters | `chapters` | SQLite-canonical | Folder-derived structure can seed or diagnose | Keep SQLite-canonical. |
+| Epigraphs | `epigraphs`, `epigraph_characters`, `epigraph_tags` | SQLite-canonical for indexed metadata; prose body file-based | Epigraph metadata/frontmatter and folder placement are compatibility input | Keep SQLite-canonical for placement/relationships; prose remains file-based. |
+| Characters | `characters`, `character_traits`; sheet files plus sidecars | Mixed: SQLite-canonical for indexed fields, file sidecars as current write surface | Character sidecars seed/update SQLite | M4 should decide whether character metadata updates become SQLite-first with generated compatibility output. |
+| Character group | Accepted by character sidecar schema; no SQLite column | Sidecar-only today | Potential organization metadata | Needs decision: migrate-to-schema, deprecate, or intentionally prose/file-owned. |
+| Character tags | Accepted by character sidecar schema; no SQLite table | Sidecar-only today | Search/classification candidate | Needs decision: migrate-to-schema, deprecate, or generated/import-only. |
+| Character prose notes | `sheet.md` and adjacent support notes | Prose-authored | Search/detail tools read notes on demand | Keep prose-authored and file-based. |
+| Character relationships | `character_relationships` | SQLite-canonical table exists | No clear public outcome workflow in this initiative yet | Include in M0/M4 relationship ownership; decide if workflow surface is needed. |
+| Places | `places`; sheet files plus sidecars | Mixed: SQLite-canonical for indexed fields, file sidecars as current write surface | Place sidecars seed/update SQLite | M4 should decide whether place metadata updates become SQLite-first with generated compatibility output. |
+| Place associated characters | Accepted/read from place sidecar; no SQLite relationship table | Sidecar-only today | Place detail output and current update surface | Needs schema decision: likely migrate-to-schema as relationship metadata or deprecate. |
+| Place tags | Accepted/read from place sidecar; no SQLite table | Sidecar-only today | Place classification/search candidate | Needs decision: migrate-to-schema, deprecate, or generated/import-only. |
+| Reference docs | `reference_docs`, `reference_doc_tags`, `reference_docs_fts` | SQLite-canonical index over file-authored docs | Reference file frontmatter seeds index | Keep SQLite-canonical index; source doc prose remains file-based. |
+| Reference links | `reference_links` with `origin`; sidecar/frontmatter aliases `reference_ids`, `references`, `related_reference_ids`, `related_references`, `related_docs`, `related`, `reference_links`, `explicit_reference_links`, `related_reference_links` | SQLite-canonical target state, but sidecar/file aliases are active inputs and some tool writes are sidecar-first | Legacy aliases and compatibility output | M4 must make apply workflows SQLite-first or transactionally couple compatibility output. |
+| FTS indexes | `scenes_fts`, `reference_docs_fts` | Generated view | Rebuildable derived search surface | Keep generated/rebuildable, never authority. |
+| Project backups | `project-backups/<project_id>/manifest.json`, `canonical.snapshot.json`, `operations.jsonl` | Recovery snapshot plus advisory operation history | Git-reviewable generated artifacts | Keep recovery snapshot; canonical mutations must refresh or document why not. |
+| Structure exports | Structure snapshot/export artifacts | Generated view and explicit restore input when invoked | Review/recovery support | Keep generated; not daily-work authority. |
+| Async jobs | `async_jobs` plus runtime job state | Runtime operational state | Not project metadata authority | Keep out of manuscript metadata ownership. |
+
+## Current Write-Order Inventory
+
+| Workflow/path | Current write order | Owner risk | Follow-up milestone |
+| --- | --- | --- | --- |
+| `syncAll` ordinary scene indexing | Reads sidecars/frontmatter/files, writes SQLite, then prunes unseen canonical rows | Filesystem absence can delete canonical state | M2. |
+| `update_scene_metadata` | Reads normalized sidecar metadata, writes sidecar, reindexes SQLite, refreshes backup | Sidecar-first and may mirror normalized structural fields | M3. |
+| `update_character_sheet` | Reads/writes character sidecar, updates SQLite character rows/traits, refreshes backup | Sidecar-first for canonical character metadata | M4. |
+| `update_place_sheet` | Reads/writes place sidecar, updates SQLite place name, refreshes backup | Sidecar-first; associated characters/tags stay sidecar-only | M4. |
+| `flag_scene` | Appends sidecar `flags`; no SQLite or backup refresh | Sidecar-only review state | M0/M4 decision required. |
+| `upsert_thread_link` | Writes `threads` and `scene_threads` in SQLite, refreshes backup | Mostly aligned; tool name is CRUD-shaped | M4 outcome-oriented replacement/rename guidance. |
+| `upsert_reference_link` | Persists sidecar/frontmatter compatibility first, then upserts `reference_links`, refreshes backup | Sidecar-first split before canonical write | M4. |
+| `suggest_scene_references` with apply | Uses SQLite/reference context, applies accepted links and refreshes backup | Needs confirmation of SQLite-first/coupled ordering | M4. |
+| `enrich_scene_characters_batch` apply | Batch writes sidecar character links, runs `syncAll`, clears stale flags, refreshes backup | Prose-derived enrichment is outcome-oriented but sidecar-first | M4. |
+| Scrivener import and direct merge | Creates/updates/relocates sidecars, optional sync indexes SQLite | Valid import compatibility path, risky if treated as daily authority | M1/M5 preserve as special import mode. |
+| World/reference sync indexing | Reads world/reference files and metadata, writes SQLite indexes and relationship rows | Mostly indexing; can prune reference docs | M0/M2 for pruning/ownership classification. |
+| Structure workflows | Mutate SQLite canonical structure and may update sidecar mirrors/backups | Intended explicit mutation surface | M2/M3 preserve as sanctioned owner. |
+
+## Compatibility Paths To Preserve
+
+- Scrivener External Folder Sync import and direct merge need sidecar-shaped
+  inputs while import remains a special mode.
+- Frontmatter-to-sidecar auto-migration currently preserves older plain-text
+  projects.
+- Numeric chapter fields and folder-derived chapter names remain read/import
+  compatibility, not mutation authority.
+- Reference aliases are used by existing metadata files and should remain
+  import/read compatibility until M4 defines canonical write workflows.
+- Existing dry-run/apply workflows need reviewable output even if writable
+  sidecars are removed; M1 should assign those outputs to review snapshots.
+
+## Schema Gap Decisions Needed Before Behavior Changes
+
+- **Migrate-to-schema candidates:** scene workflow status, scene flags/review
+  notes if retained, character tags, place tags, place associated characters,
+  and possibly character group.
+- **Generated/import-only candidates:** `external_source`, `external_id`,
+  sidecar `threads`, legacy reference aliases, numeric chapter fields, and
+  folder-derived structure.
+- **Deprecated candidates:** sidecar `threads` as daily input, version strings
+  as a separate scene field if ordinary tags are sufficient, and sidecar-only
+  flags if replaced by review snapshots.
+- **Intentionally prose/file-owned candidates:** authored scene prose,
+  character/place notes, and reference document bodies.
+
+## M0 Gate Assessment
+
+- Scenes, chapters, epigraphs, threads, characters, places, reference links,
+  tags, status fields, and source identifiers now have named current owners.
+- Sidecar-shaped fields with no SQLite home are identified and assigned a
+  required decision path.
+- Prose-derived enrichment and apply/dry-run workflows are represented in the
+  write-order inventory.
+- The schema-gap suggestions are accepted as the decision basis for M1 snapshot
+  design.
+- Later behavior-changing milestones should either resolve the unresolved
+  schema-gap decisions above or split them into focused follow-up issues before
+  changing daily-work mutation paths.
+
+## Evidence
+
+- [src/core/db.js](../../../../src/core/db.js)
+- [src/sync/metadata-lint.js](../../../../src/sync/metadata-lint.js)
+- [src/sync/sync.js](../../../../src/sync/sync.js)
+- [src/tools/metadata.js](../../../../src/tools/metadata.js)
+- [src/tools/sync.js](../../../../src/tools/sync.js)
+- [src/tools/search.js](../../../../src/tools/search.js)
+- [src/tools/reference-link-persistence.js](../../../../src/tools/reference-link-persistence.js)

--- a/docs/initiatives/backlog/architecture-alignment-follow-up/milestones.md
+++ b/docs/initiatives/backlog/architecture-alignment-follow-up/milestones.md
@@ -1,10 +1,11 @@
 # Architecture Alignment Follow-up — Milestones
 
-**Status:** Deferred backlog (not active)
+**Status:** Backlog initiative in progress by milestone
 
 This milestone plan breaks the Architecture Alignment Follow-up PRD into
 independently reviewable slices. Use [prd.md](prd.md) for product framing and
 this document for sequencing, gates, and implementation readiness.
+M0–M2 are accepted; M3–M5 remain deferred for future prioritization.
 
 ## Objective
 

--- a/docs/initiatives/backlog/architecture-alignment-follow-up/milestones.md
+++ b/docs/initiatives/backlog/architecture-alignment-follow-up/milestones.md
@@ -137,7 +137,7 @@ Out of scope:
 
 ## M2 — Managed Sync Preservation
 
-Status: In progress.
+Status: Accepted.
 
 Goal: stop ordinary managed-project sync from deleting canonical structure
 because prose or representation files are missing.
@@ -158,6 +158,22 @@ Evidence:
 
 - [src/sync/sync.js](../../../../src/sync/sync.js)
 - [src/test/unit/sync.test.mjs](../../../../src/test/unit/sync.test.mjs)
+- [release-log.md](../../../../release-log.md)
+
+Acceptance notes:
+
+- Managed sync now preserves canonical scenes, chapters, epigraphs, and scene
+  relationship rows when their filesystem representations are missing.
+- Missing canonical scene, chapter, and epigraph representations now produce
+  classified sync warnings instead of silent canonical deletion.
+- First-time import, legacy migration, and unmanaged pruning paths remain
+  covered by existing regression tests.
+- No new canonical mutation was introduced by this milestone; preservation
+  avoids deletion, so backup refresh and operation-history requirements do not
+  apply to the new missing-file diagnostics.
+- Explicit delete, detach, archive, or repair workflows remain deferred until a
+  product need requires canonical removal beyond existing restore and structure
+  workflows.
 
 Acceptance gates:
 

--- a/docs/initiatives/backlog/architecture-alignment-follow-up/milestones.md
+++ b/docs/initiatives/backlog/architecture-alignment-follow-up/milestones.md
@@ -46,8 +46,14 @@ Deliverables:
   - recovery snapshot;
   - deprecated.
 - Identify which fields remain sidecar-only or sidecar-first.
+- Identify fields without current SQLite homes, including scene
+  `external_source`, `external_id`, `status`, sidecar `threads`, character
+  `group` and `tags`, place `associated_characters` and `tags`, `versions`, and
+  legacy reference aliases.
 - Identify which outcome workflows already exist and where callers are still
   forced into storage-shaped operations.
+- Include prose-derived metadata enrichment and apply/dry-run workflows in the
+  write-order inventory.
 - Update [prd.md](prd.md) or add a companion inventory document with the
   ownership matrix.
 
@@ -58,6 +64,8 @@ Acceptance gates:
 - Relationship metadata families have explicit write-order expectations.
 - Each sidecar-shaped field is classified as current authority, generated view,
   import compatibility, review snapshot, recovery snapshot, or deprecated.
+- Fields without a current SQLite home are marked as migrate-to-schema,
+  generated/import-only, deprecated, or intentionally prose/file-owned.
 - Maintainers can see which compatibility paths are safe to preserve and which
   require migration or deprecation.
 - No behavior-changing milestone starts until this inventory is reviewed.
@@ -148,6 +156,9 @@ Acceptance gates:
   coherent after the change.
 - Tool responses guide users or agents to the next explicit outcome instead of
   silently mutating canonical state.
+- Every canonical mutation introduced or reordered by this milestone refreshes
+  project backup artifacts and operation history after successful commit, or
+  documents why the affected state is non-canonical or derived.
 
 Test strategy:
 
@@ -192,6 +203,9 @@ Acceptance gates:
   canonical input during daily work.
 - Tests prove path-conflicting managed scenes preserve structural fields.
 - Tool guidance points structural changes to explicit structure workflows.
+- Existing non-structural metadata use cases remain available, or are
+  explicitly marked pending M4 replacement with diagnostics and next-step
+  guidance.
 
 Test strategy:
 
@@ -218,7 +232,8 @@ instead of storage CRUD.
 Deliverables:
 
 - Convert or add workflows for thread tracking, character/place association,
-  reference linking, metadata audit, and metadata repair where gaps exist.
+  reference linking, prose-derived metadata enrichment, metadata audit, and
+  metadata repair where gaps exist.
 - Ensure active relationship writes are SQLite-first, validated, and
   diagnostically clear.
 - Keep compatibility files read-only, generated, import-only, or deprecated
@@ -237,6 +252,11 @@ Acceptance gates:
   as `threads`, `scene_threads`, `scene_tags`, or `reference_links`.
 - Active writes are SQLite-first and have clear validation and rollback
   behavior.
+- Every canonical mutation introduced or reordered by this milestone refreshes
+  project backup artifacts and operation history after successful commit, or
+  documents why the affected state is non-canonical or derived.
+- Reference-link apply workflows commit SQLite first or transactionally couple
+  compatibility output with canonical writes.
 - Compatibility files cannot be mistaken for current relationship authority.
 - Workflow discovery steers both humans and AI agents toward outcome-level
   operations.

--- a/docs/initiatives/backlog/architecture-alignment-follow-up/milestones.md
+++ b/docs/initiatives/backlog/architecture-alignment-follow-up/milestones.md
@@ -137,7 +137,7 @@ Out of scope:
 
 ## M2 — Managed Sync Preservation
 
-Status: Planned.
+Status: In progress.
 
 Goal: stop ordinary managed-project sync from deleting canonical structure
 because prose or representation files are missing.
@@ -153,6 +153,11 @@ Deliverables:
   missing generated artifacts.
 - Cover scenes, epigraphs, chapters, and relationship rows affected by sync
   pruning.
+
+Evidence:
+
+- [src/sync/sync.js](../../../../src/sync/sync.js)
+- [src/test/unit/sync.test.mjs](../../../../src/test/unit/sync.test.mjs)
 
 Acceptance gates:
 

--- a/docs/initiatives/backlog/architecture-alignment-follow-up/milestones.md
+++ b/docs/initiatives/backlog/architecture-alignment-follow-up/milestones.md
@@ -1,0 +1,304 @@
+# Architecture Alignment Follow-up — Milestones
+
+**Status:** Deferred backlog (not active)
+
+This milestone plan breaks the Architecture Alignment Follow-up PRD into
+independently reviewable slices. Use [prd.md](prd.md) for product framing and
+this document for sequencing, gates, and implementation readiness.
+
+## Objective
+
+Tighten remaining target-architecture drift while preserving Writing MCP's core
+direction: SQLite is canonical for structural and relationship metadata, prose
+remains file-based, generated artifacts provide transparency or recovery input,
+and public tools express writing outcomes rather than storage internals.
+
+## Guardrails
+
+- Do not make sidecars, folders, generated exports, review snapshots, or
+  recovery snapshots daily-work authority.
+- Do not remove Scrivener import or legacy compatibility paths without an
+  explicit migration decision.
+- Keep first-time import and legacy migration behavior separate from ordinary
+  managed-project sync behavior.
+- Keep destructive canonical changes explicit, recoverable, and diagnosable.
+- Preserve authored prose as file-based content.
+- Prefer outcome-oriented workflows over raw CRUD wrappers around tables or
+  files.
+- Treat Milestones 0 and 1 as decision gates before behavior-changing work.
+
+## M0 — Metadata Ownership Inventory
+
+Status: Planned.
+
+Goal: build an implementation-backed inventory before changing behavior.
+
+Deliverables:
+
+- Inventory current metadata fields, relationship tables, sidecar fields,
+  generated views, and import/export paths.
+- Mark each metadata family as one of:
+  - SQLite-canonical;
+  - prose-authored;
+  - generated view;
+  - import-only compatibility input;
+  - review snapshot;
+  - recovery snapshot;
+  - deprecated.
+- Identify which fields remain sidecar-only or sidecar-first.
+- Identify which outcome workflows already exist and where callers are still
+  forced into storage-shaped operations.
+- Update [prd.md](prd.md) or add a companion inventory document with the
+  ownership matrix.
+
+Acceptance gates:
+
+- Scenes, chapters, epigraphs, threads, characters, places, reference links,
+  tags, status fields, and source identifiers all have named canonical owners.
+- Relationship metadata families have explicit write-order expectations.
+- Each sidecar-shaped field is classified as current authority, generated view,
+  import compatibility, review snapshot, recovery snapshot, or deprecated.
+- Maintainers can see which compatibility paths are safe to preserve and which
+  require migration or deprecation.
+- No behavior-changing milestone starts until this inventory is reviewed.
+
+Test strategy:
+
+- No production behavior changes are expected.
+- Add characterization tests only when the inventory depends on fragile current
+  behavior that later milestones will change.
+
+Out of scope:
+
+- Schema migrations.
+- Tool behavior changes.
+- Sidecar deprecation.
+
+## M1 — Snapshot Model Decision
+
+Status: Planned.
+
+Goal: replace the writable-sidecar mental model with explicit review snapshots
+and recovery snapshots.
+
+Deliverables:
+
+- Define review snapshots as temporary, human/AI-readable before/after material
+  for dry runs, Git review, and proposed operations.
+- Define recovery snapshots as durable rollback or rebuild material tied to
+  backup/restore workflows.
+- Document that neither snapshot type is a daily-work source of truth.
+- Decide whether existing sidecar-shaped generated output should become a named
+  snapshot artifact or be deprecated.
+- Update architecture docs so sidecars, review snapshots, and recovery
+  snapshots have distinct ownership and mutation rules.
+
+Acceptance gates:
+
+- The Managed Structure Contract or related architecture docs state that review
+  snapshots are advisory and recovery snapshots are explicit restore inputs.
+- Planned tool behavior routes proposed changes through review snapshots and
+  committed changes through SQLite-backed workflows.
+- Generated sidecar-shaped output has a named future role or deprecation path.
+- Restore authority remains explicit and does not rely on daily sidecar edits.
+- The decision is documented before sync, metadata, or relationship workflows
+  start changing sidecar behavior.
+
+Test strategy:
+
+- Documentation-only unless an existing snapshot/export tool is renamed or
+  reclassified.
+- If tool contracts change, add focused tests for output labels, guidance, and
+  non-authoritative warnings.
+
+Out of scope:
+
+- Implementing new snapshot tools.
+- Removing existing compatibility files.
+- Changing restore implementation.
+
+## M2 — Managed Sync Preservation
+
+Status: Planned.
+
+Goal: stop ordinary managed-project sync from deleting canonical structure
+because prose or representation files are missing.
+
+Deliverables:
+
+- Change sync planning so missing files produce diagnostics or repair/delete
+  candidates instead of silent canonical deletion.
+- Preserve first-time import and legacy migration behavior as explicit modes.
+- Add explicit delete, detach, archive, or repair follow-up workflows only when
+  product needs require canonical removal.
+- Return actionable diagnostics for missing prose, stale representation, and
+  missing generated artifacts.
+- Cover scenes, epigraphs, chapters, and relationship rows affected by sync
+  pruning.
+
+Acceptance gates:
+
+- Managed daily sync observes filesystem absence without treating it as
+  canonical delete authority.
+- Destructive structural outcomes require an explicit workflow, restore
+  operation, or confirmed repair path.
+- Import and migration modes still support legitimate adoption from external
+  structure.
+- Existing chapter, scene, epigraph, backup, and structure diagnostics remain
+  coherent after the change.
+- Tool responses guide users or agents to the next explicit outcome instead of
+  silently mutating canonical state.
+
+Test strategy:
+
+- Unit tests for missing-file planning and prune behavior by project mode.
+- Integration tests for sync after deleting scene prose, epigraph files, chapter
+  folders, and relationship representations in a managed project.
+- Regression tests for first-time import and legacy migration behavior.
+
+Out of scope:
+
+- Broad sidecar deprecation.
+- Relationship workflow redesign.
+- New recovery snapshot implementation unless needed for diagnostics.
+
+## M3 — Sidecar Write Boundary
+
+Status: Planned.
+
+Goal: prevent generic metadata updates from rewriting structural sidecar
+compatibility fields and stop sidecar-shaped files from acting as active
+mutation surfaces.
+
+Deliverables:
+
+- Separate raw sidecar reads from sync-normalized metadata reads.
+- Preserve existing structural compatibility fields during non-structural
+  updates.
+- Route any regeneration of structure-shaped compatibility output through named
+  generated-view, review-snapshot, or recovery-snapshot workflows.
+- Ensure structural mirror updates are owned by explicit structure workflows or
+  named repair/regeneration flows.
+- Add diagnostics or guidance when callers attempt to use generic metadata
+  tools for structural outcomes.
+
+Acceptance gates:
+
+- `update_scene_metadata` and related generic metadata tools cannot
+  accidentally rewrite structural representations.
+- Path-derived `part`, `chapter`, `chapter_id`, or `chapter_title` values are
+  not mirrored by non-structural updates.
+- Structural compatibility output has a named owner and is not treated as
+  canonical input during daily work.
+- Tests prove path-conflicting managed scenes preserve structural fields.
+- Tool guidance points structural changes to explicit structure workflows.
+
+Test strategy:
+
+- Unit tests for raw sidecar read helpers and normalized metadata readers.
+- Unit tests for metadata update preservation of structural fields.
+- Integration tests for `update_scene_metadata` on path-conflicting managed
+  scenes.
+- Regression tests for chapter resolution, scene assignment, move scene, and
+  structure diagnostics.
+
+Out of scope:
+
+- Removing sidecar read compatibility.
+- Redesigning character/place/reference relationship workflows.
+- Changing authored prose storage.
+
+## M4 — Outcome-Oriented Relationship Workflows
+
+Status: Planned.
+
+Goal: expose relationship metadata changes through story and review outcomes
+instead of storage CRUD.
+
+Deliverables:
+
+- Convert or add workflows for thread tracking, character/place association,
+  reference linking, metadata audit, and metadata repair where gaps exist.
+- Ensure active relationship writes are SQLite-first, validated, and
+  diagnostically clear.
+- Keep compatibility files read-only, generated, import-only, or deprecated
+  according to the M0 ownership matrix.
+- Update `describe_workflows` and generated tool docs so AI agents choose
+  outcome workflows.
+- Preserve useful review/dry-run visibility through review snapshots rather
+  than writable sidecars.
+
+Acceptance gates:
+
+- Public tools express goals such as tracking an arc, linking evidence,
+  reviewing stale relationships, repairing metadata, or preparing a recovery
+  snapshot.
+- Relationship mutations do not require callers to understand table names such
+  as `threads`, `scene_threads`, `scene_tags`, or `reference_links`.
+- Active writes are SQLite-first and have clear validation and rollback
+  behavior.
+- Compatibility files cannot be mistaken for current relationship authority.
+- Workflow discovery steers both humans and AI agents toward outcome-level
+  operations.
+
+Test strategy:
+
+- Unit tests for relationship validation and write ordering.
+- Integration tests for representative thread, character/place, and reference
+  link workflows.
+- Regression tests for relationship workflow guidance and generated tool docs.
+- Characterization tests for any retained import-only sidecar relationship
+  behavior.
+
+Out of scope:
+
+- Broad prose editing redesign.
+- Raw table maintenance tools as public MCP workflow replacements.
+- New analytics features beyond relationship diagnostics needed for alignment.
+
+## M5 — Deprecation, Migration, and Documentation
+
+Status: Planned.
+
+Goal: make remaining sidecar behavior explicit, migrated, or removed from normal
+workflows.
+
+Deliverables:
+
+- Add migration guidance for projects with existing sidecars.
+- Update README, workflow docs, generated tool docs, and architecture docs where
+  user-facing behavior changes.
+- Add release-log coverage if tools or compatibility expectations change.
+- Document which sidecar paths remain import compatibility and which are
+  generated/review/recovery artifacts.
+- Remove or de-emphasize docs that imply sidecars are daily-work authority.
+
+Acceptance gates:
+
+- Product docs consistently present SQLite as canonical structural and
+  relationship metadata storage.
+- Any remaining sidecar support has a named compatibility role.
+- Users and AI agents can understand how to migrate, review, recover, and
+  continue daily work without editing sidecars as source of truth.
+- Release notes describe behavior changes and migration expectations.
+- Completed milestone evidence is linked from this file.
+
+Test strategy:
+
+- Documentation link checks where available.
+- Regression tests for generated tool docs and workflow discovery.
+- Integration tests for migration or compatibility paths that remain supported.
+- Manual review of README, PRODUCT, architecture docs, and release-log text.
+
+Out of scope:
+
+- Removing Scrivener support.
+- Introducing divisions.
+- Replacing database backup/restore with sidecar replay.
+
+## Related
+
+- [prd.md](prd.md)
+- [PRODUCT.md](../../../../PRODUCT.md)
+- [Managed Structure Contract](../../../foundations/managed-structure-contract.md)
+- [Conceptual Target Architecture](../../../foundations/target-architecture.md)

--- a/docs/initiatives/backlog/architecture-alignment-follow-up/milestones.md
+++ b/docs/initiatives/backlog/architecture-alignment-follow-up/milestones.md
@@ -29,7 +29,7 @@ and public tools express writing outcomes rather than storage internals.
 
 ## M0 — Metadata Ownership Inventory
 
-Status: Planned.
+Status: Accepted for M1 sequencing.
 
 Goal: build an implementation-backed inventory before changing behavior.
 
@@ -57,10 +57,15 @@ Deliverables:
 - Update [prd.md](prd.md) or add a companion inventory document with the
   ownership matrix.
 
+Evidence:
+
+- [inventory.md](inventory.md)
+
 Acceptance gates:
 
 - Scenes, chapters, epigraphs, threads, characters, places, reference links,
-  tags, status fields, and source identifiers all have named canonical owners.
+  tags, status fields, and source identifiers all have named current owners and
+  target ownership decisions.
 - Relationship metadata families have explicit write-order expectations.
 - Each sidecar-shaped field is classified as current authority, generated view,
   import compatibility, review snapshot, recovery snapshot, or deprecated.
@@ -84,7 +89,7 @@ Out of scope:
 
 ## M1 — Snapshot Model Decision
 
-Status: Planned.
+Status: Drafted for review.
 
 Goal: replace the writable-sidecar mental model with explicit review snapshots
 and recovery snapshots.
@@ -100,6 +105,11 @@ Deliverables:
   snapshot artifact or be deprecated.
 - Update architecture docs so sidecars, review snapshots, and recovery
   snapshots have distinct ownership and mutation rules.
+
+Evidence:
+
+- [Managed Structure Contract](../../../foundations/managed-structure-contract.md#snapshot-and-sidecar-roles)
+- [Conceptual Target Architecture](../../../foundations/target-architecture.md#snapshot-and-sidecar-roles)
 
 Acceptance gates:
 

--- a/docs/initiatives/backlog/architecture-alignment-follow-up/prd.md
+++ b/docs/initiatives/backlog/architecture-alignment-follow-up/prd.md
@@ -1,11 +1,12 @@
 # Architecture Alignment Follow-up
 
-**Status:** Deferred backlog (not active)
+**Status:** Backlog initiative in progress by milestone
 
 This initiative records target-architecture alignment gaps discovered during
 periodic reviews. It is a holding place for missing parts, correction
-candidates, and follow-up work that should not be lost, but it is not active
-implementation scope until explicitly prioritized.
+candidates, and follow-up work that should not be lost. M0–M2 have been
+accepted and implemented through the managed sync preservation slice; M3–M5
+remain deferred until explicitly prioritized.
 
 Implementation sequencing lives in [milestones.md](milestones.md). The M0
 metadata ownership inventory lives in [inventory.md](inventory.md).

--- a/docs/initiatives/backlog/architecture-alignment-follow-up/prd.md
+++ b/docs/initiatives/backlog/architecture-alignment-follow-up/prd.md
@@ -7,7 +7,8 @@ periodic reviews. It is a holding place for missing parts, correction
 candidates, and follow-up work that should not be lost, but it is not active
 implementation scope until explicitly prioritized.
 
-Implementation sequencing lives in [milestones.md](milestones.md).
+Implementation sequencing lives in [milestones.md](milestones.md). The M0
+metadata ownership inventory lives in [inventory.md](inventory.md).
 
 ## Goal
 
@@ -211,6 +212,7 @@ or delete operations for individual tables.
 - [Conceptual Target Architecture](../../../foundations/target-architecture.md)
 - [Managed Structure Contract](../../../foundations/managed-structure-contract.md)
 - [Milestones](milestones.md)
+- [Metadata Ownership Inventory](inventory.md)
 - [Structural Authority Hardening](../../done/structural-authority-hardening/prd.md)
 - [Target Architecture Migration](../../done/target-architecture-migration/prd.md)
 - [Database Backup and Recovery](../../done/database-backup-recovery/prd.md)

--- a/docs/initiatives/backlog/architecture-alignment-follow-up/prd.md
+++ b/docs/initiatives/backlog/architecture-alignment-follow-up/prd.md
@@ -7,6 +7,8 @@ periodic reviews. It is a holding place for missing parts, correction
 candidates, and follow-up work that should not be lost, but it is not active
 implementation scope until explicitly prioritized.
 
+Implementation sequencing lives in [milestones.md](milestones.md).
+
 ## Goal
 
 Keep Writing MCP converging toward the [Conceptual Target Architecture](../../../foundations/target-architecture.md)
@@ -173,135 +175,6 @@ workflows. The public tool surface should preserve author intent, validation,
 diagnostics, and next-step guidance instead of exposing direct create/read/update
 or delete operations for individual tables.
 
-## Milestone Breakdown
-
-These milestones are intended to become independently reviewable implementation
-initiatives or PRs. Milestones 0 and 1 are decision and design work; later
-milestones change behavior only after ownership and snapshot semantics are
-settled.
-
-### Milestone 0: Metadata Ownership Inventory
-
-Outcome:
-- Produce an implementation-backed inventory of current metadata fields,
-  relationship tables, sidecar fields, generated views, and import/export paths.
-
-Key questions:
-- Which fields are already SQLite-canonical?
-- Which fields remain sidecar-only or sidecar-first?
-- Which fields are legacy import compatibility rather than current product
-  state?
-- Which outcome workflows already exist, and where are callers still forced
-  into storage-shaped operations?
-
-Deliverables:
-- Update this PRD with a metadata ownership matrix.
-- Mark each metadata family as canonical, generated, import-only, review
-  snapshot, recovery snapshot, or deprecated.
-- Identify migration risks before changing behavior.
-
-Exit criteria:
-- No implementation begins until the canonical owner and compatibility role are
-  named for scenes, chapters, epigraphs, threads, characters, places, reference
-  links, tags, status fields, and source identifiers.
-
-### Milestone 1: Snapshot Model Decision
-
-Outcome:
-- Replace the writable-sidecar mental model with explicit review snapshots and
-  recovery snapshots.
-
-Deliverables:
-- Define review snapshots as temporary, human/AI-readable before/after material
-  for dry runs, reviews, and proposed operations.
-- Define recovery snapshots as durable rollback or rebuild material tied to
-  backup/restore workflows.
-- Document that neither snapshot type is a daily-work source of truth.
-- Decide whether any existing generated sidecar-shaped output should become a
-  named snapshot artifact or be deprecated.
-
-Exit criteria:
-- The architecture docs describe sidecars, review snapshots, and recovery
-  snapshots with distinct ownership and mutation rules.
-- Planned tool behavior routes proposed changes through review snapshots and
-  committed changes through SQLite-backed workflows.
-
-### Milestone 2: Managed Sync Preservation
-
-Outcome:
-- Ordinary managed-project sync stops deleting canonical structure merely
-  because prose or representation files are missing.
-
-Deliverables:
-- Change sync planning so missing files produce diagnostics or repair/delete
-  candidates instead of silent canonical deletion.
-- Preserve first-time import and legacy migration behavior as explicit modes.
-- Add focused tests for missing scene prose, epigraph files, chapters, and
-  relationship rows.
-
-Exit criteria:
-- Managed daily sync observes filesystem absence without treating it as
-  canonical delete authority.
-- Any destructive structural outcome requires an explicit workflow, restore
-  operation, or confirmed repair path.
-
-### Milestone 3: Sidecar Write Boundary
-
-Outcome:
-- Generic metadata updates no longer rewrite structural sidecar compatibility
-  fields, and sidecar-shaped files stop acting as active mutation surfaces.
-
-Deliverables:
-- Separate raw sidecar reads from sync-normalized metadata reads.
-- Preserve existing structural compatibility fields during non-structural
-  updates.
-- Route any regeneration of structure-shaped compatibility output through named
-  generated-view, review-snapshot, or recovery-snapshot workflows.
-
-Exit criteria:
-- Non-structural metadata tools cannot accidentally rewrite structural
-  representations.
-- Tests cover path-conflicting managed scenes and structural-field
-  preservation.
-
-### Milestone 4: Outcome-Oriented Relationship Workflows
-
-Outcome:
-- Relationship metadata changes are exposed through story/review outcomes, not
-  storage CRUD.
-
-Deliverables:
-- Convert or add workflows for thread tracking, character/place association,
-  reference linking, metadata audit, and metadata repair where gaps exist.
-- Ensure active writes are SQLite-first, validated, and diagnostically clear.
-- Keep compatibility files read-only, generated, import-only, or deprecated
-  according to the Milestone 0 ownership matrix.
-
-Exit criteria:
-- Public tools express user goals such as tracking an arc, linking evidence,
-  reviewing stale relationships, repairing metadata, or preparing a recovery
-  snapshot.
-- Tool docs and `describe_workflows` guide AI agents toward outcomes rather
-  than tables or files.
-
-### Milestone 5: Deprecation, Migration, and Documentation
-
-Outcome:
-- Legacy sidecar behavior is either migrated, explicitly retained as import
-  compatibility, or removed from normal workflows.
-
-Deliverables:
-- Add migration guidance for projects with existing sidecars.
-- Update README, workflow docs, generated tool docs, and architecture docs where
-  user-facing behavior changes.
-- Add release-log coverage if tools or compatibility expectations change.
-
-Exit criteria:
-- The product docs consistently present SQLite as canonical structural and
-  relationship metadata storage.
-- Any remaining sidecar support has a named compatibility role and cannot be
-  mistaken for daily-work authority.
-
 ## Acceptance Criteria
 
 1. Architecture review findings are captured in this initiative or split into
@@ -319,7 +192,7 @@ Exit criteria:
 7. Sidecar replacement work introduces outcome-oriented workflows, not raw CRUD
    wrappers around SQLite tables.
 8. The PRD contains a milestone plan that can be converted into independently
-   reviewable implementation initiatives.
+   reviewable implementation initiatives in [milestones.md](milestones.md).
 
 ## Test Strategy
 
@@ -337,6 +210,7 @@ Exit criteria:
 
 - [Conceptual Target Architecture](../../../foundations/target-architecture.md)
 - [Managed Structure Contract](../../../foundations/managed-structure-contract.md)
+- [Milestones](milestones.md)
 - [Structural Authority Hardening](../../done/structural-authority-hardening/prd.md)
 - [Target Architecture Migration](../../done/target-architecture-migration/prd.md)
 - [Database Backup and Recovery](../../done/database-backup-recovery/prd.md)

--- a/docs/initiatives/backlog/architecture-alignment-follow-up/prd.md
+++ b/docs/initiatives/backlog/architecture-alignment-follow-up/prd.md
@@ -1,0 +1,342 @@
+# Architecture Alignment Follow-up
+
+**Status:** Deferred backlog (not active)
+
+This initiative records target-architecture alignment gaps discovered during
+periodic reviews. It is a holding place for missing parts, correction
+candidates, and follow-up work that should not be lost, but it is not active
+implementation scope until explicitly prioritized.
+
+## Goal
+
+Keep Writing MCP converging toward the [Conceptual Target Architecture](../../../foundations/target-architecture.md)
+and [Managed Structure Contract](../../../foundations/managed-structure-contract.md)
+as compatibility paths, recovery workflows, and day-to-day tools evolve.
+
+The goal is not to reopen completed initiatives by default. The goal is to
+make architectural drift visible, group it by risk, and turn the highest-value
+corrections into focused implementation work when selected.
+
+## Problem
+
+Writing MCP has materially moved toward the target architecture:
+
+- SQLite is the durable canonical model for structural manuscript state.
+- Prose remains file-based and inspectable.
+- Explicit structure workflows exist for chapter, scene, and epigraph changes.
+- Generated exports and backups are transparency and recovery artifacts, not
+  normal mutation surfaces.
+- Managed sync preserves canonical structure over folder and sidecar-derived
+  hints in common conflict cases.
+
+Some compatibility and maintenance paths still need continued scrutiny. These
+paths are useful, but they can accidentally become authority leaks if they
+mutate canonical state, rewrite structural representations, or make filesystem
+state look more authoritative than the MCP control plane.
+
+## User Value
+
+- Authors get safer project state because structural changes remain deliberate.
+- AI agents have fewer tempting shortcuts around sanctioned workflows.
+- Maintainers can prioritize architecture cleanup without relying on memory
+  from past reviews.
+- Future initiatives such as divisions can build on a cleaner structure
+  boundary instead of inheriting ambiguous behavior.
+
+## Alignment Log
+
+### 1. Managed sync should not delete canonical scene structure from filesystem absence
+
+Current pressure point:
+- Ordinary `syncAll()` prunes missing scene rows, scene relationship rows,
+  epigraphs, and chapters based on what files were observed during the scan.
+
+Why it matters:
+- For managed projects, filesystem absence should be treated as missing prose,
+  stale representation, or a repair/delete candidate.
+- Actual canonical deletion should happen through an explicit workflow, restore
+  operation, or confirmed repair path.
+
+Target direction:
+- Preserve canonical rows for managed projects when prose files disappear.
+- Report missing prose or missing representation diagnostics.
+- Add explicit delete, detach, archive, or repair workflows if product needs
+  require canonical removal.
+- Keep first-time import and legacy migration behavior separate from ordinary
+  daily sync behavior.
+
+### 2. Generic metadata updates should not rewrite structural sidecar fields from path normalization
+
+Current pressure point:
+- `update_scene_metadata` rejects structural fields in user input, but it reads
+  normalized metadata and writes the merged object back to the sidecar.
+- That can mirror path-derived `part`, `chapter`, `chapter_id`, or
+  `chapter_title` compatibility fields while the user only requested a
+  non-structural metadata update.
+
+Why it matters:
+- SQLite canonical state is protected for managed projects, but the sidecar can
+  still become a misleading structural representation.
+- A tool described as non-structural should preserve structural representation
+  fields unless an explicit structure workflow owns the mirror update.
+
+Target direction:
+- Split raw sidecar reads from sync-normalized metadata reads.
+- Make generic metadata updates preserve existing structural sidecar fields.
+- Route structural sidecar mirror writes only through explicit structure
+  workflows or named repair/regeneration flows.
+
+### 3. Relationship metadata ownership and write ordering should be explicit
+
+Current pressure point:
+- Some relationship-oriented metadata, such as character/place tags, reference
+  links, and legacy thread-shaped sidecar fields, still crosses sidecar,
+  generated-output, and SQLite boundaries unevenly.
+- Several paths write a compatibility representation first and then reindex or
+  mirror data into SQLite.
+
+Why it matters:
+- SQLite should be the canonical model for structured metadata relationships.
+- Sidecar-first writes make it harder to reason about validation, rollback,
+  diagnostics, and recovery ordering.
+- Relationship metadata is exactly where AI agents need outcome-level tools,
+  because raw table operations expose implementation shape instead of story
+  intent.
+
+Target direction:
+- Classify each relationship metadata family by canonical owner, compatibility
+  input/output role, and recovery behavior.
+- Move active relationship changes behind SQLite-first, outcome-oriented
+  workflows.
+- Keep any compatibility files as generated views, import inputs, review
+  snapshots, or recovery snapshots rather than writable authority.
+
+## Scope
+
+### In Scope
+
+- Track architecture alignment gaps found during reviews.
+- Convert confirmed gaps into focused follow-up milestones.
+- Add characterization tests around risky compatibility behavior.
+- Tighten ordinary sync, generic metadata updates, diagnostics, and repair
+  workflows where they blur authority boundaries.
+- Clarify relationship metadata ownership and replace storage-shaped mutation
+  surfaces with outcome-oriented workflows.
+- Update workflow guidance and generated tool docs when behavior changes.
+
+### Out of Scope
+
+- Rewriting prose storage.
+- Removing Scrivener import or legacy compatibility paths wholesale.
+- Removing numeric chapter read aliases without a separate product decision.
+- Introducing divisions.
+- Changing generated backup or structure export authority without an explicit
+  recovery-design decision.
+
+## Architecture Alignment
+
+Use the Managed Structure Contract as the arbiter:
+
+- Canonical structure changes must go through sanctioned MCP workflows.
+- Prose can remain file-based and human-inspectable.
+- Sidecars, folders, and generated exports are representations, compatibility
+  surfaces, or recovery inputs, not daily-work authority.
+- Import may infer cautiously, but daily work should be explicit.
+- Maintenance may observe broadly and regenerate derived state, but canonical
+  repair should be deliberate.
+
+## Tooling Philosophy
+
+The product-wide tool philosophy applies here: MCP tools should express writing,
+revision, review, recovery, and reasoning outcomes rather than exposing raw
+storage CRUD or table-shaped APIs.
+
+Replacing writable sidecars with SQLite-canonical data must preserve that
+principle.
+
+The user or AI agent should not need to understand whether the implementation
+stores state in `threads`, `scene_threads`, `scene_tags`, `reference_links`, or
+future normalized tables.
+
+For example, a thread workflow should focus on outcomes such as:
+
+- track a storyline across relevant scenes;
+- mark a scene as setup, escalation, reveal, reversal, payoff, or another
+  thread-specific beat;
+- review a thread's ordered progression and identify missing setup/payoff or
+  stale scene evidence;
+- find a named or described thread such as "Mneme's tablet";
+- remove a mistaken scene from a thread because it is not actually relevant.
+
+The database remains the canonical implementation detail underneath those
+workflows. The public tool surface should preserve author intent, validation,
+diagnostics, and next-step guidance instead of exposing direct create/read/update
+or delete operations for individual tables.
+
+## Milestone Breakdown
+
+These milestones are intended to become independently reviewable implementation
+initiatives or PRs. Milestones 0 and 1 are decision and design work; later
+milestones change behavior only after ownership and snapshot semantics are
+settled.
+
+### Milestone 0: Metadata Ownership Inventory
+
+Outcome:
+- Produce an implementation-backed inventory of current metadata fields,
+  relationship tables, sidecar fields, generated views, and import/export paths.
+
+Key questions:
+- Which fields are already SQLite-canonical?
+- Which fields remain sidecar-only or sidecar-first?
+- Which fields are legacy import compatibility rather than current product
+  state?
+- Which outcome workflows already exist, and where are callers still forced
+  into storage-shaped operations?
+
+Deliverables:
+- Update this PRD with a metadata ownership matrix.
+- Mark each metadata family as canonical, generated, import-only, review
+  snapshot, recovery snapshot, or deprecated.
+- Identify migration risks before changing behavior.
+
+Exit criteria:
+- No implementation begins until the canonical owner and compatibility role are
+  named for scenes, chapters, epigraphs, threads, characters, places, reference
+  links, tags, status fields, and source identifiers.
+
+### Milestone 1: Snapshot Model Decision
+
+Outcome:
+- Replace the writable-sidecar mental model with explicit review snapshots and
+  recovery snapshots.
+
+Deliverables:
+- Define review snapshots as temporary, human/AI-readable before/after material
+  for dry runs, reviews, and proposed operations.
+- Define recovery snapshots as durable rollback or rebuild material tied to
+  backup/restore workflows.
+- Document that neither snapshot type is a daily-work source of truth.
+- Decide whether any existing generated sidecar-shaped output should become a
+  named snapshot artifact or be deprecated.
+
+Exit criteria:
+- The architecture docs describe sidecars, review snapshots, and recovery
+  snapshots with distinct ownership and mutation rules.
+- Planned tool behavior routes proposed changes through review snapshots and
+  committed changes through SQLite-backed workflows.
+
+### Milestone 2: Managed Sync Preservation
+
+Outcome:
+- Ordinary managed-project sync stops deleting canonical structure merely
+  because prose or representation files are missing.
+
+Deliverables:
+- Change sync planning so missing files produce diagnostics or repair/delete
+  candidates instead of silent canonical deletion.
+- Preserve first-time import and legacy migration behavior as explicit modes.
+- Add focused tests for missing scene prose, epigraph files, chapters, and
+  relationship rows.
+
+Exit criteria:
+- Managed daily sync observes filesystem absence without treating it as
+  canonical delete authority.
+- Any destructive structural outcome requires an explicit workflow, restore
+  operation, or confirmed repair path.
+
+### Milestone 3: Sidecar Write Boundary
+
+Outcome:
+- Generic metadata updates no longer rewrite structural sidecar compatibility
+  fields, and sidecar-shaped files stop acting as active mutation surfaces.
+
+Deliverables:
+- Separate raw sidecar reads from sync-normalized metadata reads.
+- Preserve existing structural compatibility fields during non-structural
+  updates.
+- Route any regeneration of structure-shaped compatibility output through named
+  generated-view, review-snapshot, or recovery-snapshot workflows.
+
+Exit criteria:
+- Non-structural metadata tools cannot accidentally rewrite structural
+  representations.
+- Tests cover path-conflicting managed scenes and structural-field
+  preservation.
+
+### Milestone 4: Outcome-Oriented Relationship Workflows
+
+Outcome:
+- Relationship metadata changes are exposed through story/review outcomes, not
+  storage CRUD.
+
+Deliverables:
+- Convert or add workflows for thread tracking, character/place association,
+  reference linking, metadata audit, and metadata repair where gaps exist.
+- Ensure active writes are SQLite-first, validated, and diagnostically clear.
+- Keep compatibility files read-only, generated, import-only, or deprecated
+  according to the Milestone 0 ownership matrix.
+
+Exit criteria:
+- Public tools express user goals such as tracking an arc, linking evidence,
+  reviewing stale relationships, repairing metadata, or preparing a recovery
+  snapshot.
+- Tool docs and `describe_workflows` guide AI agents toward outcomes rather
+  than tables or files.
+
+### Milestone 5: Deprecation, Migration, and Documentation
+
+Outcome:
+- Legacy sidecar behavior is either migrated, explicitly retained as import
+  compatibility, or removed from normal workflows.
+
+Deliverables:
+- Add migration guidance for projects with existing sidecars.
+- Update README, workflow docs, generated tool docs, and architecture docs where
+  user-facing behavior changes.
+- Add release-log coverage if tools or compatibility expectations change.
+
+Exit criteria:
+- The product docs consistently present SQLite as canonical structural and
+  relationship metadata storage.
+- Any remaining sidecar support has a named compatibility role and cannot be
+  mistaken for daily-work authority.
+
+## Acceptance Criteria
+
+1. Architecture review findings are captured in this initiative or split into
+   more specific initiatives before implementation begins.
+2. Each logged gap identifies the current behavior, why it matters, and the
+   target direction.
+3. Any implemented correction has focused unit coverage and integration
+   coverage when user-facing tool behavior changes.
+4. Ordinary managed-project sync no longer treats missing prose files as silent
+   canonical structural deletion.
+5. Generic metadata updates no longer rewrite structural sidecar compatibility
+   fields except through explicit structure or repair workflows.
+6. Workflow guidance continues to route humans and AI agents to named
+   structure tools for structural changes.
+7. Sidecar replacement work introduces outcome-oriented workflows, not raw CRUD
+   wrappers around SQLite tables.
+8. The PRD contains a milestone plan that can be converted into independently
+   reviewable implementation initiatives.
+
+## Test Strategy
+
+- Unit: managed sync missing-file planning, prune behavior by project mode,
+  raw sidecar read helpers, and metadata update preservation of structural
+  fields.
+- Integration: sync after prose deletion in a managed project, diagnostics for
+  missing prose, explicit delete/repair follow-up when introduced, and
+  `update_scene_metadata` on a path-conflicting managed scene.
+- Regression: chapter resolution, scene assignment, move scene, structure
+  diagnostics, backup diagnostics, relationship workflow guidance, and
+  generated tool docs.
+
+## Related
+
+- [Conceptual Target Architecture](../../../foundations/target-architecture.md)
+- [Managed Structure Contract](../../../foundations/managed-structure-contract.md)
+- [Structural Authority Hardening](../../done/structural-authority-hardening/prd.md)
+- [Target Architecture Migration](../../done/target-architecture-migration/prd.md)
+- [Database Backup and Recovery](../../done/database-backup-recovery/prd.md)

--- a/release-log.md
+++ b/release-log.md
@@ -6,6 +6,14 @@ This complements `CHANGELOG.md`:
 - `CHANGELOG.md` is technical and release-oriented.
 - This log is plain-language and outcome-oriented.
 
+### 2026-05-28 — Preserve managed scenes when prose files are missing
+
+- What changed: Ordinary `sync` now preserves canonical scene rows and their relationship metadata for managed projects when the scene prose/sidecar representation is missing, and reports a sync warning instead of silently pruning the SQLite state.
+- Why it matters: Missing files, stale generated representations, or accidental filesystem edits no longer erase canonical scene structure for projects already under MCP management.
+- Who is affected: Authors, maintainers, and AI agents running sync on managed projects after files have moved, disappeared, or been temporarily withheld.
+- Action needed: Review the sync warning, then use an explicit repair, restore, or future delete/detach workflow if the missing scene should truly be removed from canonical state.
+- PR: TBD
+
 ### 2026-05-25 — Apply trusted project backups transactionally
 
 - What changed: `restore_project_from_backup` can now apply a trusted project backup with `dry_run=false`, after the dry-run plan has been reviewed and required destructive or cross-scope confirmations are provided.

--- a/release-log.md
+++ b/release-log.md
@@ -12,7 +12,7 @@ This complements `CHANGELOG.md`:
 - Why it matters: Missing files, stale generated representations, or accidental filesystem edits no longer erase canonical structure or relationship metadata for projects already under MCP management.
 - Who is affected: Authors, maintainers, and AI agents running sync on managed projects after files have moved, disappeared, or been temporarily withheld.
 - Action needed: Review the sync warning, then use an explicit repair, restore, or future delete/detach workflow if the missing canonical item should truly be removed.
-- PR: TBD
+- PR: [#222](https://github.com/hannasdev/mcp-writing/pull/222)
 
 ### 2026-05-25 — Apply trusted project backups transactionally
 

--- a/release-log.md
+++ b/release-log.md
@@ -6,12 +6,12 @@ This complements `CHANGELOG.md`:
 - `CHANGELOG.md` is technical and release-oriented.
 - This log is plain-language and outcome-oriented.
 
-### 2026-05-28 — Preserve managed scenes when prose files are missing
+### 2026-05-28 — Preserve managed structure when representation files are missing
 
-- What changed: Ordinary `sync` now preserves canonical scene rows and their relationship metadata for managed projects when the scene prose/sidecar representation is missing, and reports a sync warning instead of silently pruning the SQLite state.
-- Why it matters: Missing files, stale generated representations, or accidental filesystem edits no longer erase canonical scene structure for projects already under MCP management.
+- What changed: Ordinary `sync` now preserves canonical scene, chapter, and epigraph rows for managed projects when prose or representation files are missing, and reports classified sync warnings instead of silently pruning the SQLite state.
+- Why it matters: Missing files, stale generated representations, or accidental filesystem edits no longer erase canonical structure or relationship metadata for projects already under MCP management.
 - Who is affected: Authors, maintainers, and AI agents running sync on managed projects after files have moved, disappeared, or been temporarily withheld.
-- Action needed: Review the sync warning, then use an explicit repair, restore, or future delete/detach workflow if the missing scene should truly be removed from canonical state.
+- Action needed: Review the sync warning, then use an explicit repair, restore, or future delete/detach workflow if the missing canonical item should truly be removed.
 - PR: TBD
 
 ### 2026-05-25 — Apply trusted project backups transactionally

--- a/src/sync/sync.js
+++ b/src/sync/sync.js
@@ -960,8 +960,8 @@ function canPruneScenes(syncDir) {
 function pruneMissingScenes(db, seenSceneKeys, syncDir, { managedProjectIds = new Set() } = {}) {
   const projectScope = inferSceneProjectScopeFromSyncDir(syncDir);
   const rows = projectScope
-    ? db.prepare(`SELECT scene_id, project_id FROM scenes WHERE project_id = ?`).all(projectScope)
-    : db.prepare(`SELECT scene_id, project_id FROM scenes`).all();
+    ? db.prepare(`SELECT scene_id, project_id, file_path FROM scenes WHERE project_id = ?`).all(projectScope)
+    : db.prepare(`SELECT scene_id, project_id, file_path FROM scenes`).all();
 
   const result = { deleted: 0, preservedManagedScenes: [] };
   for (const row of rows) {
@@ -971,6 +971,7 @@ function pruneMissingScenes(db, seenSceneKeys, syncDir, { managedProjectIds = ne
       result.preservedManagedScenes.push({
         scene_id: row.scene_id,
         project_id: row.project_id,
+        file_path: row.file_path,
       });
       continue;
     }
@@ -1085,6 +1086,21 @@ function collectMissingManagedRepresentationWarnings(db, syncDir, {
   }
 
   return warnings;
+}
+
+function formatStoredPathSuffix(syncDir, filePath) {
+  const displayPath = formatSyncRelativePath(syncDir, filePath);
+  return displayPath ? ` (${displayPath})` : "";
+}
+
+function formatPreservedManagedSceneWarning(syncDir, scene) {
+  const pathSuffix = formatStoredPathSuffix(syncDir, scene.file_path);
+  const sceneLabel = `${scene.project_id}/${scene.scene_id}`;
+  const filePaths = storedSyncPathCandidates(syncDir, scene.file_path);
+  if (filePaths.some(candidate => fs.existsSync(candidate))) {
+    return `Managed sync preserved canonical scene not observed during sync scan: ${sceneLabel}${pathSuffix}`;
+  }
+  return `Managed sync preserved canonical scene missing from filesystem: ${sceneLabel}${pathSuffix}`;
 }
 
 export function pruneSyncDerivedIndexes(db, syncDir, {
@@ -1525,6 +1541,7 @@ const WARNING_TYPE_LABELS = {
   orphaned_sidecar: "Orphaned sidecar",
   moved_scene: "Moved scene",
   missing_canonical_scene: "Missing canonical scene",
+  unobserved_canonical_scene: "Unobserved canonical scene",
   missing_canonical_chapter: "Missing canonical chapter",
   missing_canonical_epigraph: "Missing canonical epigraph",
   nested_mirror: "Ignored nested mirror path",
@@ -1538,6 +1555,7 @@ const WARNING_PATTERNS = [
   { type: "moved_scene",            re: /^Moved scene detected:/      },
   { type: "orphaned_sidecar",       re: /^Orphaned sidecar/          },
   { type: "missing_canonical_scene", re: /^Managed sync preserved canonical scene missing from filesystem:/ },
+  { type: "unobserved_canonical_scene", re: /^Managed sync preserved canonical scene not observed during sync scan:/ },
   { type: "missing_canonical_chapter", re: /^Managed sync preserved canonical chapter missing from filesystem:/ },
   { type: "missing_canonical_epigraph", re: /^Managed sync preserved canonical epigraph missing from filesystem:/ },
   { type: "nested_mirror",          re: /^Ignored nested mirror path:/ },
@@ -1721,7 +1739,7 @@ export function syncAll(db, syncDir, { quiet = false, writable = false } = {}) {
     managedProjectIds,
   });
   for (const scene of pruneResult.scenePrune?.preservedManagedScenes ?? []) {
-    warnings.push(`Managed sync preserved canonical scene missing from filesystem: ${scene.project_id}/${scene.scene_id}`);
+    warnings.push(formatPreservedManagedSceneWarning(syncDir, scene));
   }
   for (const warning of collectMissingManagedRepresentationWarnings(db, syncDir, {
     observedChapterKeys,

--- a/src/sync/sync.js
+++ b/src/sync/sync.js
@@ -1023,6 +1023,47 @@ function pruneMissingEpigraphs(db, seenEpigraphKeys, syncDir) {
   }
 }
 
+function formatSyncRelativePath(syncDir, filePath) {
+  if (!filePath) return null;
+  const resolvedSyncDir = path.resolve(syncDir);
+  const resolvedFilePath = path.resolve(filePath);
+  const relativePath = path.relative(resolvedSyncDir, resolvedFilePath);
+  if (relativePath && !relativePath.startsWith("..") && !path.isAbsolute(relativePath)) {
+    return relativePath.split(path.sep).join("/");
+  }
+  return resolvedFilePath;
+}
+
+function collectMissingManagedRepresentationWarnings(db, syncDir, {
+  observedChapterKeys,
+  observedEpigraphKeys,
+}) {
+  const projectScope = inferSceneProjectScopeFromSyncDir(syncDir);
+  const chapterRows = projectScope
+    ? db.prepare(`SELECT chapter_id, project_id, source_path FROM chapters WHERE project_id = ?`).all(projectScope)
+    : db.prepare(`SELECT chapter_id, project_id, source_path FROM chapters`).all();
+  const epigraphRows = projectScope
+    ? db.prepare(`SELECT epigraph_id, project_id, file_path FROM epigraphs WHERE project_id = ?`).all(projectScope)
+    : db.prepare(`SELECT epigraph_id, project_id, file_path FROM epigraphs`).all();
+  const warnings = [];
+
+  for (const row of chapterRows) {
+    const key = `${row.chapter_id}::${row.project_id}`;
+    if (observedChapterKeys.has(key)) continue;
+    if (!row.source_path || fs.existsSync(row.source_path)) continue;
+    warnings.push(`Managed sync preserved canonical chapter missing from filesystem: ${row.project_id}/${row.chapter_id} (${formatSyncRelativePath(syncDir, row.source_path)})`);
+  }
+
+  for (const row of epigraphRows) {
+    const key = `${row.epigraph_id}::${row.project_id}`;
+    if (observedEpigraphKeys.has(key)) continue;
+    if (!row.file_path || fs.existsSync(row.file_path)) continue;
+    warnings.push(`Managed sync preserved canonical epigraph missing from filesystem: ${row.project_id}/${row.epigraph_id} (${formatSyncRelativePath(syncDir, row.file_path)})`);
+  }
+
+  return warnings;
+}
+
 export function pruneSyncDerivedIndexes(db, syncDir, {
   seenSceneKeys,
   seenEpigraphKeys,
@@ -1461,6 +1502,8 @@ const WARNING_TYPE_LABELS = {
   orphaned_sidecar: "Orphaned sidecar",
   moved_scene: "Moved scene",
   missing_canonical_scene: "Missing canonical scene",
+  missing_canonical_chapter: "Missing canonical chapter",
+  missing_canonical_epigraph: "Missing canonical epigraph",
   nested_mirror: "Ignored nested mirror path",
 };
 
@@ -1472,6 +1515,8 @@ const WARNING_PATTERNS = [
   { type: "moved_scene",            re: /^Moved scene detected:/      },
   { type: "orphaned_sidecar",       re: /^Orphaned sidecar/          },
   { type: "missing_canonical_scene", re: /^Managed sync preserved canonical scene missing from filesystem:/ },
+  { type: "missing_canonical_chapter", re: /^Managed sync preserved canonical chapter missing from filesystem:/ },
+  { type: "missing_canonical_epigraph", re: /^Managed sync preserved canonical epigraph missing from filesystem:/ },
   { type: "nested_mirror",          re: /^Ignored nested mirror path:/ },
 ];
 
@@ -1524,6 +1569,8 @@ export function syncAll(db, syncDir, { quiet = false, writable = false } = {}) {
   const indexedSceneIds = new Set(); // scene_id only — for orphaned sidecar move detection
   const seenChapterKeys = new Set(managedChapterKeys);
   const seenEpigraphKeys = new Set(managedEpigraphKeys);
+  const observedChapterKeys = new Set();
+  const observedEpigraphKeys = new Set();
   let sceneIndexFailures = 0;
   const warnings = [];
   const chapterFoldersByProject = new Map();
@@ -1601,7 +1648,9 @@ export function syncAll(db, syncDir, { quiet = false, writable = false } = {}) {
         warnings.push(result.warning);
       }
       if (result.chapterId) {
-        seenChapterKeys.add(`${result.chapterId}::${project_id}`);
+        const chapterKey = `${result.chapterId}::${project_id}`;
+        seenChapterKeys.add(chapterKey);
+        observedChapterKeys.add(chapterKey);
       }
       if (chapterStructure.chapter && result.chapterId) {
         const chapterMapKey = `${project_id}::${chapterStructure.chapter.sort_index}`;
@@ -1620,7 +1669,9 @@ export function syncAll(db, syncDir, { quiet = false, writable = false } = {}) {
       if (result.skippedAsEpigraph) {
         if (result.epigraphIndexed && result.epigraphId) {
           const epigraphId = result.epigraphId;
-          seenEpigraphKeys.add(`${epigraphId}::${project_id}`);
+          const epigraphKey = `${epigraphId}::${project_id}`;
+          seenEpigraphKeys.add(epigraphKey);
+          observedEpigraphKeys.add(epigraphKey);
         }
         if (result.epigraphIndexed) {
           epigraphsIndexed++;
@@ -1648,6 +1699,12 @@ export function syncAll(db, syncDir, { quiet = false, writable = false } = {}) {
   });
   for (const scene of pruneResult.scenePrune?.preservedManagedScenes ?? []) {
     warnings.push(`Managed sync preserved canonical scene missing from filesystem: ${scene.project_id}/${scene.scene_id}`);
+  }
+  for (const warning of collectMissingManagedRepresentationWarnings(db, syncDir, {
+    observedChapterKeys,
+    observedEpigraphKeys,
+  })) {
+    warnings.push(warning);
   }
 
   // --- Orphaned sidecar detection ---

--- a/src/sync/sync.js
+++ b/src/sync/sync.js
@@ -1026,12 +1026,19 @@ function pruneMissingEpigraphs(db, seenEpigraphKeys, syncDir) {
 function formatSyncRelativePath(syncDir, filePath) {
   if (!filePath) return null;
   const resolvedSyncDir = path.resolve(syncDir);
-  const resolvedFilePath = path.resolve(filePath);
+  const resolvedFilePath = resolveStoredSyncPath(syncDir, filePath);
   const relativePath = path.relative(resolvedSyncDir, resolvedFilePath);
   if (relativePath && !relativePath.startsWith("..") && !path.isAbsolute(relativePath)) {
     return relativePath.split(path.sep).join("/");
   }
   return resolvedFilePath;
+}
+
+function resolveStoredSyncPath(syncDir, filePath) {
+  if (!filePath) return null;
+  return path.isAbsolute(filePath)
+    ? path.resolve(filePath)
+    : path.resolve(syncDir, filePath);
 }
 
 function collectMissingManagedRepresentationWarnings(db, syncDir, {
@@ -1050,14 +1057,16 @@ function collectMissingManagedRepresentationWarnings(db, syncDir, {
   for (const row of chapterRows) {
     const key = `${row.chapter_id}::${row.project_id}`;
     if (observedChapterKeys.has(key)) continue;
-    if (!row.source_path || fs.existsSync(row.source_path)) continue;
+    const sourcePath = resolveStoredSyncPath(syncDir, row.source_path);
+    if (!sourcePath || fs.existsSync(sourcePath)) continue;
     warnings.push(`Managed sync preserved canonical chapter missing from filesystem: ${row.project_id}/${row.chapter_id} (${formatSyncRelativePath(syncDir, row.source_path)})`);
   }
 
   for (const row of epigraphRows) {
     const key = `${row.epigraph_id}::${row.project_id}`;
     if (observedEpigraphKeys.has(key)) continue;
-    if (!row.file_path || fs.existsSync(row.file_path)) continue;
+    const filePath = resolveStoredSyncPath(syncDir, row.file_path);
+    if (!filePath || fs.existsSync(filePath)) continue;
     warnings.push(`Managed sync preserved canonical epigraph missing from filesystem: ${row.project_id}/${row.epigraph_id} (${formatSyncRelativePath(syncDir, row.file_path)})`);
   }
 

--- a/src/sync/sync.js
+++ b/src/sync/sync.js
@@ -1025,8 +1025,9 @@ function pruneMissingEpigraphs(db, seenEpigraphKeys, syncDir) {
 
 function formatSyncRelativePath(syncDir, filePath) {
   if (!filePath) return null;
+  if (!path.isAbsolute(filePath)) return filePath.split(/[\\/]+/).join("/");
   const resolvedSyncDir = path.resolve(syncDir);
-  const resolvedFilePath = resolveStoredSyncPath(syncDir, filePath);
+  const resolvedFilePath = path.resolve(filePath);
   const relativePath = path.relative(resolvedSyncDir, resolvedFilePath);
   if (relativePath && !relativePath.startsWith("..") && !path.isAbsolute(relativePath)) {
     return relativePath.split(path.sep).join("/");
@@ -1034,11 +1035,24 @@ function formatSyncRelativePath(syncDir, filePath) {
   return resolvedFilePath;
 }
 
-function resolveStoredSyncPath(syncDir, filePath) {
-  if (!filePath) return null;
-  return path.isAbsolute(filePath)
-    ? path.resolve(filePath)
-    : path.resolve(syncDir, filePath);
+function storedSyncPathCandidates(syncDir, filePath) {
+  if (!filePath) return [];
+  if (path.isAbsolute(filePath)) return [path.resolve(filePath)];
+
+  const candidates = new Set([path.resolve(syncDir, filePath)]);
+  const normalizedParts = filePath.split(/[\\/]+/).filter(Boolean);
+  const anchor = normalizedParts[0];
+  if (["projects", "universes", "scenes"].includes(anchor)) {
+    const syncParts = path.resolve(syncDir).split(path.sep);
+    for (let index = syncParts.length - 1; index >= 0; index--) {
+      if (syncParts[index] !== anchor) continue;
+      const rootParts = syncParts.slice(0, index);
+      const root = rootParts.length ? rootParts.join(path.sep) : path.sep;
+      candidates.add(path.resolve(root, filePath));
+    }
+  }
+
+  return [...candidates];
 }
 
 function collectMissingManagedRepresentationWarnings(db, syncDir, {
@@ -1057,16 +1071,16 @@ function collectMissingManagedRepresentationWarnings(db, syncDir, {
   for (const row of chapterRows) {
     const key = `${row.chapter_id}::${row.project_id}`;
     if (observedChapterKeys.has(key)) continue;
-    const sourcePath = resolveStoredSyncPath(syncDir, row.source_path);
-    if (!sourcePath || fs.existsSync(sourcePath)) continue;
+    const sourcePaths = storedSyncPathCandidates(syncDir, row.source_path);
+    if (!sourcePaths.length || sourcePaths.some(candidate => fs.existsSync(candidate))) continue;
     warnings.push(`Managed sync preserved canonical chapter missing from filesystem: ${row.project_id}/${row.chapter_id} (${formatSyncRelativePath(syncDir, row.source_path)})`);
   }
 
   for (const row of epigraphRows) {
     const key = `${row.epigraph_id}::${row.project_id}`;
     if (observedEpigraphKeys.has(key)) continue;
-    const filePath = resolveStoredSyncPath(syncDir, row.file_path);
-    if (!filePath || fs.existsSync(filePath)) continue;
+    const filePaths = storedSyncPathCandidates(syncDir, row.file_path);
+    if (!filePaths.length || filePaths.some(candidate => fs.existsSync(candidate))) continue;
     warnings.push(`Managed sync preserved canonical epigraph missing from filesystem: ${row.project_id}/${row.epigraph_id} (${formatSyncRelativePath(syncDir, row.file_path)})`);
   }
 

--- a/src/sync/sync.js
+++ b/src/sync/sync.js
@@ -957,15 +957,23 @@ function canPruneScenes(syncDir) {
   return hasBroadRootChild;
 }
 
-function pruneMissingScenes(db, seenSceneKeys, syncDir) {
+function pruneMissingScenes(db, seenSceneKeys, syncDir, { managedProjectIds = new Set() } = {}) {
   const projectScope = inferSceneProjectScopeFromSyncDir(syncDir);
   const rows = projectScope
     ? db.prepare(`SELECT scene_id, project_id FROM scenes WHERE project_id = ?`).all(projectScope)
     : db.prepare(`SELECT scene_id, project_id FROM scenes`).all();
 
+  const result = { deleted: 0, preservedManagedScenes: [] };
   for (const row of rows) {
     const key = `${row.scene_id}::${row.project_id}`;
     if (seenSceneKeys.has(key)) continue;
+    if (managedProjectIds.has(row.project_id)) {
+      result.preservedManagedScenes.push({
+        scene_id: row.scene_id,
+        project_id: row.project_id,
+      });
+      continue;
+    }
 
     db.prepare(`DELETE FROM scenes_fts WHERE scene_id = ? AND project_id = ?`).run(row.scene_id, row.project_id);
     db.prepare(`
@@ -977,7 +985,9 @@ function pruneMissingScenes(db, seenSceneKeys, syncDir) {
     db.prepare(`DELETE FROM scene_places WHERE scene_id = ? AND project_id = ?`).run(row.scene_id, row.project_id);
     db.prepare(`DELETE FROM scene_tags WHERE scene_id = ? AND project_id = ?`).run(row.scene_id, row.project_id);
     db.prepare(`DELETE FROM scene_threads WHERE scene_id = ? AND project_id = ?`).run(row.scene_id, row.project_id);
+    result.deleted++;
   }
+  return result;
 }
 
 function pruneMissingChapters(db, seenChapterKeys, syncDir) {
@@ -1018,14 +1028,15 @@ export function pruneSyncDerivedIndexes(db, syncDir, {
   seenEpigraphKeys,
   seenChapterKeys,
   sceneIndexFailures,
+  managedProjectIds = new Set(),
 }) {
   if (!canPruneScenes(syncDir)) return { pruned: false, reason: "scope_not_prunable" };
   if (sceneIndexFailures !== 0) return { pruned: false, reason: "scene_index_failures" };
 
-  pruneMissingScenes(db, seenSceneKeys, syncDir);
+  const scenePrune = pruneMissingScenes(db, seenSceneKeys, syncDir, { managedProjectIds });
   pruneMissingEpigraphs(db, seenEpigraphKeys, syncDir);
   pruneMissingChapters(db, seenChapterKeys, syncDir);
-  return { pruned: true, reason: null };
+  return { pruned: true, reason: null, scenePrune };
 }
 
 export function regenerateReferenceAndWorldIndexes(db, syncDir, files, {
@@ -1449,6 +1460,7 @@ const WARNING_TYPE_LABELS = {
   chapter_structure: "Chapter structure",
   orphaned_sidecar: "Orphaned sidecar",
   moved_scene: "Moved scene",
+  missing_canonical_scene: "Missing canonical scene",
   nested_mirror: "Ignored nested mirror path",
 };
 
@@ -1459,6 +1471,7 @@ const WARNING_PATTERNS = [
   { type: "chapter_structure",      re: /^(Chapter structure warning|Epigraph requires explicit chapter linkage|Epigraph references unknown chapter_id|Scene references unknown chapter_id|Ambiguous chapter linkage|Epigraph identity conflict|Managed structure sync ignored|Managed structure sync preserved canonical epigraph)/ },
   { type: "moved_scene",            re: /^Moved scene detected:/      },
   { type: "orphaned_sidecar",       re: /^Orphaned sidecar/          },
+  { type: "missing_canonical_scene", re: /^Managed sync preserved canonical scene missing from filesystem:/ },
   { type: "nested_mirror",          re: /^Ignored nested mirror path:/ },
 ];
 
@@ -1626,12 +1639,16 @@ export function syncAll(db, syncDir, { quiet = false, writable = false } = {}) {
     }
   }
 
-  pruneSyncDerivedIndexes(db, syncDir, {
+  const pruneResult = pruneSyncDerivedIndexes(db, syncDir, {
     seenSceneKeys,
     seenEpigraphKeys,
     seenChapterKeys,
     sceneIndexFailures,
+    managedProjectIds,
   });
+  for (const scene of pruneResult.scenePrune?.preservedManagedScenes ?? []) {
+    warnings.push(`Managed sync preserved canonical scene missing from filesystem: ${scene.project_id}/${scene.scene_id}`);
+  }
 
   // --- Orphaned sidecar detection ---
   for (const diagnostic of observeOrphanedSidecars(syncDir, { indexedSceneIds })) {

--- a/src/test/integration/sync.test.mjs
+++ b/src/test/integration/sync.test.mjs
@@ -1354,6 +1354,32 @@ describe("sync warning_summary", () => {
       assert.equal("warnings" in parsed.sync, false, "raw warnings list should not appear in sync response");
     }
   });
+
+  test("sync tool reports missing managed canonical representations in warning summary", async () => {
+    const projectId = "missing-managed-summary";
+    const chapterDir = path.join(writeSyncDir, "projects", projectId, "Draft", "01-Arrival");
+    fs.mkdirSync(chapterDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(chapterDir, "sc-001.md"),
+      "---\nscene_id: sc-001\ntitle: Arrival\n---\nScene prose.",
+      "utf8"
+    );
+    fs.writeFileSync(
+      path.join(chapterDir, "epigraph.md"),
+      "---\nepigraph_id: epi-arrival\n---\nOpening epigraph.",
+      "utf8"
+    );
+
+    await callWriteTool("sync");
+    fs.rmSync(chapterDir, { recursive: true });
+
+    const text = await callWriteTool("sync");
+
+    assert.match(text, /Warning summary:/);
+    assert.match(text, /missing_canonical_scene: 1/);
+    assert.match(text, /missing_canonical_chapter: 1/);
+    assert.match(text, /missing_canonical_epigraph: 1/);
+  });
 });
 
 describe("enrich_scene tool", () => {

--- a/src/test/unit/sync.test.mjs
+++ b/src/test/unit/sync.test.mjs
@@ -1974,6 +1974,83 @@ describe("syncAll", () => {
     fs.rmSync(dir, { recursive: true });
   });
 
+  test("managed sync warns and preserves canonical epigraphs when epigraph files are missing", () => {
+    const dir = makeTempSync();
+    const db = openDb(":memory:");
+    const chapterDir = path.join(dir, "projects", "test-novel", "Draft", "01-Arrival");
+    const epigraphPath = path.join(chapterDir, "epigraph.md");
+    fs.mkdirSync(chapterDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(chapterDir, "sc-001.md"),
+      "---\nscene_id: sc-001\ntitle: Arrival\n---\nScene prose."
+    );
+    fs.writeFileSync(
+      epigraphPath,
+      "---\nepigraph_id: epi-arrival\ncharacters:\n  - elena\ntags:\n  - threshold\n---\nOpening epigraph."
+    );
+
+    syncAll(db, dir, { quiet: true });
+    fs.rmSync(epigraphPath);
+    const result = syncAll(db, dir, { quiet: true });
+
+    assert.equal(
+      db.prepare(`SELECT COUNT(*) AS count FROM epigraphs WHERE epigraph_id = 'epi-arrival' AND project_id = 'test-novel'`).get().count,
+      1
+    );
+    assert.equal(
+      db.prepare(`SELECT COUNT(*) AS count FROM epigraph_characters WHERE epigraph_id = 'epi-arrival' AND project_id = 'test-novel'`).get().count,
+      1
+    );
+    assert.equal(
+      db.prepare(`SELECT COUNT(*) AS count FROM epigraph_tags WHERE epigraph_id = 'epi-arrival' AND project_id = 'test-novel'`).get().count,
+      1
+    );
+    assert.ok(result.warnings.some((warning) => warning.includes("Managed sync preserved canonical epigraph missing from filesystem")));
+    assert.equal(result.warningSummary.missing_canonical_epigraph.count, 1);
+
+    db.close();
+    fs.rmSync(dir, { recursive: true });
+  });
+
+  test("managed sync warns and preserves canonical chapters when chapter folders are missing", () => {
+    const dir = makeTempSync();
+    const db = openDb(":memory:");
+    const chapterDir = path.join(dir, "projects", "test-novel", "Draft", "01-Arrival");
+    fs.mkdirSync(chapterDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(chapterDir, "sc-001.md"),
+      "---\nscene_id: sc-001\ntitle: Arrival\n---\nScene prose."
+    );
+    fs.writeFileSync(
+      path.join(chapterDir, "epigraph.md"),
+      "---\nepigraph_id: epi-arrival\n---\nOpening epigraph."
+    );
+
+    syncAll(db, dir, { quiet: true });
+    fs.rmSync(chapterDir, { recursive: true });
+    const result = syncAll(db, dir, { quiet: true });
+
+    assert.equal(
+      db.prepare(`SELECT COUNT(*) AS count FROM chapters WHERE chapter_id = 'ch-01-arrival' AND project_id = 'test-novel'`).get().count,
+      1
+    );
+    assert.equal(
+      db.prepare(`SELECT COUNT(*) AS count FROM scenes WHERE scene_id = 'sc-001' AND project_id = 'test-novel'`).get().count,
+      1
+    );
+    assert.equal(
+      db.prepare(`SELECT COUNT(*) AS count FROM epigraphs WHERE epigraph_id = 'epi-arrival' AND project_id = 'test-novel'`).get().count,
+      1
+    );
+    assert.ok(result.warnings.some((warning) => warning.includes("Managed sync preserved canonical chapter missing from filesystem")));
+    assert.ok(result.warnings.some((warning) => warning.includes("Managed sync preserved canonical scene missing from filesystem")));
+    assert.ok(result.warnings.some((warning) => warning.includes("Managed sync preserved canonical epigraph missing from filesystem")));
+    assert.equal(result.warningSummary.missing_canonical_chapter.count, 1);
+
+    db.close();
+    fs.rmSync(dir, { recursive: true });
+  });
+
   test("pruning one project does not clear scene metadata for same scene_id in another project", () => {
     const dir = makeTempSync();
     const db = openDb(":memory:");

--- a/src/test/unit/sync.test.mjs
+++ b/src/test/unit/sync.test.mjs
@@ -1896,7 +1896,10 @@ describe("syncAll", () => {
       "---\ndoc_id: ref-vampirism\ntitle: Vampirism in this universe\n---\nReference body."
     );
 
-    writeScene(dir, "sc-001", { reference_ids: ["ref-vampirism"] });
+    fs.writeFileSync(
+      path.join(dir, "projects", "test-novel", "scenes", "sc-001.md"),
+      "---\nscene_id: sc-001\ntitle: Unmanaged Scene\nreference_ids:\n  - ref-vampirism\n---\nScene prose."
+    );
     syncAll(db, dir, { quiet: true });
     assert.equal(db.prepare(`SELECT COUNT(*) AS count FROM scenes WHERE scene_id = 'sc-001'`).get().count, 1);
     assert.equal(
@@ -1912,6 +1915,60 @@ describe("syncAll", () => {
       db.prepare(`SELECT COUNT(*) AS count FROM reference_links WHERE source_kind = 'scene' AND source_id = 'sc-001'`).get().count,
       0
     );
+
+    db.close();
+    fs.rmSync(dir, { recursive: true });
+  });
+
+  test("managed sync preserves canonical scenes and relationship rows when prose files are missing", () => {
+    const dir = makeTempSync();
+    const db = openDb(":memory:");
+
+    fs.mkdirSync(path.join(dir, "projects", "test-novel", "world", "reference"), { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, "projects", "test-novel", "world", "reference", "vampirism.md"),
+      "---\ndoc_id: ref-vampirism\ntitle: Vampirism in this universe\n---\nReference body."
+    );
+
+    const chapterDir = path.join(dir, "projects", "test-novel", "Draft", "01-Arrival");
+    fs.mkdirSync(chapterDir, { recursive: true });
+    const scenePath = path.join(chapterDir, "sc-managed.md");
+    fs.writeFileSync(
+      scenePath,
+      "---\nscene_id: sc-managed\ntitle: Managed Scene\ncharacters:\n  - elena\nplaces:\n  - harbor\ntags:\n  - setup\nreference_ids:\n  - ref-vampirism\n---\nManaged prose."
+    );
+
+    syncAll(db, dir, { quiet: true });
+    assert.equal(
+      db.prepare(`SELECT COUNT(*) AS count FROM scenes WHERE scene_id = 'sc-managed' AND project_id = 'test-novel'`).get().count,
+      1
+    );
+
+    fs.rmSync(scenePath);
+    fs.rmSync(sidecarPath(scenePath), { force: true });
+    const result = syncAll(db, dir, { quiet: true });
+
+    assert.equal(
+      db.prepare(`SELECT COUNT(*) AS count FROM scenes WHERE scene_id = 'sc-managed' AND project_id = 'test-novel'`).get().count,
+      1
+    );
+    assert.equal(
+      db.prepare(`SELECT COUNT(*) AS count FROM scene_characters WHERE scene_id = 'sc-managed' AND project_id = 'test-novel'`).get().count,
+      1
+    );
+    assert.equal(
+      db.prepare(`SELECT COUNT(*) AS count FROM scene_places WHERE scene_id = 'sc-managed' AND project_id = 'test-novel'`).get().count,
+      1
+    );
+    assert.equal(
+      db.prepare(`SELECT COUNT(*) AS count FROM scene_tags WHERE scene_id = 'sc-managed' AND project_id = 'test-novel'`).get().count,
+      1
+    );
+    assert.equal(
+      db.prepare(`SELECT COUNT(*) AS count FROM reference_links WHERE source_kind = 'scene' AND source_project_id = 'test-novel' AND source_id = 'sc-managed'`).get().count,
+      1
+    );
+    assert.ok(result.warnings.some((warning) => warning.includes("Managed sync preserved canonical scene missing from filesystem")));
 
     db.close();
     fs.rmSync(dir, { recursive: true });
@@ -1960,8 +2017,12 @@ describe("syncAll", () => {
   test("does not prune existing scenes when scene indexing fails", () => {
     const dir = makeTempSync();
     const db = openDb(":memory:");
+    const scenePath = path.join(dir, "projects", "test-novel", "scenes", "sc-001.md");
 
-    writeScene(dir, "sc-001");
+    fs.writeFileSync(
+      scenePath,
+      "---\nscene_id: sc-001\ntitle: Unmanaged Scene\n---\nScene prose."
+    );
     syncAll(db, dir, { quiet: true });
     assert.equal(db.prepare(`SELECT COUNT(*) AS count FROM scenes WHERE scene_id = 'sc-001'`).get().count, 1);
 
@@ -2030,7 +2091,10 @@ describe("syncAll", () => {
     const scenePath = path.join(dir, "projects", "test-novel", "scenes", "sc-001.md");
     const notePath = path.join(dir, "projects", "test-novel", "scenes", "notes.md");
 
-    writeScene(dir, "sc-001");
+    fs.writeFileSync(
+      scenePath,
+      "---\nscene_id: sc-001\ntitle: Unmanaged Scene\n---\nScene prose."
+    );
     syncAll(db, dir, { quiet: true });
     assert.equal(db.prepare(`SELECT COUNT(*) AS count FROM scenes WHERE scene_id = 'sc-001'`).get().count, 1);
 
@@ -2689,7 +2753,7 @@ describe("syncAll", () => {
     fs.rmSync(dir, { recursive: true });
   });
 
-  test("managed sync does not create an epigraph when a scene file is converted to epigraph representation", () => {
+  test("managed sync does not create an epigraph or delete the scene when a scene file is converted to epigraph representation", () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "sync-"));
     const db = openDb(":memory:");
     const chapterDir = path.join(dir, "projects", "test-novel", "Draft", "01-The perfect chapter");
@@ -2726,7 +2790,7 @@ describe("syncAll", () => {
       WHERE project_id = 'test-novel'
     `).all();
 
-    assert.deepEqual(scenes.map((row) => row.scene_id), ["sc-001"]);
+    assert.deepEqual(scenes.map((row) => row.scene_id), ["sc-001", "sc-epi"]);
     assert.deepEqual(epigraphs.map((row) => [row.chapter_id, row.body]), []);
     assert.ok(result.warnings.some((warning) => warning.includes("Managed structure sync ignored file-derived epigraph linkage")));
 

--- a/src/test/unit/sync.test.mjs
+++ b/src/test/unit/sync.test.mjs
@@ -2051,10 +2051,11 @@ describe("syncAll", () => {
     fs.rmSync(dir, { recursive: true });
   });
 
-  test("managed sync does not warn when a relative canonical chapter folder still exists", () => {
+  test("managed sync does not warn when a relative canonical chapter folder still exists from a scoped root", () => {
     const dir = makeTempSync();
     const db = openDb(":memory:");
     const relativeChapterPath = "projects/test-novel/Draft/01-Arrival";
+    const projectRoot = path.join(dir, "projects", "test-novel");
     fs.mkdirSync(path.join(dir, relativeChapterPath), { recursive: true });
     db.prepare(`
       INSERT INTO projects (project_id, name)
@@ -2068,7 +2069,7 @@ describe("syncAll", () => {
       )
     `).run(relativeChapterPath);
 
-    const result = syncAll(db, dir, { quiet: true });
+    const result = syncAll(db, projectRoot, { quiet: true });
 
     assert.equal(
       result.warnings.some((warning) => warning.includes("Managed sync preserved canonical chapter missing from filesystem")),

--- a/src/test/unit/sync.test.mjs
+++ b/src/test/unit/sync.test.mjs
@@ -1974,6 +1974,40 @@ describe("syncAll", () => {
     fs.rmSync(dir, { recursive: true });
   });
 
+  test("managed sync reports an existing unobserved canonical scene separately from missing files", () => {
+    const dir = makeTempSync();
+    const db = openDb(":memory:");
+
+    const chapterDir = path.join(dir, "projects", "test-novel", "Draft", "01-Arrival");
+    fs.mkdirSync(chapterDir, { recursive: true });
+    const scenePath = path.join(chapterDir, "sc-managed.md");
+    fs.writeFileSync(
+      scenePath,
+      "---\nscene_id: sc-managed\ntitle: Managed Scene\n---\nManaged prose."
+    );
+
+    syncAll(db, dir, { quiet: true });
+    fs.writeFileSync(
+      scenePath,
+      "---\ntitle: Missing ID\n---\nManaged prose still exists."
+    );
+
+    const result = syncAll(db, dir, { quiet: true });
+
+    assert.equal(
+      db.prepare(`SELECT COUNT(*) AS count FROM scenes WHERE scene_id = 'sc-managed' AND project_id = 'test-novel'`).get().count,
+      1
+    );
+    assert.ok(result.warnings.some((warning) => warning.includes(
+      "Managed sync preserved canonical scene not observed during sync scan: test-novel/sc-managed (projects/test-novel/Draft/01-Arrival/sc-managed.md)"
+    )));
+    assert.equal(result.warningSummary.unobserved_canonical_scene.count, 1);
+    assert.equal(result.warningSummary.missing_canonical_scene, undefined);
+
+    db.close();
+    fs.rmSync(dir, { recursive: true });
+  });
+
   test("managed sync warns and preserves canonical epigraphs when epigraph files are missing", () => {
     const dir = makeTempSync();
     const db = openDb(":memory:");

--- a/src/test/unit/sync.test.mjs
+++ b/src/test/unit/sync.test.mjs
@@ -2051,6 +2051,35 @@ describe("syncAll", () => {
     fs.rmSync(dir, { recursive: true });
   });
 
+  test("managed sync does not warn when a relative canonical chapter folder still exists", () => {
+    const dir = makeTempSync();
+    const db = openDb(":memory:");
+    const relativeChapterPath = "projects/test-novel/Draft/01-Arrival";
+    fs.mkdirSync(path.join(dir, relativeChapterPath), { recursive: true });
+    db.prepare(`
+      INSERT INTO projects (project_id, name)
+      VALUES ('test-novel', 'Test Novel')
+    `).run();
+    db.prepare(`
+      INSERT INTO chapters (
+        chapter_id, project_id, title, sort_index, source_path, source_checksum, metadata_stale, updated_at
+      ) VALUES (
+        'ch-01-arrival', 'test-novel', 'Arrival', 1, ?, 'checksum', 0, '2026-05-28T00:00:00.000Z'
+      )
+    `).run(relativeChapterPath);
+
+    const result = syncAll(db, dir, { quiet: true });
+
+    assert.equal(
+      result.warnings.some((warning) => warning.includes("Managed sync preserved canonical chapter missing from filesystem")),
+      false
+    );
+    assert.equal(result.warningSummary.missing_canonical_chapter, undefined);
+
+    db.close();
+    fs.rmSync(dir, { recursive: true });
+  });
+
   test("pruning one project does not clear scene metadata for same scene_id in another project", () => {
     const dir = makeTempSync();
     const db = openDb(":memory:");


### PR DESCRIPTION
## Summary

- Adds an architecture-alignment follow-up initiative for removing sidecars as canonical daily-work artifacts.
- Documents the metadata ownership inventory, snapshot model decision, and accepted M2 managed sync preservation milestone.
- Changes managed sync so missing scene, chapter, or epigraph representations preserve canonical SQLite state and emit classified warnings instead of silently deleting canonical rows.

## Motivation

SQLite is the canonical store for structural and relationship metadata, while prose remains file-authored. Ordinary sync should observe missing filesystem representations and guide repair/recovery decisions, not treat absence as canonical delete authority.

## Implementation

- Adds backlog PRD, milestone plan, inventory, and architecture-doc updates distinguishing canonical state, review snapshots, recovery snapshots, generated views, import compatibility, and deprecated sidecar roles.
- Preserves managed scene rows and scene relationship rows when prose/sidecar representations are missing.
- Tracks observed managed chapter and epigraph representations separately from existing canonical rows so missing chapter folders and epigraph files produce classified diagnostics.
- Keeps unmanaged pruning, first-time import, and legacy migration behavior covered and unchanged.

## Testing

- `node --experimental-sqlite --test src/test/unit/sync.test.mjs`
- `npm run test:unit`
- `npm run lint`
- `npm run test:integration`
- `npm run check:pr`

## Risks and tradeoffs

- Missing managed files now preserve canonical SQLite rows, so users must use explicit restore/repair/delete workflows for intentional canonical removal.
- Explicit delete/detach/archive workflows are intentionally deferred until there is a concrete product need beyond the existing restore and structure workflows.

## Follow-up

- M3: Sidecar Write Boundary, likely as a separate focused PR.
