### PR TITLE
docs: accept architecture snapshot milestone

### DIFF
--- a/docs/initiatives/backlog/architecture-alignment-follow-up/milestones.md
+++ b/docs/initiatives/backlog/architecture-alignment-follow-up/milestones.md
@@ -90,7 +90,7 @@ Out of scope:
 
 ## M1 — Snapshot Model Decision
 
-Status: Drafted for review.
+Status: Accepted.
 
 Goal: replace the writable-sidecar mental model with explicit review snapshots
 and recovery snapshots.


### PR DESCRIPTION
## Summary

- Marks the Architecture Alignment Follow-up M1 snapshot model decision as accepted.
- Aligns the M1 milestone status with the merged M0-M2 acceptance state from PR #222.

## Motivation

Post-merge initiative bookkeeping found one stale status line: the initiative summary already says M0-M2 are accepted, while M1 still read as drafted for review.

## Implementation

- Updates only the M1 status line in the architecture-alignment milestone plan.
- Leaves M3-M5 deferred and does not activate new implementation work.

## Testing

- `git diff --check origin/main...HEAD`
- `node /Users/hanna/.codex/skills/pr-description/scripts/pr-prep.mjs --base origin/main`

## Risks and tradeoffs

- Low risk: documentation-only bookkeeping.

## Follow-up

- Activate M3 with initiative-activation if/when Sidecar Write Boundary is selected.