### PR TITLE
docs: plan relationship metadata boundary

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -22,6 +22,12 @@ Add optional project-scoped Parts, Acts, or other larger structural sections abo
 
 **Status:** Deferred backlog (not active). Chapter and epigraph structure is complete; this follow-up captures the optional division layer without reopening shipped chapter behavior.
 
+### 🔗 [Relationship Metadata Boundary](docs/initiatives/backlog/relationship-metadata-boundary/prd.md) 📋
+
+Close the remaining sidecar-first relationship mutation path so generic scene metadata updates no longer act as canonical character/place relationship writes.
+
+**Status:** Deferred backlog (not active). Planning captures the next target-architecture cleanup candidate from the architecture review.
+
 ### 📊 [Embedding-Based Search](docs/initiatives/backlog/embeddings-search/prd.md) 📋
 
 Semantic search for queries that require understanding meaning, not just keywords.

--- a/docs/initiatives/backlog/relationship-metadata-boundary/architecture.md
+++ b/docs/initiatives/backlog/relationship-metadata-boundary/architecture.md
@@ -91,7 +91,7 @@ through sidecar-first writes.
 
 | Decision | Preferred Direction | Rationale | Alternative |
 | --- | --- | --- | --- |
-| `characters` and `places` in `update_scene_metadata` | Reject and route to relationship workflows. | Clearest agent/user contract and matches structural-field rejection. | Allow compatibility-only writes that do not affect canonical relationship indexes. |
+| `characters` and `places` in `update_scene_metadata` | Reject and route to relationship workflows. | Clearest agent/user contract and matches structural-field rejection. | Allow compatibility-only writes only if ordinary sync cannot later adopt those writes into canonical relationship indexes. |
 | Legacy sync handling | Preserve indexing from existing sidecar/frontmatter fields. | Import is a special mode and existing projects need continuity. | Require an explicit migration before indexing legacy relationship fields. |
 | Backup refresh | Refresh backups after canonical relationship workflows, not after compatibility-only writes. | Recovery snapshots should represent canonical state. | Refresh backup after all sidecar metadata writes, even if non-canonical. |
 | Diagnostic owner | Use `audit_relationship_metadata` for authority/drift guidance. | Keeps repair reasoning in an outcome-oriented workflow. | Add a new diagnostic tool just for character/place sidecars. |
@@ -168,6 +168,11 @@ If compatibility-only behavior is chosen, callers should receive:
 - a statement that canonical relationship rows were not changed;
 - next-step guidance to use `connect_character_place_evidence` for authority.
 
+Compatibility-only behavior must not write ordinary `characters` or `places`
+sidecar fields that existing sync treats as relationship input unless sync is
+changed in the same milestone to keep those fields non-authoritative for that
+path. Otherwise the canonical mutation is merely delayed until the next sync.
+
 ## Failure Modes
 
 - **Stale indexed scene path:** canonical relationship tools should commit only
@@ -177,6 +182,9 @@ If compatibility-only behavior is chosen, callers should receive:
   remain current; response includes compatibility diagnostics.
 - **Legacy sidecar disagreement:** sync/audit reports drift and points to
   outcome-level repair; ordinary sync does not silently decide author intent.
+- **Compatibility-only delayed mutation:** if retained review metadata is stored
+  in a shape that sync still consumes, the plan has failed; M0 must choose a
+  storage shape or sync rule that prevents this.
 - **Ambiguous character or place identity:** relationship workflows reject or
   require explicit IDs instead of guessing from names.
 - **Existing clients use old metadata path:** M0 decides whether to use strict

--- a/docs/initiatives/backlog/relationship-metadata-boundary/architecture.md
+++ b/docs/initiatives/backlog/relationship-metadata-boundary/architecture.md
@@ -1,0 +1,212 @@
+# Relationship Metadata Boundary — Architecture Notes
+
+**Status:** Deferred backlog (not active)
+
+## Context
+
+The target architecture says the manuscript is a domain model with prose
+attachments, not a folder tree with metadata sprinkled around it. Structural
+and relationship state should be mutated through sanctioned MCP workflows.
+Sidecars, frontmatter, generated exports, and backups can explain, migrate, or
+recover state, but they should not become competing daily-work authority.
+
+The Architecture Alignment Follow-up closed several known gaps:
+
+- managed sync preserves canonical structure when filesystem representations
+  disappear;
+- generic metadata updates preserve structural sidecar compatibility fields;
+- relationship workflows now exist for threads, character/place evidence,
+  character relationship beats, and reference evidence;
+- sidecar compatibility roles are documented.
+
+The remaining boundary issue is narrower: `update_scene_metadata` can still
+write scene `characters` and `places` to sidecars before SQLite relationship
+indexes are refreshed from those files.
+
+## Current State
+
+### Canonical Relationship State
+
+Canonical or indexed relationship state currently includes:
+
+- `scene_characters`
+- `scene_places`
+- `threads`
+- `scene_threads`
+- `character_relationships`
+- `reference_links`
+
+Outcome-level relationship workflows already commit SQLite first for current
+relationship work:
+
+- `track_thread_arc`
+- `connect_character_place_evidence`
+- `record_character_relationship_beat`
+- `link_reference_evidence`
+- `suggest_scene_references` in apply mode
+
+### Compatibility State
+
+Scene sidecar/frontmatter fields such as `characters` and `places` remain
+useful as:
+
+- import compatibility input;
+- legacy sync input;
+- generated compatibility output;
+- review or migration evidence when audited.
+
+They should not be the normal daily-work mutation surface once a project is
+managed through MCP.
+
+### Problematic Flow
+
+The current generic metadata flow is:
+
+1. Caller invokes `update_scene_metadata` with `characters` or `places`.
+2. The tool reads raw source metadata.
+3. The tool writes the supplied fields to `.meta.yaml`.
+4. The tool normalizes and reindexes the scene.
+5. `scene_characters` and `scene_places` are rebuilt from the sidecar-derived
+   values.
+
+This makes sidecar data the write authority for that operation.
+
+## Target Shape
+
+Daily relationship writes should follow this shape:
+
+1. Caller expresses relationship intent through an outcome tool.
+2. The MCP validates stable IDs and project scope.
+3. SQLite canonical/indexed relationship rows commit first.
+4. Project backup artifacts and operation history refresh after commit.
+5. Sidecar/frontmatter compatibility output refreshes only as generated
+   transparency.
+6. Compatibility output failure is reported as a warning, not as canonical
+   rollback.
+
+Generic scene metadata updates should not mutate canonical relationship rows
+through sidecar-first writes.
+
+## Decisions To Make
+
+| Decision | Preferred Direction | Rationale | Alternative |
+| --- | --- | --- | --- |
+| `characters` and `places` in `update_scene_metadata` | Reject and route to relationship workflows. | Clearest agent/user contract and matches structural-field rejection. | Allow compatibility-only writes that do not affect canonical relationship indexes. |
+| Legacy sync handling | Preserve indexing from existing sidecar/frontmatter fields. | Import is a special mode and existing projects need continuity. | Require an explicit migration before indexing legacy relationship fields. |
+| Backup refresh | Refresh backups after canonical relationship workflows, not after compatibility-only writes. | Recovery snapshots should represent canonical state. | Refresh backup after all sidecar metadata writes, even if non-canonical. |
+| Diagnostic owner | Use `audit_relationship_metadata` for authority/drift guidance. | Keeps repair reasoning in an outcome-oriented workflow. | Add a new diagnostic tool just for character/place sidecars. |
+
+## Contracts And Boundaries
+
+### `update_scene_metadata`
+
+Allowed daily-work role:
+
+- non-relationship editorial scene metadata;
+- compatibility/review metadata only where explicitly retained;
+- no prose mutation;
+- no structural mutation.
+
+Disallowed daily-work role:
+
+- scene-backed character/place authority mutation;
+- chapter, epigraph, or ordering mutation;
+- raw table-shaped relationship editing.
+
+### `connect_character_place_evidence`
+
+Owned role:
+
+- current scene-backed character/place relationship authority;
+- SQLite-first commit;
+- project backup refresh;
+- generated compatibility sidecar refresh when possible.
+
+### Sync And Import
+
+Owned role:
+
+- interpret legacy sidecar/frontmatter relationship fields;
+- populate indexes from compatibility input;
+- diagnose drift and stale representations;
+- avoid hidden canonical repair in ordinary managed-project sync.
+
+### Generated Compatibility Output
+
+Owned role:
+
+- help external tools and older workflows inspect or bridge state;
+- remain non-authoritative;
+- fail independently from canonical commit success.
+
+## Migration And Compatibility
+
+Existing projects can keep sidecar `characters` and `places` fields. The
+initiative should not require a data migration before existing material remains
+searchable.
+
+The migration is behavioral:
+
+- current relationship changes should stop using generic metadata writes;
+- docs and workflow guidance should route callers to relationship tools;
+- audit diagnostics should help identify retained sidecar fields and stale
+  relationship indexes;
+- generated compatibility output can continue as long as it is labeled
+  non-authoritative.
+
+If strict rejection is chosen, callers that still send `characters` or `places`
+to `update_scene_metadata` should receive:
+
+- a stable validation error code;
+- the blocked fields;
+- replacement tools and suggested sequence;
+- no sidecar or SQLite mutation.
+
+If compatibility-only behavior is chosen, callers should receive:
+
+- an explicit `compatibility_only` indicator;
+- a statement that canonical relationship rows were not changed;
+- next-step guidance to use `connect_character_place_evidence` for authority.
+
+## Failure Modes
+
+- **Stale indexed scene path:** canonical relationship tools should commit only
+  after validating the scene and should warn when compatibility output cannot
+  refresh.
+- **Sidecar write failure after SQLite commit:** canonical state and backups
+  remain current; response includes compatibility diagnostics.
+- **Legacy sidecar disagreement:** sync/audit reports drift and points to
+  outcome-level repair; ordinary sync does not silently decide author intent.
+- **Ambiguous character or place identity:** relationship workflows reject or
+  require explicit IDs instead of guessing from names.
+- **Existing clients use old metadata path:** M0 decides whether to use strict
+  rejection or compatibility-only migration based on compatibility risk.
+
+## Safety Considerations
+
+- Continue routing file writes through filesystem-boundary helpers.
+- Do not widen raw filesystem mutation permissions.
+- Avoid destructive relationship deletes unless a future explicit repair
+  workflow is planned and reviewed.
+- Keep backup/restore authority tied to canonical SQLite snapshots, not edited
+  sidecars.
+
+## Validation
+
+Required validation should combine:
+
+- unit tests for tool contract and DB mutation behavior;
+- integration tests through MCP tool calls;
+- sync/import compatibility tests for legacy sidecar fields;
+- generated docs checks for tool guidance;
+- full PR gate before merge.
+
+## Open Questions
+
+1. Should strict rejection happen immediately, or should compatibility-only
+   behavior be used as a transition?
+2. Do authors need a character-only or place-only evidence workflow, or is the
+   paired `connect_character_place_evidence` workflow enough for the current
+   daily-work model?
+3. Should a later initiative promote scene tags to a clearer canonical schema,
+   or are they intentionally retained as search/editorial metadata?

--- a/docs/initiatives/backlog/relationship-metadata-boundary/milestones.md
+++ b/docs/initiatives/backlog/relationship-metadata-boundary/milestones.md
@@ -1,0 +1,198 @@
+# Relationship Metadata Boundary — Milestones
+
+**Status:** Deferred backlog (not active)
+
+Use [prd.md](prd.md) for product framing and this document for sequencing,
+review gates, and implementation readiness.
+
+## Objective
+
+Close the remaining sidecar-first relationship mutation path while preserving
+legacy compatibility and keeping the repository coherent after each slice.
+
+## Guardrails
+
+- Do not remove sidecar/frontmatter import compatibility.
+- Do not turn sync into a daily-work relationship mutation API.
+- Do not broaden this initiative into tags, flags, status, versions, or place
+  profile metadata unless a milestone explicitly re-scopes through planning.
+- Preserve SQLite as canonical for scene-backed character/place relationships.
+- Keep project backups refreshed after canonical relationship mutations.
+- Keep public tools outcome-oriented.
+
+## M0 — Contract Decision And Characterization
+
+Goal: make the current behavior and target contract reviewable before changing
+tool behavior.
+
+Deliverables:
+
+- Characterization tests for current `update_scene_metadata` handling of
+  `characters` and `places`.
+- A documented contract decision choosing strict rejection or
+  compatibility-only behavior for those fields.
+- Identification of any known clients or docs that still recommend generic
+  metadata updates for relationship changes.
+- Explicit confirmation that `tags`, `status`, `flags`, and `versions` remain
+  outside this initiative.
+
+Acceptance criteria:
+
+- Reviewers can see the before/after contract from tests and docs.
+- The chosen contract is consistent with the Managed Structure Contract.
+- The migration path preserves legacy sync/import compatibility.
+- No public behavior changes are included beyond characterization or docs.
+
+Required validation:
+
+- `node --experimental-sqlite --test src/test/unit/metadata-tools.test.mjs`
+- `node --experimental-sqlite --test src/test/integration/metadata.test.mjs`
+
+Out of scope:
+
+- Rejecting fields in production.
+- Adding new relationship tools.
+- Changing sync indexing behavior.
+
+## M1 — Generic Metadata Relationship Guardrail
+
+Goal: stop `update_scene_metadata` from silently converting sidecar-first
+character/place edits into canonical relationship authority.
+
+Deliverables:
+
+- Apply the M0 contract decision to `update_scene_metadata`.
+- Return actionable guidance that points callers to
+  `connect_character_place_evidence`, `audit_relationship_metadata`, and
+  relevant discovery tools.
+- Preserve non-relationship metadata behavior for title, logline, status, beat,
+  POV, tags, and story time.
+- Preserve structural sidecar-field protection from the earlier sidecar
+  boundary work.
+
+Acceptance criteria:
+
+- A call to `update_scene_metadata` with `characters` or `places` either fails
+  with a clear relationship-boundary error or stores only non-authoritative
+  compatibility/review metadata without changing canonical relationship rows,
+  depending on the M0 decision.
+- The tool response names the correct relationship workflow for daily work.
+- Existing allowed metadata fields continue to work.
+- Sidecar structural compatibility fields remain preserved.
+- Canonical relationship indexes do not change through sidecar-first generic
+  metadata writes.
+
+Required validation:
+
+- `node --experimental-sqlite --test src/test/unit/metadata-tools.test.mjs`
+- `node --experimental-sqlite --test src/test/integration/metadata.test.mjs`
+- `node --experimental-sqlite --test src/test/integration/search.test.mjs`
+
+Out of scope:
+
+- Removing sync/import compatibility fields.
+- Redesigning tags.
+- Bulk relationship editing.
+
+## M2 — Compatibility Sync And Audit Alignment
+
+Goal: keep legacy projects usable while making compatibility authority visible.
+
+Deliverables:
+
+- Ensure sync/import still indexes existing sidecar/frontmatter
+  `characters` and `places` as compatibility input.
+- Ensure `audit_relationship_metadata` distinguishes retained compatibility
+  fields from canonical relationship authority.
+- Add diagnostics or next-step guidance for scenes where compatibility fields
+  appear stale or disagree with canonical indexes.
+- Confirm generated sidecar compatibility output remains clearly
+  non-authoritative.
+
+Acceptance criteria:
+
+- Existing projects with sidecar `characters` and `places` still become
+  searchable after sync.
+- Audit output gives a clear next step for compatibility relationship drift.
+- No ordinary sync path deletes or rewrites canonical relationship authority as
+  a hidden repair.
+- Compatibility output failures do not roll back successful canonical commits.
+
+Required validation:
+
+- `node --experimental-sqlite --test src/test/unit/sync.test.mjs`
+- `node --experimental-sqlite --test src/test/unit/metadata-tools.test.mjs`
+- `node --experimental-sqlite --test src/test/integration/sync.test.mjs`
+
+Out of scope:
+
+- Full sidecar deprecation.
+- New repair workflows beyond guidance unless M1 reveals a blocker.
+
+## M3 — Workflow And Documentation Update
+
+Goal: make the new boundary discoverable for humans, AI agents, and generated
+tool consumers.
+
+Deliverables:
+
+- Update tool descriptions and schemas for `update_scene_metadata` and
+  relationship tools.
+- Update `describe_workflows` so relationship repair and sidecar migration
+  guidance routes to outcome-level tools.
+- Regenerate `docs/agents/tools.md`.
+- Update user/agent docs if they mention sidecar relationship editing or
+  generic metadata relationship updates.
+- Add a release-log entry if the public tool contract changes.
+
+Acceptance criteria:
+
+- Generated tool docs match the source tool descriptions.
+- Workflow guidance no longer implies generic sidecar editing is a daily
+  relationship mutation path.
+- Users and agents get actionable replacement workflows.
+- Any breaking or compatibility-sensitive behavior is documented.
+
+Required validation:
+
+- `npm run docs`
+- `npm run check:docs`
+- `npm run check:static`
+
+Out of scope:
+
+- Broad documentation rewrites unrelated to relationship authority.
+
+## M4 — End-To-End Regression And Release Readiness
+
+Goal: prove the boundary holds across common writing workflows before PR
+completion.
+
+Deliverables:
+
+- End-to-end integration coverage for relationship mutation, metadata update,
+  sync compatibility, search reads, and backup freshness.
+- Regression coverage for review bundles or other consumers if they depend on
+  scene character/place indexes.
+- Final PR description that calls out migration behavior and any compatibility
+  notes.
+
+Acceptance criteria:
+
+- `connect_character_place_evidence` remains the daily-work relationship write
+  path and refreshes backups after canonical commit.
+- `update_scene_metadata` no longer creates hidden canonical relationship
+  changes from sidecar-first writes.
+- Legacy sync/import compatibility still works.
+- Search, arc, and bundle consumers still read relationship indexes correctly.
+- Maintainers have clear release notes for any changed client behavior.
+
+Required validation:
+
+- `npm test`
+- `npm run check:pr`
+
+Out of scope:
+
+- Activating unrelated backlog initiatives.
+- Shipping a new client UI.

--- a/docs/initiatives/backlog/relationship-metadata-boundary/milestones.md
+++ b/docs/initiatives/backlog/relationship-metadata-boundary/milestones.md
@@ -31,6 +31,8 @@ Deliverables:
   `characters` and `places`.
 - A documented contract decision choosing strict rejection or
   compatibility-only behavior for those fields.
+- If compatibility-only behavior remains an option, a decision on how it avoids
+  delayed canonical mutation through ordinary sync.
 - Identification of any known clients or docs that still recommend generic
   metadata updates for relationship changes.
 - Explicit confirmation that `tags`, `status`, `flags`, and `versions` remain
@@ -41,6 +43,8 @@ Acceptance criteria:
 - Reviewers can see the before/after contract from tests and docs.
 - The chosen contract is consistent with the Managed Structure Contract.
 - The migration path preserves legacy sync/import compatibility.
+- Compatibility-only behavior, if chosen, cannot write ordinary fields that
+  ordinary sync later adopts as canonical relationship state.
 - No public behavior changes are included beyond characterization or docs.
 
 Required validation:
@@ -76,6 +80,8 @@ Acceptance criteria:
   with a clear relationship-boundary error or stores only non-authoritative
   compatibility/review metadata without changing canonical relationship rows,
   depending on the M0 decision.
+- If compatibility/review metadata is retained, subsequent ordinary sync does
+  not convert that retained metadata into canonical relationship rows.
 - The tool response names the correct relationship workflow for daily work.
 - Existing allowed metadata fields continue to work.
 - Sidecar structural compatibility fields remain preserved.

--- a/docs/initiatives/backlog/relationship-metadata-boundary/prd.md
+++ b/docs/initiatives/backlog/relationship-metadata-boundary/prd.md
@@ -1,0 +1,221 @@
+# PRD: Relationship Metadata Boundary
+
+**Status:** Deferred backlog (not active)
+
+Created: 2026-05-28.
+
+Related docs:
+- [Product Overview](../../../../PRODUCT.md)
+- [Managed Structure Contract](../../../foundations/managed-structure-contract.md)
+- [Conceptual Target Architecture](../../../foundations/target-architecture.md)
+- [Architecture Alignment Follow-up](../../done/architecture-alignment-follow-up/prd.md)
+- [Architecture Alignment Follow-up Inventory](../../done/architecture-alignment-follow-up/inventory.md)
+
+## Goal
+
+Close the remaining relationship-metadata authority gap left after the
+Architecture Alignment Follow-up: generic scene metadata updates should no
+longer be an active sidecar-first mutation path for canonical scene
+relationships.
+
+The target state is that daily relationship changes use outcome-oriented,
+SQLite-first workflows, while `.meta.yaml` relationship fields remain
+compatibility input, generated compatibility output, import material, or
+review notes according to the Managed Structure Contract.
+
+## Problem
+
+Writing MCP now has outcome-level relationship tools for threads,
+character/place evidence, character relationship beats, and reference evidence.
+Those tools commit canonical SQLite state first, refresh project backups, and
+treat sidecar/frontmatter output as generated compatibility.
+
+One older path still blurs the boundary:
+
+- `update_scene_metadata` accepts `characters` and `places`.
+- It writes the supplied values to the scene sidecar first.
+- It then reindexes `scene_characters` and `scene_places` from that sidecar
+  content.
+
+That behavior is useful for legacy compatibility, but it means a generic
+metadata tool can still function as a relationship mutation surface. It is the
+opposite write order from the current relationship workflows and makes it
+harder for humans and AI agents to know which path owns relationship authority.
+
+## User Value
+
+- Authors get relationship changes that preserve intent and validation instead
+  of treating sidecar lists as the interface.
+- AI agents get a clearer rule: use relationship workflows for relationship
+  changes, not generic metadata patching.
+- Maintainers get simpler ownership reasoning when debugging stale relationship
+  indexes, backups, and compatibility output.
+- Future relationship work can build on a single mutation doctrine instead of
+  carrying a sidecar-first exception forward.
+
+## Design Alignment
+
+This initiative supports the product design principles:
+
+1. **Preserve authorship and intent:** relationship edits should say what story
+   evidence changed, not just which YAML list was overwritten.
+2. **Explicit structural mutation:** relationship metadata is canonical
+   structured state and should move through sanctioned workflows.
+3. **Stable identities:** relationship changes should reference stable
+   `scene_id`, `character_id`, `place_id`, `thread_id`, and `doc_id` values.
+4. **Separated artifact ownership:** sidecars should not become daily-work
+   authority for canonical relationship state.
+5. **Generated transparency:** compatibility sidecar output can explain or
+   bridge state, but it should not define relationship truth.
+6. **Import is a special mode:** sync/import can still interpret legacy
+   relationship fields, but daily work should be explicit.
+7. **Outcome-oriented tools:** public relationship writes should express writing
+   and continuity outcomes rather than raw storage fields.
+
+Use the Managed Structure Contract as the arbiter for every behavior change.
+
+## Scope
+
+In scope:
+
+- Decide the future contract for `characters` and `places` in
+  `update_scene_metadata`.
+- Keep existing read/search behavior working for indexed scene relationship
+  data.
+- Preserve legacy import and sync compatibility for existing sidecar
+  `characters` and `places` fields.
+- Route daily scene-backed character/place relationship changes to
+  `connect_character_place_evidence` or a deliberately named replacement.
+- Update workflow guidance and generated tool documentation so agents stop
+  treating sidecar lists as relationship authority.
+- Refresh project backups after canonical relationship mutations, or document
+  why a retained compatibility operation is non-canonical.
+- Add regression tests around sidecar preservation, relationship index
+  mutation order, warnings, and compatibility behavior.
+
+Out of scope:
+
+- Removing sidecar support wholesale.
+- Removing Scrivener import, frontmatter migration, or legacy sync indexing.
+- Redesigning all scene tags, versions, status, flags, character tags, place
+  tags, or place associated-character notes.
+- Introducing a broad relationship editor UI.
+- Changing prose storage.
+- Adding divisions or other manuscript structure concepts.
+
+## Proposed Direction
+
+The preferred direction is a staged migration:
+
+1. Freeze the current behavior with characterization tests and document the
+   public contract decision.
+2. Stop `update_scene_metadata` from acting as a sidecar-first canonical
+   relationship writer for `characters` and `places`.
+3. Preserve legacy relationship fields as compatibility input/output and
+   diagnostics.
+4. Ensure outcome-level tools are sufficient for the common daily-work cases
+   that `update_scene_metadata` previously covered.
+
+There are two acceptable implementation shapes:
+
+- **Strict contract:** reject `characters` and `places` in
+  `update_scene_metadata`, similar to structural fields, and point callers to
+  relationship workflows.
+- **Compatibility-only contract:** allow the fields only as retained
+  sidecar/review metadata and do not let that operation rebuild canonical
+  relationship rows.
+
+The strict contract is the default planning assumption because it is easiest for
+agents and users to understand. The compatibility-only contract remains a
+fallback if existing integrations need a softer migration.
+
+## Workflows
+
+### Daily Character/Place Evidence
+
+1. Use `find_scenes`, `list_characters`, and `list_places` to identify stable
+   IDs.
+2. Use `connect_character_place_evidence` when a scene proves a character/place
+   association.
+3. Treat any sidecar refresh as generated compatibility output.
+4. Use `audit_relationship_metadata` when sidecar relationship fields disagree
+   with canonical indexes.
+
+### Legacy Project Compatibility
+
+1. Run `sync` to index existing sidecar/frontmatter relationship fields.
+2. Run `audit_relationship_metadata` to classify retained compatibility notes
+   and stale indexes.
+3. Use outcome tools for current repairs.
+4. Generate backups after meaningful canonical repair work.
+
+### Generic Scene Metadata
+
+`update_scene_metadata` remains useful for non-relationship editorial metadata
+such as title, logline, status, beat, POV, tags, and story time. It should not
+be the current path for scene-backed character/place authority.
+
+## Acceptance Criteria
+
+1. The public contract for `update_scene_metadata` explicitly states whether
+   `characters` and `places` are rejected or compatibility-only.
+2. Daily scene-backed character/place relationship changes are routed through
+   outcome-level SQLite-first workflows.
+3. Existing legacy sidecar/frontmatter `characters` and `places` fields remain
+   indexable through sync/import compatibility paths.
+4. Generic scene metadata updates no longer silently convert sidecar-first
+   character/place edits into canonical relationship authority.
+5. Tool responses and workflow guidance point agents to the correct
+   relationship workflow.
+6. Backups and operation history stay current after canonical relationship
+   mutations.
+7. Tests cover old compatibility behavior, new daily-work guardrails, stale
+   sidecar diagnostics, and generated documentation.
+
+## Risks And Tradeoffs
+
+| Risk | Impact | Mitigation / Decision Path |
+| --- | --- | --- |
+| Existing clients may call `update_scene_metadata` with `characters` or `places`. | Behavior change could surprise integrations. | Characterize current behavior first, then choose strict rejection or compatibility-only migration with clear error guidance. |
+| Removing the sidecar-first path may leave no bulk relationship update path. | Authors may need repetitive calls for broad relationship repair. | Keep `enrich_scene_characters_batch` for dry-run-first repair and consider a future bulk outcome workflow only if needed. |
+| Sync still indexes legacy sidecar fields. | The compatibility path could be mistaken for daily authority. | Keep sync wording and audit diagnostics explicit: import/sync compatibility is not a mutation contract. |
+| Tags, versions, flags, and status have adjacent ownership questions. | Scope could balloon into a broad metadata redesign. | Limit this initiative to scene character/place relationship authority; record other families as future schema/deprecation decisions. |
+| Compatibility sidecar output can fail after SQLite commit. | Users may see stale files even though canonical state is current. | Preserve existing warning pattern: SQLite and backup artifacts are current; sidecar output is generated compatibility. |
+
+## Test Strategy
+
+Unit tests:
+
+- `update_scene_metadata` relationship-field contract.
+- Relationship index mutation behavior before and after generic metadata calls.
+- Sync/import indexing of legacy sidecar `characters` and `places`.
+- `audit_relationship_metadata` diagnostics for retained compatibility fields.
+- Backup refresh behavior for canonical relationship workflows.
+
+Integration tests:
+
+- MCP tool call rejecting or demoting `characters` and `places` in
+  `update_scene_metadata`.
+- `connect_character_place_evidence` remains SQLite-first and refreshes
+  compatibility output.
+- Legacy project sync still indexes existing relationship sidecar fields.
+- `describe_workflows` and generated tool docs route callers to outcome
+  workflows.
+
+Regression tests:
+
+- `find_scenes`, `get_arc`, `get_scene_prose`, review bundles, and styleguide
+  scene targeting still read relationship indexes correctly.
+- Existing sidecar structural-field preservation remains intact.
+
+## Open Questions
+
+1. Should `update_scene_metadata` strictly reject `characters` and `places`, or
+   should it retain them as compatibility-only sidecar/review metadata without
+   canonical reindexing?
+2. Is `connect_character_place_evidence` enough for practical daily-work
+   character/place updates, or is a separate named workflow needed for
+   character-only or place-only scene evidence?
+3. Should scene `tags` stay in `update_scene_metadata` as search/editorial
+   metadata, or should a later initiative decide whether tags need their own
+   canonical ownership model?

--- a/docs/initiatives/backlog/relationship-metadata-boundary/prd.md
+++ b/docs/initiatives/backlog/relationship-metadata-boundary/prd.md
@@ -127,7 +127,12 @@ There are two acceptable implementation shapes:
 
 The strict contract is the default planning assumption because it is easiest for
 agents and users to understand. The compatibility-only contract remains a
-fallback if existing integrations need a softer migration.
+fallback if existing integrations need a softer migration, but it has an
+important constraint: it must not write ordinary `characters` or `places`
+sidecar fields that ordinary sync will later adopt into canonical relationship
+rows. If compatibility-only behavior is chosen, it needs a review-only storage
+shape that sync ignores, or an accompanying sync contract change that prevents
+delayed canonical mutation.
 
 ## Workflows
 
@@ -165,11 +170,13 @@ be the current path for scene-backed character/place authority.
    indexable through sync/import compatibility paths.
 4. Generic scene metadata updates no longer silently convert sidecar-first
    character/place edits into canonical relationship authority.
-5. Tool responses and workflow guidance point agents to the correct
+5. If a compatibility-only transition is chosen, later ordinary sync cannot
+   convert those compatibility writes into canonical relationship rows.
+6. Tool responses and workflow guidance point agents to the correct
    relationship workflow.
-6. Backups and operation history stay current after canonical relationship
+7. Backups and operation history stay current after canonical relationship
    mutations.
-7. Tests cover old compatibility behavior, new daily-work guardrails, stale
+8. Tests cover old compatibility behavior, new daily-work guardrails, stale
    sidecar diagnostics, and generated documentation.
 
 ## Risks And Tradeoffs
@@ -177,6 +184,7 @@ be the current path for scene-backed character/place authority.
 | Risk | Impact | Mitigation / Decision Path |
 | --- | --- | --- |
 | Existing clients may call `update_scene_metadata` with `characters` or `places`. | Behavior change could surprise integrations. | Characterize current behavior first, then choose strict rejection or compatibility-only migration with clear error guidance. |
+| Compatibility-only writes are later adopted by sync. | A delayed canonical mutation would preserve the authority leak under a different timing. | If compatibility-only is selected, use review-only metadata ignored by sync or change sync so those writes remain non-authoritative. |
 | Removing the sidecar-first path may leave no bulk relationship update path. | Authors may need repetitive calls for broad relationship repair. | Keep `enrich_scene_characters_batch` for dry-run-first repair and consider a future bulk outcome workflow only if needed. |
 | Sync still indexes legacy sidecar fields. | The compatibility path could be mistaken for daily authority. | Keep sync wording and audit diagnostics explicit: import/sync compatibility is not a mutation contract. |
 | Tags, versions, flags, and status have adjacent ownership questions. | Scope could balloon into a broad metadata redesign. | Limit this initiative to scene character/place relationship authority; record other families as future schema/deprecation decisions. |


### PR DESCRIPTION
## Summary

- Adds a deferred Relationship Metadata Boundary initiative to the backlog.
- Captures a PRD, milestone gates, and architecture notes for closing the remaining sidecar-first character/place relationship metadata mutation path.
- Adds the initiative to BACKLOG.md for future prioritization.

## Motivation

The architecture review found one remaining target-architecture gap: update_scene_metadata can still accept characters/places, write them to sidecars first, and then reindex SQLite relationship rows from that compatibility data. The new initiative preserves that finding as durable planning instead of leaving it in chat history.

## Implementation

- Documents the problem, user value, scope, non-goals, risks, acceptance criteria, and open questions.
- Defines milestone gates from contract characterization through metadata guardrails, sync/audit alignment, docs, and release readiness.
- Adds architecture notes for ownership boundaries, migration behavior, failure modes, and preferred contract decisions.
- Incorporates adversarial-review guidance that any compatibility-only path must avoid delayed canonical mutation through ordinary sync.

## Testing

- `npm run check:static`

## Risks and tradeoffs

- Docs-only change: no runtime behavior changes are included.
- The strict rejection vs. compatibility-only migration decision remains intentionally open for M0.
- release-log.md was not updated because this is backlog planning only, not a shipped user-facing behavior change.

## Initiative adversary review

- Verdict: Accepted with notes after revision.
- The review found one must-fix ambiguity: compatibility-only writes could be adopted by a later sync if stored in ordinary characters/places fields. The docs now require any compatibility-only path to use sync-ignored review metadata or change sync semantics in the same milestone.

## Follow-up

- Activate the initiative only after review acceptance.
- If accepted, start with M0 contract decision and characterization.