### PR TITLE
docs: document sidecar compatibility migration

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -14,7 +14,8 @@ How metadata is stored, managed, and kept in sync with prose.
 Highlights:
 
 - Tier 1 (structural) and Tier 2 (editorial) metadata split
-- Sidecar-based storage with `.meta.yaml`
+- SQLite-canonical structural and relationship metadata with `.meta.yaml`
+  compatibility input/output
 - Auto-migration from legacy frontmatter
 - Staleness detection and `enrich_scene`
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -9,9 +9,9 @@ It supports metadata-first reasoning, explicit prose editing workflows, and revi
 
 ## Product Status
 
-Active initiative: [Architecture Alignment Follow-up](docs/initiatives/active/architecture-alignment-follow-up/prd.md), implementing milestone M4 Outcome-Oriented Relationship Workflows.
+Active initiative: [Architecture Alignment Follow-up](docs/initiatives/active/architecture-alignment-follow-up/prd.md), implementing milestone M5 Deprecation, Migration, and Documentation.
 
-Current focus: Implement M4 outcome-oriented relationship workflows after a partial conformance review identified remaining character/place, enrichment, audit/repair, compatibility-authority, release-log, and generated-doc gaps.
+Current focus: Document remaining sidecar compatibility roles, migration posture, workflow guidance, release-log expectations, and generated tool guidance after PR #225 delivered outcome-oriented relationship workflows.
 
 Most recent completed initiative: [Database Backup and Recovery](docs/initiatives/done/database-backup-recovery/prd.md).
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -50,7 +50,7 @@ For structural manuscript state, use [Managed Structure Contract](docs/foundatio
 
 - [Features](FEATURES.md) — shipped product capabilities and links to completed initiative docs
 - [Backlog](BACKLOG.md) — deferred product work that is not currently active
-- [Architecture Alignment Follow-up](docs/initiatives/active/architecture-alignment-follow-up/prd.md) — active initiative with M4 relationship workflow alignment remaining
+- [Architecture Alignment Follow-up](docs/initiatives/active/architecture-alignment-follow-up/prd.md) — active initiative documenting sidecar compatibility, migration, and deprecation expectations
 - [Database Backup and Recovery](docs/initiatives/done/database-backup-recovery/prd.md) — completed initiative for Git-reviewable recovery artifacts and explicit restore workflows for SQLite-canonical state
 - [Conceptual Target Architecture](docs/foundations/target-architecture.md) — idealized architectural model for evaluating future structure, tooling, and workflow decisions
 - [Managed Structure Contract](docs/foundations/managed-structure-contract.md) — design boundaries for structural mutation, generated transparency, import, and maintenance workflows

--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ For VS Code-native setup flows (including prose styleguide setup), use:
 Instead of feeding an entire manuscript to an AI and hoping it fits in the context window, `mcp-writing` builds a structured index from your scene files. The AI queries that index first — finding relevant characters, beats, and loglines — then loads only the specific prose it needs.
 
 **Current status:**
-- **Core platform complete:** Metadata-first analysis, sidecar-backed metadata maintenance, AI-assisted prose editing with confirmation + git history, review bundles, and Scrivener Direct extraction are all implemented.
+- **Core platform complete:** Metadata-first analysis, SQLite-canonical structural and relationship metadata, compatibility sidecar maintenance, AI-assisted prose editing with confirmation + git history, review bundles, and Scrivener Direct extraction are all implemented.
 - **Recently completed:** Database Backup and Recovery added project backup export, freshness diagnostics, advisory operation history, automatic backup refresh after sanctioned project-scoped canonical mutations, dry-run restore planning, transactional restore application, and backup/restore operations guidance.
 - **Previous milestone:** Docker, CI, and Deployment Workflow made Docker a supported way to build, run, smoke-test, and deploy Writing MCP.
-- **Active development:** Post-initiative stabilization and backlog selection.
+- **Active development:** Architecture Alignment Follow-up M5, documenting sidecar compatibility, migration, and deprecation expectations.
 - **Deferred backlog:** OpenClaw integration, client-agnostic setup, divisions, and embeddings search.
 - **Ideas and open questions:** tracked separately so future exploration does not distort the active roadmap.
 
@@ -48,6 +48,7 @@ Instead of feeding an entire manuscript to an AI and hoping it fits in the conte
 | [mcp-writing-vscode](https://github.com/hannasdev/mcp-writing-vscode) | VS Code extension for client-native setup flows |
 | [docs/guides/docker.md](docs/guides/docker.md) | Docker Compose, deployment operations, MCP gateway notes |
 | [docs/guides/backup-recovery.md](docs/guides/backup-recovery.md) | Project backup artifacts, diagnostics, and explicit restore workflow |
+| [docs/guides/sidecar-compatibility.md](docs/guides/sidecar-compatibility.md) | Sidecar compatibility roles, migration posture, and daily-work authority boundaries |
 | [docs/foundations/managed-structure-contract.md](docs/foundations/managed-structure-contract.md) | Design boundaries for structural mutation, generated views, import, and maintenance workflows |
 | [docs/agents/tools.md](docs/agents/tools.md) | Full tool reference — auto-generated from source |
 | [docs/agents/README.md](docs/agents/README.md) | Index of agent-focused guidance, examples, and boot files |
@@ -142,7 +143,7 @@ Goal: make sure subplot threads progress intentionally and resolve on time.
 
 1. Run `list_threads` for the project.
 2. Use `get_thread_arc` to inspect scene order and beat labels for each thread.
-3. When a beat is missing, call `upsert_thread_link` to add or update it on the right scene.
+3. When a beat is missing, call `track_thread_arc` to add or update it on the right scene.
 4. Re-run `get_thread_arc` to confirm pacing and coverage.
 
 Outcome: subplot structure stays visible and auditable, which reduces dropped threads in late drafts.
@@ -185,7 +186,7 @@ Outcome: character-link maintenance becomes a preview-first batch operation inst
 Goal: recover index confidence quickly when legacy upgrade warnings indicate ambiguous rows were skipped.
 
 1. Start by checking `get_runtime_config` (or `describe_workflows`) and confirm whether `db_migration_warnings` contains `LEGACY_JOIN_ROWS_SKIPPED`.
-2. If present, run `sync` immediately to rebuild scene relationships from current sidecars and prose metadata.
+2. If present, run `sync` immediately to rebuild scene relationships from compatibility sidecars and prose metadata.
 3. Continue normal discovery (`find_scenes`, `get_arc`, `get_thread_arc`) and watch for stale-metadata warnings.
 4. When you touch stale scenes, run `enrich_scene(scene_id, project_id)` to recover metadata parity incrementally.
 5. If many scenes remain stale, switch to `enrich_scene_characters_batch` (dry-run first) for broader catch-up.

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -16,4 +16,5 @@ This section collects documentation primarily intended for AI agents and agent m
 ## Related References
 
 - [docs/guides/setup.md](../guides/setup.md) - Shipped setup guide covering prerequisites, setup flows, import paths, and runtime ownership expectations.
+- [docs/guides/sidecar-compatibility.md](../guides/sidecar-compatibility.md) - Compatibility and migration guidance for existing `.meta.yaml` sidecars.
 - [tools.md](tools.md) - Auto-generated tool catalog and parameter contracts.

--- a/docs/agents/tools.md
+++ b/docs/agents/tools.md
@@ -79,7 +79,7 @@
 
 ## describe_workflows
 
-Return the default workflow map and current project context for this server. Call this first in most sessions and again whenever you are unsure what to do next. Never write scripts to invoke tools — call them directly.
+Return the default workflow map and current project context for this server. Call this first in most sessions and again whenever you are unsure what to do next. Treat sidecars, frontmatter, Scrivener-derived fields, generated exports, and backups by their named compatibility, review, or recovery roles; use outcome workflows for current SQLite-canonical structure and relationship changes. Never write scripts to invoke tools — call them directly.
 
 _No parameters._
 

--- a/docs/foundations/managed-structure-contract.md
+++ b/docs/foundations/managed-structure-contract.md
@@ -94,6 +94,11 @@ Review snapshots and recovery snapshots must not be treated as competing daily
 sources of truth. Daily work reads and mutates canonical SQLite state through
 outcome-oriented MCP workflows, while prose remains authored file content.
 
+Migration guidance for existing projects lives in
+[Sidecar Compatibility and Migration](../guides/sidecar-compatibility.md).
+That guide names the retained compatibility roles for existing sidecars without
+making direct sidecar edits the daily-work contract.
+
 ## Workflow Zones
 
 ### Setup and Import
@@ -167,6 +172,7 @@ This contract refines existing ownership principles:
 
 - [Product Overview](../../PRODUCT.md)
 - [Conceptual Target Architecture](./target-architecture.md)
+- [Sidecar Compatibility and Migration](../guides/sidecar-compatibility.md)
 - [Data Ownership](../history/data-ownership.md)
 - [Chapter and Epigraph Structure](../initiatives/done/chapter-structure/prd.md)
 - [Divisions](../initiatives/backlog/divisions/prd.md)

--- a/docs/foundations/target-architecture.md
+++ b/docs/foundations/target-architecture.md
@@ -180,6 +180,12 @@ allowed to define current manuscript state. Review snapshots explain proposed
 state. Recovery snapshots support explicit recovery. Canonical SQLite state and
 authored prose remain the daily-work authority.
 
+For existing projects, the migration posture is documented in
+[Sidecar Compatibility and Migration](../guides/sidecar-compatibility.md):
+sidecars may remain import inputs, generated compatibility output, retained
+review notes, or deprecated artifacts, but direct sidecar editing is not the
+normal managed-project mutation path.
+
 ## Workflow Zones
 
 ### Setup and Import

--- a/docs/guides/setup.md
+++ b/docs/guides/setup.md
@@ -7,6 +7,7 @@
 - [Quick start with Scrivener (stable default)](#quick-start-with-scrivener-stable-default)
 - [Direct Scrivener project merge](#direct-scrivener-project-merge)
 - [Compatibility notes and fallback](#compatibility-notes-and-fallback)
+- [Sidecar compatibility after setup](#sidecar-compatibility-after-setup)
 - [Advanced: Native sync format](#advanced-native-sync-format)
 - [Managed structure contract](../foundations/managed-structure-contract.md)
 
@@ -65,8 +66,8 @@ If you use VS Code, client-native setup flows are available via:
 Once this is working, you can come back to:
 
 - **Advanced: Native sync format** below for custom project layouts
-- **[docs/agents/tools.md](agents/tools.md)** for the full tool catalog
-- **[README.md](../README.md#usage-scenarios)** for workflow ideas
+- **[docs/agents/tools.md](../agents/tools.md)** for the full tool catalog
+- **[README.md](../../README.md#usage-scenarios)** for workflow ideas
 
 If you later want richer metadata from a full `.scriv` bundle, add the **Direct Scrivener project merge** step after the stable import has already created your scene sidecars.
 
@@ -247,9 +248,34 @@ If the merge returns warnings:
 
 ---
 
+## Sidecar compatibility after setup
+
+Sidecars remain supported for import compatibility, generated compatibility
+output, and retained review notes. After a project is indexed and managed,
+daily structural and relationship work should use MCP tools instead of direct
+sidecar edits.
+
+Use this rule of thumb:
+
+- Setup/import may read sidecars, frontmatter, Scrivener output, and legacy
+  folders to seed canonical state.
+- Daily structure changes use tools such as `assign_scene_to_chapter`,
+  `move_scene`, `rename_chapter`, `reorder_chapter`, and `attach_epigraph`.
+- Daily relationship changes use tools such as `track_thread_arc`,
+  `connect_character_place_evidence`, `record_character_relationship_beat`,
+  and `link_reference_evidence`.
+- Sidecar-only flags, status, tags, and place associated-character notes are
+  compatibility/review metadata unless a future release promotes or removes
+  them.
+
+See [Sidecar Compatibility and Migration](sidecar-compatibility.md) for the
+current compatibility matrix and migration posture.
+
+---
+
 ## Advanced: Native sync format
 
-For projects not starting from a Scrivener export, place plain `.md` files in the sync folder directly. Metadata lives in a YAML frontmatter block.
+For projects not starting from a Scrivener export, place plain `.md` files in the sync folder directly. Metadata can seed the project from a YAML frontmatter block during setup/import.
 
 ### Scene file example
 
@@ -272,7 +298,7 @@ tags: [first-meeting, tension]
 Prose starts here...
 ```
 
-Alternatively, metadata can live in a sidecar file named `<scene-file>.meta.yaml` alongside the prose file — useful for keeping the prose file clean.
+Alternatively, metadata can live in a sidecar file named `<scene-file>.meta.yaml` alongside the prose file. In managed projects, treat that file as compatibility input/output rather than the preferred daily mutation surface for structure or relationships.
 
 ### Project structure
 

--- a/docs/guides/sidecar-compatibility.md
+++ b/docs/guides/sidecar-compatibility.md
@@ -1,0 +1,87 @@
+# Sidecar Compatibility and Migration
+
+This guide explains how to work with existing `.meta.yaml` sidecars now that
+Writing MCP treats SQLite as canonical for structural and relationship
+metadata.
+
+Sidecars are still supported. They are no longer the daily-work source of truth
+for structure or relationships once a project is managed by Writing MCP.
+
+## Current Authority Model
+
+| Metadata area | Current daily-work authority | Sidecar role |
+| --- | --- | --- |
+| Scene identity and import linkage | SQLite after import/sync | Import compatibility input and generated compatibility output |
+| Chapter placement, chapter titles, ordering, epigraph links | SQLite via explicit structure tools | Generated compatibility output and drift signal |
+| Thread beats | SQLite via `track_thread_arc` | Deprecated/import compatibility input |
+| Scene character/place evidence | SQLite via `connect_character_place_evidence` and sync indexes | Compatibility input/output; retained batch repair output |
+| Character relationship beats | SQLite via `record_character_relationship_beat` | No active sidecar authority |
+| Reference links | SQLite via `link_reference_evidence` or reference suggestion apply workflows | Generated compatibility output and legacy alias input |
+| Character/place names and profile fields | SQLite via sheet update tools | Generated compatibility output |
+| Scene flags, scene status, character tags, place tags, place associated characters | Retained compatibility/review metadata | Review notes until a future schema migration or deprecation decision |
+| Authored prose and support notes | Filesystem prose files | Not sidecar metadata |
+
+## Migration Posture
+
+Existing projects do not need a one-time manual sidecar rewrite to keep working.
+Use this migration posture instead:
+
+1. Run `sync` after upgrading so SQLite indexes and compatibility diagnostics
+   reflect the current project.
+2. Run `describe_workflows` to choose the outcome workflow for the task.
+3. Use explicit structure tools for chapter, scene placement, and epigraph
+   changes: `list_chapters`, `assign_scene_to_chapter`, `move_scene`,
+   `rename_chapter`, `reorder_chapter`, and `attach_epigraph`.
+4. Use relationship outcome tools for story metadata:
+   `track_thread_arc`, `connect_character_place_evidence`,
+   `record_character_relationship_beat`, `link_reference_evidence`, and
+   `audit_relationship_metadata`.
+5. Treat sidecar-only flags, tags, status, and associated-character notes as
+   compatibility/review notes. Do not rely on them as canonical relationship
+   authority unless a future release promotes the field into SQLite.
+6. Use `diagnose_structure`, `audit_relationship_metadata`, and
+   `diagnose_project_backups` before repair or recovery work.
+
+## What Not To Do
+
+- Do not edit sidecar chapter, order, thread, character/place relationship, or
+  reference-link fields as the normal way to change a managed project.
+- Do not treat generated sidecars, structure exports, review bundles, or project
+  backups as competing sources of truth.
+- Do not use Scrivener import conventions as daily mutation rules after the
+  import has established canonical state.
+
+## Supported Compatibility Paths
+
+The following sidecar paths remain intentionally supported:
+
+- Scrivener External Folder Sync import can create scene sidecars and seed
+  canonical state.
+- Direct `.scriv` merge can add Scrivener-derived compatibility metadata after
+  the stable import path has created matching sidecars.
+- Frontmatter and legacy sidecars can seed or refresh indexes during setup,
+  import, legacy migration, and named repair workflows.
+- Some tools refresh sidecar-shaped files as generated compatibility output so
+  existing projects and external tools remain inspectable during migration.
+
+## Recovery and Review
+
+For review and recovery, prefer generated artifacts that are explicitly labeled
+for that purpose:
+
+- `export_structure_snapshot` creates a structure export for Git review and
+  explicit structure recovery.
+- `export_project_backup` creates a broader recovery snapshot with
+  `manifest.json`, `canonical.snapshot.json`, and advisory `operations.jsonl`.
+- `restore_structure_from_export` and `restore_project_from_backup` are explicit
+  dry-run-first restore workflows. Editing generated files does not mutate
+  current project state.
+
+## Future Deprecation Boundaries
+
+No sidecar file type is removed by this guide. Remaining sidecar-only fields are
+documented so future work can make focused decisions:
+
+- promote a field to SQLite when it has durable product value;
+- keep it as compatibility/review metadata when it is useful but not canonical;
+- deprecate it when outcome workflows or generated snapshots replace the need.

--- a/docs/initiatives/active/architecture-alignment-follow-up/inventory.md
+++ b/docs/initiatives/active/architecture-alignment-follow-up/inventory.md
@@ -28,13 +28,13 @@ schemas, sync indexers, and MCP write tools.
 | Scene identity and core metadata | `scenes.scene_id`, `project_id`, `title`, `pov`, `logline`, `scene_change`, `causality`, `stakes`, `scene_functions`, `save_the_cat_beat`, `story_time`, `word_count`, `metadata_stale` | SQLite-canonical after sync/tool writes | Sidecar/frontmatter remains compatibility input | Keep SQLite-canonical; M3 preserves structural compatibility fields during generic metadata writes. |
 | Scene structural placement | `scenes.chapter_id`, `scene_role`, `part`, `chapter`, `chapter_title`, `timeline_position`; `chapters` | SQLite-canonical | Folder names and numeric chapter fields are compatibility hints/read aliases | Keep SQLite-canonical; M2/M3 preserve structure unless explicit workflows mutate it. |
 | Scene prose | Markdown/text scene files | Prose-authored | Sync computes checksum and stale state | Keep prose-authored and file-based. |
-| Scene workflow status | Accepted by scene sidecar schema and `update_scene_metadata`; no SQLite column | Sidecar-only today | Daily metadata field, not import-only | Needs decision: migrate-to-schema or intentionally deprecated/replaced by review workflow status. |
+| Scene workflow status | Accepted by scene sidecar schema and `update_scene_metadata`; no SQLite column | Sidecar-only today | Retained compatibility/review metadata | M5 documents status as compatibility/review metadata until a future schema migration or deprecation decision promotes or removes it. |
 | Scene source identifiers | `external_source`, `external_id` accepted by scene sidecar schema; Scrivener import/merge uses them | Import-only compatibility input today | Scrivener/import reconciliation | Mark import-only unless a future provenance model adds SQLite columns. |
-| Scene flags/review notes | `flag_scene` appends `flags` to sidecar; not in lint schema or SQLite | Sidecar-only today | Review note scratchpad | M4 classifies flags as compatibility review notes, not canonical relationship authority; future migration/deprecation remains M5/follow-up scope. |
+| Scene flags/review notes | `flag_scene` appends `flags` to sidecar; not in lint schema or SQLite | Sidecar-only today | Review note scratchpad | M5 documents flags as retained compatibility/review notes, not canonical relationship authority; future schema migration or deprecation remains follow-up scope. |
 | Scene characters | `scene_characters`; populated by sync from sidecar, by `connect_character_place_evidence`, and by enrichment apply/sync | SQLite-canonical index; active scene-backed association writes are SQLite-first except retained prose-derived batch repair | Sidecar `characters` is compatibility input/output and retained batch repair output | M4 adds `connect_character_place_evidence`; batch enrichment now documents sidecar output as compatibility before sync-index repair. |
-| Scene places | `scene_places`; populated by sync from sidecar and by `connect_character_place_evidence` | SQLite-canonical index; active scene-backed association writes are SQLite-first | Sidecar `places` is compatibility input/output | M4 adds outcome-level character/place association through scene evidence; broad sidecar deprecation remains M5. |
+| Scene places | `scene_places`; populated by sync from sidecar and by `connect_character_place_evidence` | SQLite-canonical index; active scene-backed association writes are SQLite-first | Sidecar `places` is compatibility input/output | M5 documents sidecar `places` as compatibility input/output; active scene-backed association work should use `connect_character_place_evidence`. |
 | Scene tags | `scene_tags`; populated by sync from sidecar `tags` and `versions` | SQLite-canonical search index; generic tag writes remain retained metadata compatibility | Sidecar `tags` is compatibility input/output for search keywords | M4 does not promote tags to relationship authority; schema/semantics decision remains future scope. |
-| Scene versions | Sidecar `versions`; indexed into `scene_tags`; legacy script splits version markers out of characters | Generated/import compatibility today | Search keyword continuity and legacy cleanup | Decide whether versions become first-class schema, ordinary tags, or deprecated import cleanup. |
+| Scene versions | Sidecar `versions`; indexed into `scene_tags`; legacy script splits version markers out of characters | Generated/import compatibility today | Search keyword continuity and legacy cleanup | M5 documents versions as compatibility metadata; future work can decide whether to promote them, fold them into ordinary tags, or deprecate import cleanup. |
 | Threads and scene-thread beats | `threads`, `scene_threads`; `upsert_thread_link` writes SQLite-first | SQLite-canonical | Sidecar `threads` is lint-accepted but not active authority | Keep SQLite-canonical; treat sidecar `threads` as deprecated/import-only unless M4 defines migration. |
 | Chapters | `chapters` | SQLite-canonical | Folder-derived structure can seed or diagnose | Keep SQLite-canonical. |
 | Epigraphs | `epigraphs`, `epigraph_characters`, `epigraph_tags` | SQLite-canonical for indexed metadata; prose body file-based | Epigraph metadata/frontmatter and folder placement are compatibility input | Keep SQLite-canonical for placement/relationships; prose remains file-based. |
@@ -44,7 +44,7 @@ schemas, sync indexers, and MCP write tools.
 | Character prose notes | `sheet.md` and adjacent support notes | Prose-authored | Search/detail tools read notes on demand | Keep prose-authored and file-based. |
 | Character relationships | `character_relationships`; `record_character_relationship_beat` writes relationship beats with scene evidence | SQLite-canonical | Public workflow hides table shape from callers | M4 adds outcome-level mutation surface and backup refresh. |
 | Places | `places`; sheet files plus sidecars | SQLite-canonical for indexed name; sidecars are compatibility input/output and retained review notes | Place sidecars seed import/sync and are refreshed as compatibility output | M4 reorders canonical place-name updates SQLite-first; relationship fields remain review notes unless backed by scene evidence. |
-| Place associated characters | Accepted/read from place sidecar; scene-backed authority is `scene_characters` + `scene_places` through `connect_character_place_evidence` | Sidecar-only review note unless connected through scene evidence | Place detail output and audit diagnostic | M4 classifies retained sidecar values as compatibility/review notes and adds scene-backed outcome workflow; schema migration remains future scope. |
+| Place associated characters | Accepted/read from place sidecar; scene-backed authority is `scene_characters` + `scene_places` through `connect_character_place_evidence` | Sidecar-only review note unless connected through scene evidence | Place detail output and audit diagnostic | M5 documents retained sidecar values as compatibility/review notes; scene-backed authority uses `connect_character_place_evidence`, and schema migration remains future scope. |
 | Place tags | Accepted/read from place sidecar; no SQLite table | Sidecar-only today | Compatibility/review note surfaced by `audit_relationship_metadata` | M4 classifies as non-authoritative compatibility/review notes; migrate/deprecate decision remains future scope. |
 | Reference docs | `reference_docs`, `reference_doc_tags`, `reference_docs_fts` | SQLite-canonical index over file-authored docs | Reference file frontmatter seeds index | Keep SQLite-canonical index; source doc prose remains file-based. |
 | Reference links | `reference_links` with `origin`; sidecar/frontmatter aliases `reference_ids`, `references`, `related_reference_ids`, `related_references`, `related_docs`, `related`, `reference_links`, `explicit_reference_links`, `related_reference_links` | SQLite-canonical target state; `link_reference_evidence` and apply workflows commit SQLite first | Legacy aliases and generated compatibility output | M4 makes explicit/apply workflows SQLite-first and treats sidecar/frontmatter refresh as compatibility output. |
@@ -86,19 +86,21 @@ schemas, sync indexers, and MCP write tools.
 - Existing dry-run/apply workflows need reviewable output even if writable
   sidecars are removed; M1 should assign those outputs to review snapshots.
 
-## Schema Gap Decisions Needed Before Behavior Changes
+## Schema Gap Decisions And Migration Posture
 
 - **Migrate-to-schema candidates:** scene workflow status, scene flags/review
   notes if retained, character tags, place tags, place associated characters,
-  and possibly character group. M4 classifies flags/tags/place
-  associated_characters as non-authoritative compatibility/review notes unless
-  a scene-backed relationship workflow writes SQLite evidence.
+  and possibly character group. M5 documents these as retained
+  compatibility/review metadata unless a scene-backed relationship workflow
+  writes SQLite evidence.
 - **Generated/import-only candidates:** `external_source`, `external_id`,
   sidecar `threads`, legacy reference aliases, numeric chapter fields, and
   folder-derived structure.
 - **Deprecated candidates:** sidecar `threads` as daily input, version strings
   as a separate scene field if ordinary tags are sufficient, and sidecar-only
-  flags if replaced by review snapshots.
+  flags if replaced by review snapshots. M5 does not remove these paths; it
+  names their compatibility role so removal or schema promotion can be planned
+  separately.
 - **Intentionally prose/file-owned candidates:** authored scene prose,
   character/place notes, and reference document bodies.
 

--- a/docs/initiatives/active/architecture-alignment-follow-up/milestones.md
+++ b/docs/initiatives/active/architecture-alignment-follow-up/milestones.md
@@ -1,12 +1,12 @@
 # Architecture Alignment Follow-up — Milestones
 
-**Status:** Active — M4 Outcome-Oriented Relationship Workflows in implementation
+**Status:** Active — M5 Deprecation, Migration, and Documentation in implementation
 
 This milestone plan breaks the Architecture Alignment Follow-up PRD into
 independently reviewable slices. Use [prd.md](prd.md) for product framing and
 this document for sequencing, gates, and implementation readiness.
-M0–M3 are accepted; M4 is in implementation; M5 remains
-deferred for future prioritization.
+M0–M3 are accepted; M4 was implemented in PR #225; M5 is in
+implementation.
 
 ## Objective
 
@@ -288,7 +288,7 @@ Out of scope:
 
 ## M4 — Outcome-Oriented Relationship Workflows
 
-Status: In implementation after partial conformance follow-up.
+Status: Implemented; pending conformance acceptance.
 
 Goal: expose relationship metadata changes through story and review outcomes
 instead of storage CRUD.
@@ -326,6 +326,13 @@ Implementation notes:
   workflow-status fields, and place associated-character fields remains M5 or a
   future focused initiative.
 
+Evidence:
+
+- [release-log.md](../../../../release-log.md)
+- [docs/agents/tools.md](../../../agents/tools.md)
+- [src/workflows/workflow-catalogue.js](../../../../src/workflows/workflow-catalogue.js)
+- [src/tools/metadata.js](../../../../src/tools/metadata.js)
+
 Acceptance gates:
 
 - Public tools express goals such as tracking an arc, linking evidence,
@@ -361,7 +368,7 @@ Out of scope:
 
 ## M5 — Deprecation, Migration, and Documentation
 
-Status: Planned.
+Status: In implementation.
 
 Goal: make remaining sidecar behavior explicit, migrated, or removed from normal
 workflows.
@@ -375,6 +382,16 @@ Deliverables:
 - Document which sidecar paths remain import compatibility and which are
   generated/review/recovery artifacts.
 - Remove or de-emphasize docs that imply sidecars are daily-work authority.
+
+Evidence:
+
+- [Sidecar Compatibility and Migration](../../../guides/sidecar-compatibility.md)
+- [Setup Guide](../../../guides/setup.md#sidecar-compatibility-after-setup)
+- [Agent Docs](../../../agents/README.md)
+- [Managed Structure Contract](../../../foundations/managed-structure-contract.md#snapshot-and-sidecar-roles)
+- [Conceptual Target Architecture](../../../foundations/target-architecture.md#snapshot-and-sidecar-roles)
+- [Generated Tool Reference](../../../agents/tools.md)
+- [release-log.md](../../../../release-log.md)
 
 Acceptance gates:
 

--- a/docs/initiatives/active/architecture-alignment-follow-up/prd.md
+++ b/docs/initiatives/active/architecture-alignment-follow-up/prd.md
@@ -1,13 +1,15 @@
 # Architecture Alignment Follow-up
 
-**Status:** Active — M4 Outcome-Oriented Relationship Workflows in implementation
+**Status:** Active — M5 Deprecation, Migration, and Documentation in implementation
 
 This initiative records target-architecture alignment gaps discovered during
 periodic reviews. It is a holding place for missing parts, correction
 candidates, and follow-up work that should not be lost. M0–M2 have been
 accepted and implemented through the managed sync preservation slice; M3 is
-accepted and implemented through the sidecar write-boundary slice. M4 is in
-implementation; M5 remains deferred until explicitly prioritized.
+accepted and implemented through the sidecar write-boundary slice. M4 is
+implemented through the outcome-oriented relationship workflow slice. M5 is in
+implementation to document sidecar compatibility, migration, and deprecation
+expectations.
 
 Implementation sequencing lives in [milestones.md](milestones.md). The M0
 metadata ownership inventory lives in [inventory.md](inventory.md).

--- a/release-log.md
+++ b/release-log.md
@@ -12,6 +12,7 @@ This complements `CHANGELOG.md`:
 - Why it matters: Authors, maintainers, and AI agents can keep existing sidecar-based projects working while understanding that SQLite and outcome workflows are current authority for structure and relationships.
 - Who is affected: Authors, maintainers, and AI agents upgrading existing projects, using Scrivener import/merge paths, or reviewing retained sidecar-only fields such as flags, status, tags, and place associated characters.
 - Action needed: Run `sync` after upgrading, then use `describe_workflows`, `diagnose_structure`, and `audit_relationship_metadata` before repair work. Prefer explicit structure and relationship tools over direct sidecar edits for managed projects.
+- PR: [#226](https://github.com/hannasdev/mcp-writing/pull/226)
 
 ### 2026-05-28 — Add outcome-oriented relationship workflows
 

--- a/release-log.md
+++ b/release-log.md
@@ -6,6 +6,14 @@ This complements `CHANGELOG.md`:
 - `CHANGELOG.md` is technical and release-oriented.
 - This log is plain-language and outcome-oriented.
 
+### 2026-05-28 — Document sidecar compatibility and migration posture
+
+- What changed: Added sidecar compatibility and migration guidance, updated setup, product, architecture, and agent docs, and added workflow discovery guidance for projects or prompts that still treat `.meta.yaml` files as mutation surfaces.
+- Why it matters: Authors, maintainers, and AI agents can keep existing sidecar-based projects working while understanding that SQLite and outcome workflows are current authority for structure and relationships.
+- Who is affected: Authors, maintainers, and AI agents upgrading existing projects, using Scrivener import/merge paths, or reviewing retained sidecar-only fields such as flags, status, tags, and place associated characters.
+- Action needed: Run `sync` after upgrading, then use `describe_workflows`, `diagnose_structure`, and `audit_relationship_metadata` before repair work. Prefer explicit structure and relationship tools over direct sidecar edits for managed projects.
+- PR: Pending
+
 ### 2026-05-28 — Add outcome-oriented relationship workflows
 
 - What changed: Added relationship tools for scene-backed character/place evidence, character relationship beats, and relationship metadata audits. Character and place profile updates now present sidecar files as generated compatibility or review output, while reference-link and thread workflows steer callers toward outcome-level operations.

--- a/release-log.md
+++ b/release-log.md
@@ -12,7 +12,6 @@ This complements `CHANGELOG.md`:
 - Why it matters: Authors, maintainers, and AI agents can keep existing sidecar-based projects working while understanding that SQLite and outcome workflows are current authority for structure and relationships.
 - Who is affected: Authors, maintainers, and AI agents upgrading existing projects, using Scrivener import/merge paths, or reviewing retained sidecar-only fields such as flags, status, tags, and place associated characters.
 - Action needed: Run `sync` after upgrading, then use `describe_workflows`, `diagnose_structure`, and `audit_relationship_metadata` before repair work. Prefer explicit structure and relationship tools over direct sidecar edits for managed projects.
-- PR: Pending
 
 ### 2026-05-28 — Add outcome-oriented relationship workflows
 

--- a/src/index.js
+++ b/src/index.js
@@ -336,7 +336,7 @@ function createMcpServer() {
   // ---- describe_workflows --------------------------------------------------
   s.tool(
     "describe_workflows",
-    "Return the default workflow map and current project context for this server. Call this first in most sessions and again whenever you are unsure what to do next. Never write scripts to invoke tools — call them directly.",
+    "Return the default workflow map and current project context for this server. Call this first in most sessions and again whenever you are unsure what to do next. Treat sidecars, frontmatter, Scrivener-derived fields, generated exports, and backups by their named compatibility, review, or recovery roles; use outcome workflows for current SQLite-canonical structure and relationship changes. Never write scripts to invoke tools — call them directly.",
     {},
     async () => {
       const projectRow = db.prepare(
@@ -453,6 +453,7 @@ function createMcpServer() {
           "When calling bootstrap_prose_styleguide_config or check_prose_styleguide_drift, set max_scenes to context.scene_count to avoid the default limit.",
           "Use context.setup_contract.styleguide_setup_status to decide whether styleguide setup is missing/invalid and advisory/blocking.",
           "Styleguide tools resolve config in priority order: project_root > universe_root > sync_root. If any styleguide_exists field is true, a config exists and styleguide tools will work. For invalid setup states, use setup_contract plan preview actions (which may set overwrite=true for repair).",
+          "Treat sidecars, frontmatter, Scrivener-derived fields, generated exports, and project backups by their named compatibility, review, or recovery roles. Use outcome workflows for current SQLite-canonical structure and relationship changes.",
           ...(DB_STARTUP_WARNINGS.length > 0
             ? ["Database migration warnings are present in context.db_migration_warnings. Run sync() now, then run enrich_scene(scene_id, project_id) for stale scenes you touch."]
             : []),

--- a/src/test/integration/runtime.test.mjs
+++ b/src/test/integration/runtime.test.mjs
@@ -362,6 +362,7 @@ describe("describe_workflows tool", () => {
       "thread_understanding",
       "relationship_alignment",
       "parity_recovery",
+      "sidecar_compatibility_migration",
       "backup_recovery",
       "review_preparation",
       "first_time_setup",
@@ -394,6 +395,26 @@ describe("describe_workflows tool", () => {
     assert.match(evidenceStep.note, /generated transparency/);
   });
 
+  test("sidecar compatibility migration workflow steers away from direct sidecar authority", async () => {
+    const text = await callWriteTool("describe_workflows");
+    const parsed = JSON.parse(text);
+    const workflow = parsed.workflows.find(w => w.id === "sidecar_compatibility_migration");
+
+    assert.ok(workflow, "sidecar_compatibility_migration workflow missing");
+    assert.match(workflow.use_when, /\.meta\.yaml sidecars/);
+    const tools = workflow.steps.map(step => step.tool);
+    assert.deepEqual(tools.slice(0, 3), [
+      "sync",
+      "diagnose_structure",
+      "audit_relationship_metadata",
+    ]);
+    assert.ok(tools.includes("track_thread_arc"));
+    assert.ok(tools.includes("connect_character_place_evidence"));
+    assert.ok(tools.includes("link_reference_evidence"));
+    const relationshipStep = workflow.steps.find(step => step.tool === "connect_character_place_evidence");
+    assert.match(relationshipStep.note, /instead of editing sidecar/);
+  });
+
   test("backup recovery workflow apply guidance includes reviewed checksum", async () => {
     const text = await callWriteTool("describe_workflows");
     const parsed = JSON.parse(text);
@@ -419,6 +440,7 @@ describe("describe_workflows tool", () => {
       "character_understanding",
     ]);
 
+    assert.ok(ids.indexOf("sidecar_compatibility_migration") > ids.indexOf("parity_recovery"));
     assert.ok(ids.indexOf("first_time_setup") > ids.indexOf("review_preparation"));
     assert.ok(ids.indexOf("styleguide_setup_new") > ids.indexOf("first_time_setup"));
   });

--- a/src/workflows/workflow-catalogue.js
+++ b/src/workflows/workflow-catalogue.js
@@ -95,6 +95,20 @@ export const WORKFLOW_CATALOGUE = [
     ],
   },
   {
+    id: "sidecar_compatibility_migration",
+    label: "Migrate legacy sidecar expectations",
+    use_when: "Use when an existing project, prompt, or external workflow still treats .meta.yaml sidecars, frontmatter, or Scrivener-derived fields as the place to make structural or relationship changes.",
+    steps: [
+      { tool: "sync", note: "Refresh SQLite indexes from current compatibility inputs, then review warnings instead of patching sidecars as the first repair step." },
+      { tool: "diagnose_structure", note: "Use when sidecar, frontmatter, folder, chapter, epigraph, or generated-export structure appears to disagree with SQLite canonical state." },
+      { tool: "audit_relationship_metadata", note: "Use when sidecar threads, tags, flags, associated_characters, characters, places, or reference aliases need authority classification before repair." },
+      { tool: "track_thread_arc", note: "Use for current thread authority instead of editing sidecar threads." },
+      { tool: "connect_character_place_evidence", note: "Use for current scene-backed character/place authority instead of editing sidecar relationship lists." },
+      { tool: "link_reference_evidence", note: "Use for current reference-link authority instead of editing sidecar/frontmatter aliases." },
+      { tool: "export_project_backup", note: "Generate a recovery snapshot from SQLite canonical state after meaningful canonical migration or repair work; editing backup artifacts does not mutate current state." },
+    ],
+  },
+  {
     id: "structure_assignment",
     label: "Manage chapter structure",
     use_when: "Use when the user wants to create, rename, or reorder a canonical chapter, attach an epigraph to a chapter, move a scene into a canonical chapter or position, repair an explicit scene chapter link, or clear a scene's explicit chapter assignment.",


### PR DESCRIPTION
## Summary

- Adds sidecar compatibility and migration guidance for existing `.meta.yaml` projects.
- Updates setup, README, product, architecture, agent, generated tool, and initiative docs to present SQLite/outcome workflows as current authority.
- Adds `describe_workflows` guidance and integration coverage for sidecar compatibility migration.

## Motivation

M5 needs to make remaining sidecar behavior explicit so authors, maintainers, and AI agents can keep existing sidecar-based projects working without treating sidecars as the daily-work source of truth for structure or relationships.

## Implementation

- Added `docs/guides/sidecar-compatibility.md` with authority roles, migration posture, supported compatibility paths, recovery/review guidance, and future deprecation boundaries.
- Added a `sidecar_compatibility_migration` workflow to steer callers through sync, diagnostics, audit, and outcome-level relationship tools.
- Updated generated tool docs, setup guidance, architecture docs, initiative bookkeeping, and release-log text to match the M5 compatibility posture.

## Testing

- `npm run check:docs`
- `npm run test:integration`
- `git diff --check origin/main...HEAD`
- `npm run check:pr`

## Risks and tradeoffs

- This documents and routes compatibility behavior; it does not remove sidecars or migrate remaining sidecar-only fields.

## Follow-up

- Decide whether to promote, retain, or deprecate remaining sidecar-only fields such as status, flags, tags, versions, character group, and place associated-character notes.
