### PR TITLE
docs: activate relationship metadata boundary M0

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -22,12 +22,6 @@ Add optional project-scoped Parts, Acts, or other larger structural sections abo
 
 **Status:** Deferred backlog (not active). Chapter and epigraph structure is complete; this follow-up captures the optional division layer without reopening shipped chapter behavior.
 
-### 🔗 [Relationship Metadata Boundary](docs/initiatives/backlog/relationship-metadata-boundary/prd.md) 📋
-
-Close the remaining sidecar-first relationship mutation path so generic scene metadata updates no longer act as canonical character/place relationship writes.
-
-**Status:** Deferred backlog (not active). Planning captures the next target-architecture cleanup candidate from the architecture review.
-
 ### 📊 [Embedding-Based Search](docs/initiatives/backlog/embeddings-search/prd.md) 📋
 
 Semantic search for queries that require understanding meaning, not just keywords.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -9,9 +9,9 @@ It supports metadata-first reasoning, explicit prose editing workflows, and revi
 
 ## Product Status
 
-Active initiative: None selected.
+Active initiative: [Relationship Metadata Boundary](docs/initiatives/active/relationship-metadata-boundary/prd.md).
 
-Current focus: Select the next initiative from the deferred backlog or a new planning cycle.
+Current focus: Relationship Metadata Boundary M0 is implemented in the active branch and pending review; M1 is the next planned implementation slice after M0 is accepted.
 
 Most recent completed initiative: [Architecture Alignment Follow-up](docs/initiatives/done/architecture-alignment-follow-up/prd.md).
 
@@ -51,6 +51,7 @@ For structural manuscript state, use [Managed Structure Contract](docs/foundatio
 
 - [Features](FEATURES.md) — shipped product capabilities and links to completed initiative docs
 - [Backlog](BACKLOG.md) — deferred product work that is not currently active
+- [Relationship Metadata Boundary](docs/initiatives/active/relationship-metadata-boundary/prd.md) — active initiative for closing the remaining sidecar-first scene character/place relationship mutation path
 - [Architecture Alignment Follow-up](docs/initiatives/done/architecture-alignment-follow-up/prd.md) — completed initiative documenting sidecar compatibility, migration, deprecation expectations, and relationship workflow alignment
 - [Database Backup and Recovery](docs/initiatives/done/database-backup-recovery/prd.md) — completed initiative for Git-reviewable recovery artifacts and explicit restore workflows for SQLite-canonical state
 - [Conceptual Target Architecture](docs/foundations/target-architecture.md) — idealized architectural model for evaluating future structure, tooling, and workflow decisions

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -11,7 +11,7 @@ It supports metadata-first reasoning, explicit prose editing workflows, and revi
 
 Active initiative: [Relationship Metadata Boundary](docs/initiatives/active/relationship-metadata-boundary/prd.md).
 
-Current focus: Relationship Metadata Boundary M0 is implemented in the active branch and pending review; M1 is the next planned implementation slice after M0 is accepted.
+Current focus: Relationship Metadata Boundary M0 establishes the contract decision and characterization baseline; M1 is the next planned implementation slice.
 
 Most recent completed initiative: [Architecture Alignment Follow-up](docs/initiatives/done/architecture-alignment-follow-up/prd.md).
 

--- a/docs/initiatives/active/relationship-metadata-boundary/architecture.md
+++ b/docs/initiatives/active/relationship-metadata-boundary/architecture.md
@@ -1,6 +1,6 @@
 # Relationship Metadata Boundary — Architecture Notes
 
-**Status:** Deferred backlog (not active)
+**Status:** Active — M0 selected
 
 ## Context
 
@@ -35,6 +35,18 @@ Canonical or indexed relationship state currently includes:
 - `scene_threads`
 - `character_relationships`
 - `reference_links`
+
+Scene character/place relationship metadata is for sheet-backed entities. A
+named person or location mentioned in prose should not become a canonical scene
+relationship unless it has a corresponding character or place sheet. Unsheeted
+mentions remain prose context or review material until a deliberate workflow
+promotes them into the world model.
+
+Scene-character and scene-place links are independent optional relationships. A
+scene can validly have no linked characters or places, one or more linked
+characters without a linked place, one or more linked places without a linked
+character, or both. The model should not require paired character/place
+evidence.
 
 Outcome-level relationship workflows already commit SQLite first for current
 relationship work:
@@ -91,7 +103,9 @@ through sidecar-first writes.
 
 | Decision | Preferred Direction | Rationale | Alternative |
 | --- | --- | --- | --- |
-| `characters` and `places` in `update_scene_metadata` | Reject and route to relationship workflows. | Clearest agent/user contract and matches structural-field rejection. | Allow compatibility-only writes only if ordinary sync cannot later adopt those writes into canonical relationship indexes. |
+| `characters` and `places` in `update_scene_metadata` | M0 selected strict rejection for M1. | Clearest agent/user contract, matches structural-field rejection, and avoids delayed canonical mutation through ordinary sync. | Compatibility-only writes would require a review-only storage shape or sync-rule change; M0 does not select that path. |
+| Scene character/place cardinality | Preserve independent optional links. | Scenes do not always have sheet-backed characters or places, and a valid scene can have one side without the other. | Treat character/place evidence as a required pair, which would misrepresent common manuscript cases. |
+| Unsheeted people or locations in scene metadata | Do not treat them as relationship metadata. | Scene relationship authority should reference stable, sheet-backed entity IDs rather than freeform prose mentions. | A future review-note or entity-promotion workflow could capture candidates without indexing them as canonical relationships. |
 | Legacy sync handling | Preserve indexing from existing sidecar/frontmatter fields. | Import is a special mode and existing projects need continuity. | Require an explicit migration before indexing legacy relationship fields. |
 | Backup refresh | Refresh backups after canonical relationship workflows, not after compatibility-only writes. | Recovery snapshots should represent canonical state. | Refresh backup after all sidecar metadata writes, even if non-canonical. |
 | Diagnostic owner | Use `audit_relationship_metadata` for authority/drift guidance. | Keeps repair reasoning in an outcome-oriented workflow. | Add a new diagnostic tool just for character/place sidecars. |
@@ -117,10 +131,19 @@ Disallowed daily-work role:
 
 Owned role:
 
-- current scene-backed character/place relationship authority;
+- current scene-backed, sheet-backed character/place relationship authority;
 - SQLite-first commit;
 - project backup refresh;
 - generated compatibility sidecar refresh when possible.
+
+Boundary:
+
+- not a universal replacement for every freeform `characters` or `places` list;
+- not a complete replacement for independent character-only or place-only
+  sheet-backed scene links;
+- not responsible for unsheeted people or locations that appear only in prose;
+- may need a future companion workflow if sheet-backed character-only or
+  place-only scene evidence becomes a daily-work need.
 
 ### Sync And Import
 
@@ -162,7 +185,12 @@ to `update_scene_metadata` should receive:
 - replacement tools and suggested sequence;
 - no sidecar or SQLite mutation.
 
-If compatibility-only behavior is chosen, callers should receive:
+M0 selected strict rejection for M1. Compatibility-only behavior is not selected
+because writing ordinary sidecar `characters` or `places` would risk delayed
+canonical mutation through ordinary sync unless paired with a separate ignored
+storage shape or sync-rule change.
+
+If a future compatibility-only behavior is reconsidered, callers should receive:
 
 - an explicit `compatibility_only` indicator;
 - a statement that canonical relationship rows were not changed;
@@ -182,13 +210,15 @@ path. Otherwise the canonical mutation is merely delayed until the next sync.
   remain current; response includes compatibility diagnostics.
 - **Legacy sidecar disagreement:** sync/audit reports drift and points to
   outcome-level repair; ordinary sync does not silently decide author intent.
-- **Compatibility-only delayed mutation:** if retained review metadata is stored
-  in a shape that sync still consumes, the plan has failed; M0 must choose a
-  storage shape or sync rule that prevents this.
+- **Compatibility-only delayed mutation:** M0 avoids this by selecting strict
+  rejection. If a future compatibility-only path is reconsidered, retained
+  review metadata must use a shape that sync does not consume or include a sync
+  rule that prevents adoption as canonical relationship rows.
 - **Ambiguous character or place identity:** relationship workflows reject or
   require explicit IDs instead of guessing from names.
-- **Existing clients use old metadata path:** M0 decides whether to use strict
-  rejection or compatibility-only migration based on compatibility risk.
+- **Existing clients use old metadata path:** M0 selected strict rejection for
+  M1; the implementation should provide a stable error and replacement
+  guidance.
 
 ## Safety Considerations
 
@@ -209,12 +239,10 @@ Required validation should combine:
 - generated docs checks for tool guidance;
 - full PR gate before merge.
 
-## Open Questions
+## Remaining Open Questions
 
-1. Should strict rejection happen immediately, or should compatibility-only
-   behavior be used as a transition?
-2. Do authors need a character-only or place-only evidence workflow, or is the
-   paired `connect_character_place_evidence` workflow enough for the current
-   daily-work model?
-3. Should a later initiative promote scene tags to a clearer canonical schema,
+1. What workflow should handle character-only or place-only sheet-backed scene
+   evidence now that scene-character and scene-place links are explicitly
+   independent optional relationships?
+2. Should a later initiative promote scene tags to a clearer canonical schema,
    or are they intentionally retained as search/editorial metadata?

--- a/docs/initiatives/active/relationship-metadata-boundary/milestones.md
+++ b/docs/initiatives/active/relationship-metadata-boundary/milestones.md
@@ -1,6 +1,6 @@
 # Relationship Metadata Boundary — Milestones
 
-**Status:** Deferred backlog (not active)
+**Status:** Active — M0 selected
 
 Use [prd.md](prd.md) for product framing and this document for sequencing,
 review gates, and implementation readiness.
@@ -22,6 +22,8 @@ legacy compatibility and keeping the repository coherent after each slice.
 
 ## M0 — Contract Decision And Characterization
 
+Status: Implemented in branch; pending review.
+
 Goal: make the current behavior and target contract reviewable before changing
 tool behavior.
 
@@ -29,12 +31,24 @@ Deliverables:
 
 - Characterization tests for current `update_scene_metadata` handling of
   `characters` and `places`.
-- A documented contract decision choosing strict rejection or
-  compatibility-only behavior for those fields.
-- If compatibility-only behavior remains an option, a decision on how it avoids
-  delayed canonical mutation through ordinary sync.
+- A documented contract decision choosing strict rejection for those fields in
+  M1.
+- Documentation explaining why compatibility-only behavior was not selected:
+  writing ordinary sidecar `characters` or `places` would risk delayed
+  canonical mutation through ordinary sync unless a separate ignored storage
+  shape or sync-rule change existed.
 - Identification of any known clients or docs that still recommend generic
   metadata updates for relationship changes.
+- A decision on whether `connect_character_place_evidence` is sufficient for
+  character-only or place-only scene evidence, or whether that replacement
+  guidance needs a future named workflow.
+- Explicit confirmation that scene-character and scene-place links are
+  independent optional relationships: a scene can have zero, one, or many
+  sheet-backed character links and zero, one, or many sheet-backed place links,
+  without requiring both sides.
+- A documented product rule that scene `characters` and `places` metadata is
+  sheet-backed only; unsheeted people or locations remain prose context until a
+  deliberate sheet-creation workflow promotes them.
 - Explicit confirmation that `tags`, `status`, `flags`, and `versions` remain
   outside this initiative.
 
@@ -43,14 +57,26 @@ Acceptance criteria:
 - Reviewers can see the before/after contract from tests and docs.
 - The chosen contract is consistent with the Managed Structure Contract.
 - The migration path preserves legacy sync/import compatibility.
-- Compatibility-only behavior, if chosen, cannot write ordinary fields that
-  ordinary sync later adopts as canonical relationship state.
+- The chosen contract preserves independent optional scene-character and
+  scene-place cardinality instead of requiring paired character/place evidence.
+- The chosen contract does not promote unsheeted named people or locations into
+  canonical scene relationship metadata.
+- The selected strict contract avoids writing ordinary fields that ordinary sync
+  later adopts as canonical relationship state.
 - No public behavior changes are included beyond characterization or docs.
 
 Required validation:
 
 - `node --experimental-sqlite --test src/test/unit/metadata-tools.test.mjs`
 - `node --experimental-sqlite --test src/test/integration/metadata.test.mjs`
+
+Activation notes:
+
+- No production behavior change in M0.
+- M0 selected strict rejection, so no compatibility-only storage shape or sync
+  rule is introduced.
+- Carry release-log expectations forward to the first milestone that changes
+  the public `update_scene_metadata` contract.
 
 Out of scope:
 
@@ -76,13 +102,10 @@ Deliverables:
 
 Acceptance criteria:
 
-- A call to `update_scene_metadata` with `characters` or `places` either fails
-  with a clear relationship-boundary error or stores only non-authoritative
-  compatibility/review metadata without changing canonical relationship rows,
-  depending on the M0 decision.
-- If compatibility/review metadata is retained, subsequent ordinary sync does
-  not convert that retained metadata into canonical relationship rows.
-- The tool response names the correct relationship workflow for daily work.
+- A call to `update_scene_metadata` with `characters` or `places` fails with a
+  clear relationship-boundary error and does not write scene sidecar metadata.
+- The rejection response names the correct relationship/audit workflows for
+  daily work and compatibility review.
 - Existing allowed metadata fields continue to work.
 - Sidecar structural compatibility fields remain preserved.
 - Canonical relationship indexes do not change through sidecar-first generic

--- a/docs/initiatives/active/relationship-metadata-boundary/prd.md
+++ b/docs/initiatives/active/relationship-metadata-boundary/prd.md
@@ -1,8 +1,9 @@
 # PRD: Relationship Metadata Boundary
 
-**Status:** Deferred backlog (not active)
+**Status:** Active — M0 selected
 
 Created: 2026-05-28.
+Activated: 2026-05-29.
 
 Related docs:
 - [Product Overview](../../../../PRODUCT.md)
@@ -86,6 +87,13 @@ In scope:
   `characters` and `places` fields.
 - Route daily scene-backed character/place relationship changes to
   `connect_character_place_evidence` or a deliberately named replacement.
+- Treat scene `characters` and `places` metadata as sheet-backed entity
+  references only. A character or place should not be promoted into scene
+  relationship metadata unless it has a corresponding character or place sheet.
+- Preserve the independent cardinality of scene relationship links: a scene may
+  have no linked characters or places, one or more sheet-backed characters with
+  no linked place, one or more sheet-backed places with no linked character, or
+  both.
 - Update workflow guidance and generated tool documentation so agents stop
   treating sidecar lists as relationship authority.
 - Refresh project backups after canonical relationship mutations, or document
@@ -116,7 +124,17 @@ The preferred direction is a staged migration:
 4. Ensure outcome-level tools are sufficient for the common daily-work cases
    that `update_scene_metadata` previously covered.
 
-There are two acceptable implementation shapes:
+The contract decision must preserve one product rule: scene `characters` and
+`places` metadata is for sheet-backed entities. Not every named person or
+location in prose deserves a character or place sheet. Unmodeled mentions should
+remain prose context, not relationship metadata.
+
+Scene character and scene place links are independent optional relationships,
+not a required character/place pair. `connect_character_place_evidence` covers
+paired evidence, but it is not by itself a complete replacement for character-
+only or place-only sheet-backed scene evidence.
+
+Before M0 there were two acceptable implementation shapes:
 
 - **Strict contract:** reject `characters` and `places` in
   `update_scene_metadata`, similar to structural fields, and point callers to
@@ -125,14 +143,57 @@ There are two acceptable implementation shapes:
   sidecar/review metadata and do not let that operation rebuild canonical
   relationship rows.
 
-The strict contract is the default planning assumption because it is easiest for
-agents and users to understand. The compatibility-only contract remains a
-fallback if existing integrations need a softer migration, but it has an
-important constraint: it must not write ordinary `characters` or `places`
-sidecar fields that ordinary sync will later adopt into canonical relationship
-rows. If compatibility-only behavior is chosen, it needs a review-only storage
+M0 selects the strict contract because it is easiest for agents and users to
+understand and avoids the delayed-mutation risk. The compatibility-only contract
+is not selected for this initiative because it would need a review-only storage
 shape that sync ignores, or an accompanying sync contract change that prevents
-delayed canonical mutation.
+ordinary sidecar `characters` or `places` from becoming canonical relationship
+rows later.
+
+## M0 Contract Decision
+
+M0 selects the **strict contract** for M1 implementation:
+
+- `update_scene_metadata` should reject `characters` and `places` as
+  relationship-boundary fields rather than storing compatibility-only values.
+- Generic scene metadata writes must not mutate canonical `scene_characters` or
+  `scene_places` rows immediately, and must not write ordinary sidecar fields
+  that a later ordinary sync can adopt as canonical relationship rows.
+- Legacy sidecar/frontmatter `characters` and `places` remain supported as
+  setup, import, sync compatibility, generated compatibility output, and audit
+  evidence.
+- Scene `characters` and `places` represent sheet-backed entities only.
+  Unsheeted named people or locations remain prose context until a deliberate
+  sheet-creation workflow promotes them into the world model.
+- Scene-character and scene-place links are independent optional relationships:
+  a scene can have zero, one, or many sheet-backed character links and zero,
+  one, or many sheet-backed place links, without requiring both sides.
+- `connect_character_place_evidence` is the replacement workflow only when a
+  scene proves a paired sheet-backed character/place association. Character-only
+  and place-only sheet-backed scene evidence need a future deliberately named
+  workflow if daily-work mutation support is required.
+- `tags`, `status`, `flags`, and `versions` remain outside this initiative and
+  keep their current compatibility/review/search roles until a separate
+  planning decision changes them.
+
+### M0 Guidance Inventory
+
+Current user-facing guidance does not recommend using `update_scene_metadata`
+for scene `characters` or `places`:
+
+- `README.md` recommends `update_scene_metadata` for editorial fields such as
+  beat, POV, status, and tags.
+- `docs/guides/sidecar-compatibility.md` routes current relationship work to
+  outcome tools and warns against direct sidecar relationship edits.
+- `docs/agents/tools.md` is generated from the current tool schema and still
+  exposes `characters` and `places` as accepted `update_scene_metadata` fields;
+  M3 should regenerate it after M1 changes the schema and tool description.
+
+Historical completed initiative docs still mention relationship updates through
+`update_scene_metadata`, notably the completed prose-editing and metadata
+architecture PRDs. Those documents are historical records rather than current
+product guidance, but reviewers should be aware of them when checking for stale
+public wording.
 
 ## Workflows
 
@@ -140,10 +201,14 @@ delayed canonical mutation.
 
 1. Use `find_scenes`, `list_characters`, and `list_places` to identify stable
    IDs.
-2. Use `connect_character_place_evidence` when a scene proves a character/place
-   association.
-3. Treat any sidecar refresh as generated compatibility output.
-4. Use `audit_relationship_metadata` when sidecar relationship fields disagree
+2. Use `connect_character_place_evidence` when a scene proves a paired
+   character/place association.
+3. Do not add a character or place to scene metadata unless it has a
+   corresponding character or place sheet. Unsheeted named people or locations
+   remain prose context until a deliberate sheet-creation workflow promotes
+   them.
+4. Treat any sidecar refresh as generated compatibility output.
+5. Use `audit_relationship_metadata` when sidecar relationship fields disagree
    with canonical indexes.
 
 ### Legacy Project Compatibility
@@ -162,16 +227,16 @@ be the current path for scene-backed character/place authority.
 
 ## Acceptance Criteria
 
-1. The public contract for `update_scene_metadata` explicitly states whether
-   `characters` and `places` are rejected or compatibility-only.
+1. The public contract for `update_scene_metadata` explicitly states that
+   `characters` and `places` are rejected as relationship-boundary fields.
 2. Daily scene-backed character/place relationship changes are routed through
    outcome-level SQLite-first workflows.
 3. Existing legacy sidecar/frontmatter `characters` and `places` fields remain
    indexable through sync/import compatibility paths.
 4. Generic scene metadata updates no longer silently convert sidecar-first
    character/place edits into canonical relationship authority.
-5. If a compatibility-only transition is chosen, later ordinary sync cannot
-   convert those compatibility writes into canonical relationship rows.
+5. Generic metadata writes cannot create canonical relationship rows
+   immediately or through later ordinary sync.
 6. Tool responses and workflow guidance point agents to the correct
    relationship workflow.
 7. Backups and operation history stay current after canonical relationship
@@ -183,8 +248,10 @@ be the current path for scene-backed character/place authority.
 
 | Risk | Impact | Mitigation / Decision Path |
 | --- | --- | --- |
-| Existing clients may call `update_scene_metadata` with `characters` or `places`. | Behavior change could surprise integrations. | Characterize current behavior first, then choose strict rejection or compatibility-only migration with clear error guidance. |
+| Existing clients may call `update_scene_metadata` with `characters` or `places`. | Behavior change could surprise integrations. | Characterize current behavior first, then implement strict rejection with clear error guidance. |
+| Replacement guidance overfits to paired character/place evidence. | Scenes can validly have zero links, character-only links, place-only links, multiple characters, multiple places, or both; routing every case to a paired workflow would misrepresent the model. | M0 must state independent optional cardinality and decide whether a future character-only/place-only workflow is needed before M1 guidance changes. |
 | Compatibility-only writes are later adopted by sync. | A delayed canonical mutation would preserve the authority leak under a different timing. | If compatibility-only is selected, use review-only metadata ignored by sync or change sync so those writes remain non-authoritative. |
+| Callers may list unsheeted named people or locations as scene metadata. | Freeform mentions could be accidentally promoted into canonical relationship state, creating weak IDs and false authority. | State that `characters` and `places` metadata is sheet-backed only; unsheeted mentions stay in prose until deliberately promoted through sheet creation and relationship evidence. |
 | Removing the sidecar-first path may leave no bulk relationship update path. | Authors may need repetitive calls for broad relationship repair. | Keep `enrich_scene_characters_batch` for dry-run-first repair and consider a future bulk outcome workflow only if needed. |
 | Sync still indexes legacy sidecar fields. | The compatibility path could be mistaken for daily authority. | Keep sync wording and audit diagnostics explicit: import/sync compatibility is not a mutation contract. |
 | Tags, versions, flags, and status have adjacent ownership questions. | Scope could balloon into a broad metadata redesign. | Limit this initiative to scene character/place relationship authority; record other families as future schema/deprecation decisions. |
@@ -216,14 +283,28 @@ Regression tests:
   scene targeting still read relationship indexes correctly.
 - Existing sidecar structural-field preservation remains intact.
 
-## Open Questions
+## Remaining Open Questions
 
-1. Should `update_scene_metadata` strictly reject `characters` and `places`, or
-   should it retain them as compatibility-only sidecar/review metadata without
-   canonical reindexing?
-2. Is `connect_character_place_evidence` enough for practical daily-work
-   character/place updates, or is a separate named workflow needed for
-   character-only or place-only scene evidence?
-3. Should scene `tags` stay in `update_scene_metadata` as search/editorial
+1. What named workflow, if any, should handle character-only or place-only
+   sheet-backed scene evidence, given that scenes can validly have either side
+   independently and `connect_character_place_evidence` only covers paired
+   associations?
+2. Should scene `tags` stay in `update_scene_metadata` as search/editorial
    metadata, or should a later initiative decide whether tags need their own
    canonical ownership model?
+
+## Activation Notes
+
+- Activate M0 first; do not make production behavior changes before the
+  strict-versus-compatibility contract and replacement workflow adequacy are
+  decided.
+- M0 preserves that scene-character and scene-place links are independent
+  optional relationships. Character-only and place-only sheet-backed scene
+  evidence remain a future workflow decision unless M1 adds only guidance.
+- M0 should preserve the rule that scene `characters` and `places` metadata is
+  only for entities with character or place sheets; unsheeted mentions remain
+  prose context.
+- M0 selected strict rejection, so no compatibility-only storage shape or sync
+  rule is introduced.
+- Generic metadata writes must not create canonical relationship changes
+  immediately or after a later ordinary sync.

--- a/src/test/integration/metadata.test.mjs
+++ b/src/test/integration/metadata.test.mjs
@@ -144,6 +144,51 @@ describe("update_scene_metadata tool", () => {
     assert.notEqual(sidecar.chapter_id, "ch-08-chapter-8");
     assert.notEqual(sidecar.chapter_title, "Chapter 8");
   });
+
+  test("characterizes current characters and places updates as independent sidecar-first index mutations", async () => {
+    const sceneDir = path.join(writeSyncDir, "projects", "test-novel", "scenes");
+    fs.mkdirSync(sceneDir, { recursive: true });
+    const scenePath = path.join(sceneDir, "sc-m0-relationship-characterization.md");
+    const sidecarFile = path.join(sceneDir, "sc-m0-relationship-characterization.meta.yaml");
+    const uniquePlaceId = "m0characterizationyard";
+    const placeDir = path.join(writeSyncDir, "projects", "test-novel", "world", "places");
+    fs.mkdirSync(placeDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(placeDir, `${uniquePlaceId}.md`),
+      `---\nplace_id: ${uniquePlaceId}\nname: M0 Characterization Yard\n---\nA temporary place sheet for M0 characterization.`,
+      "utf8"
+    );
+    fs.writeFileSync(
+      scenePath,
+      `---\nscene_id: sc-m0-relationship-characterization\ntitle: M0 Relationship Characterization\ncharacters:\n  - elena\nplaces:\n  - ${uniquePlaceId}\n---\nM0 relationship characterization prose.`,
+      "utf8"
+    );
+
+    await callWriteTool("sync");
+
+    const updateText = await callWriteTool("update_scene_metadata", {
+      scene_id: "sc-m0-relationship-characterization",
+      project_id: "test-novel",
+      fields: {
+        characters: ["marcus"],
+        places: [],
+      },
+    });
+    const updateParsed = JSON.parse(updateText);
+    assert.equal(updateParsed.ok, true, updateText);
+
+    const sidecar = yaml.load(fs.readFileSync(sidecarFile, "utf8"));
+    assert.deepEqual(sidecar.characters, ["marcus"]);
+    assert.deepEqual(sidecar.places, []);
+
+    const marcusScenesText = await callWriteTool("find_scenes", {
+      project_id: "test-novel",
+      character: "marcus",
+      page_size: 200,
+    });
+    const marcusScenes = JSON.parse(marcusScenesText);
+    assert.ok(marcusScenes.results.some((row) => row.scene_id === "sc-m0-relationship-characterization"));
+  });
 });
 
 describe("assign_scene_to_chapter tool", () => {

--- a/src/test/integration/metadata.test.mjs
+++ b/src/test/integration/metadata.test.mjs
@@ -188,6 +188,14 @@ describe("update_scene_metadata tool", () => {
     });
     const marcusScenes = JSON.parse(marcusScenesText);
     assert.ok(marcusScenes.results.some((row) => row.scene_id === "sc-m0-relationship-characterization"));
+
+    await callWriteTool("sync");
+
+    const retainedPlaceSearchText = await callWriteTool("search_metadata", {
+      query: uniquePlaceId,
+    });
+    const retainedPlaceSearch = JSON.parse(retainedPlaceSearchText);
+    assert.ok(retainedPlaceSearch.results.some((row) => row.scene_id === "sc-m0-relationship-characterization"));
   });
 });
 

--- a/src/test/unit/metadata-tools.test.mjs
+++ b/src/test/unit/metadata-tools.test.mjs
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import yaml from "js-yaml";
 import { openDb } from "../../core/db.js";
 import { registerMetadataTools } from "../../tools/metadata.js";
 
@@ -83,6 +84,25 @@ function seedScene(db, { sceneId, projectId }) {
       scene_id, project_id, title, file_path, prose_checksum, metadata_stale, updated_at
     ) VALUES (?, ?, ?, ?, ?, 0, ?)
   `).run(sceneId, projectId, sceneId, scenePath, "deadbeef", new Date().toISOString());
+}
+
+function seedProjectSceneFile(db, { sceneId, projectId, metadata = {} }) {
+  seedCounter += 1;
+  const sceneDir = path.join(SEED_TMP_DIR, "projects", projectId, "scenes");
+  fs.mkdirSync(sceneDir, { recursive: true });
+  const scenePath = path.join(sceneDir, `${sceneId}-${seedCounter}.md`);
+  const frontmatter = yaml.dump({
+    scene_id: sceneId,
+    title: sceneId,
+    ...metadata,
+  });
+  fs.writeFileSync(scenePath, `---\n${frontmatter}---\nScene prose.`, "utf8");
+  db.prepare(`
+    INSERT INTO scenes (
+      scene_id, project_id, title, file_path, prose_checksum, metadata_stale, updated_at
+    ) VALUES (?, ?, ?, ?, ?, 0, ?)
+  `).run(sceneId, projectId, sceneId, scenePath, "deadbeef", new Date().toISOString());
+  return scenePath;
 }
 
 function seedReferenceDoc(db, { docId, projectId, title }) {
@@ -403,6 +423,69 @@ describe("metadata upsert_reference_link tool", () => {
 
       assert.equal(parsed.ok, false);
       assert.equal(parsed.error.code, "VALIDATION_ERROR");
+    } finally {
+      db.close();
+    }
+  });
+});
+
+describe("metadata update_scene_metadata relationship-field characterization", () => {
+  test("currently writes characters and places to the sidecar before rebuilding scene relationship indexes", async () => {
+    const db = openDb(":memory:");
+    try {
+      seedProject(db, "test-novel");
+      seedCharacter(db, { characterId: "char-elena", projectId: "test-novel", name: "Elena" });
+      seedCharacter(db, { characterId: "char-marcus", projectId: "test-novel", name: "Marcus" });
+      seedPlace(db, { placeId: "place-harbor", projectId: "test-novel", name: "Harbor" });
+      const scenePath = seedProjectSceneFile(db, {
+        sceneId: "sc-relationship-characterization",
+        projectId: "test-novel",
+        metadata: {
+          characters: ["char-elena"],
+          places: ["place-harbor"],
+        },
+      });
+      db.prepare(`
+        INSERT INTO scene_characters (scene_id, project_id, character_id)
+        VALUES (?, ?, ?)
+      `).run("sc-relationship-characterization", "test-novel", "char-elena");
+      db.prepare(`
+        INSERT INTO scene_places (scene_id, project_id, place_id)
+        VALUES (?, ?, ?)
+      `).run("sc-relationship-characterization", "test-novel", "place-harbor");
+
+      const tools = makeToolHarness(db);
+      const parsed = await tools.call("update_scene_metadata", {
+        scene_id: "sc-relationship-characterization",
+        project_id: "test-novel",
+        fields: {
+          characters: ["char-marcus"],
+          places: [],
+        },
+      });
+
+      assert.equal(parsed.ok, true);
+      assert.equal(parsed.action, "updated");
+
+      const sidecar = yaml.load(fs.readFileSync(scenePath.replace(/\.md$/, ".meta.yaml"), "utf8"));
+      assert.deepEqual(sidecar.characters, ["char-marcus"]);
+      assert.deepEqual(sidecar.places, []);
+
+      const sceneCharacters = db.prepare(`
+        SELECT character_id
+        FROM scene_characters
+        WHERE scene_id = ? AND project_id = ?
+        ORDER BY character_id
+      `).all("sc-relationship-characterization", "test-novel").map((row) => row.character_id);
+      const scenePlaces = db.prepare(`
+        SELECT place_id
+        FROM scene_places
+        WHERE scene_id = ? AND project_id = ?
+        ORDER BY place_id
+      `).all("sc-relationship-characterization", "test-novel").map((row) => row.place_id);
+
+      assert.deepEqual(sceneCharacters, ["char-marcus"]);
+      assert.deepEqual(scenePlaces, []);
     } finally {
       db.close();
     }


### PR DESCRIPTION
## Summary

- Activate the Relationship Metadata Boundary initiative and move it from backlog to active.
- Implement M0 by documenting the strict-contract decision for future `update_scene_metadata` relationship-field handling.
- Add characterization tests showing current `characters` / `places` behavior writes sidecar metadata and rebuilds relationship indexes.

## Motivation

`update_scene_metadata` can currently act as a sidecar-first mutation path for scene character/place relationship authority. M0 freezes that current behavior with tests and records the intended contract before any production behavior changes land.

## Implementation

- Records M0 decision that M1 should strictly reject `characters` and `places` in `update_scene_metadata`.
- Clarifies that scene character/place metadata is sheet-backed only.
- Clarifies that scene-character and scene-place links are independent and optional.
- Documents that `connect_character_place_evidence` only covers paired evidence; character-only/place-only sheet-backed evidence remains future workflow scope.
- Updates product/backlog bookkeeping for the active initiative.
- Adds unit and integration characterization coverage for the current sidecar-first behavior.

## Testing

- `node --experimental-sqlite --test src/test/unit/metadata-tools.test.mjs`
- `node --experimental-sqlite --test src/test/integration/metadata.test.mjs`
- `git diff --check`
- `node /Users/hanna/.codex/skills/initiative-completion/scripts/check-initiative-lifecycle.mjs --repo /Users/hanna/Code/mcp-writing --initiative docs/initiatives/active/relationship-metadata-boundary --milestone M0 --strict`

## Risks and tradeoffs

- No production behavior changes are included in this PR.
- Generated tool docs and release-log updates are intentionally deferred until M1 changes the public `update_scene_metadata` contract.
- Character-only/place-only sheet-backed evidence remains an explicit future workflow decision.

## Follow-up

- Implement M1 strict rejection for `characters` and `places` in `update_scene_metadata`.
- Update generated docs and release-log when M1 changes public behavior.