### PR TITLE
feat: guard scene relationship metadata updates

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -11,7 +11,7 @@ It supports metadata-first reasoning, explicit prose editing workflows, and revi
 
 Active initiative: [Relationship Metadata Boundary](docs/initiatives/active/relationship-metadata-boundary/prd.md).
 
-Current focus: Relationship Metadata Boundary M0 establishes the contract decision and characterization baseline; M1 is the next planned implementation slice.
+Current focus: Relationship Metadata Boundary M1 applies the strict relationship guardrail to `update_scene_metadata`.
 
 Most recent completed initiative: [Architecture Alignment Follow-up](docs/initiatives/done/architecture-alignment-follow-up/prd.md).
 

--- a/docs/agents/tools.md
+++ b/docs/agents/tools.md
@@ -692,7 +692,7 @@ Assign a scene to a canonical chapter through the explicit structure workflow. W
 
 ## update_scene_metadata
 
-Update one or more non-structural metadata fields for a scene. Writes only supplied non-structural fields to the .meta.yaml sidecar and preserves existing structural compatibility fields; it never modifies prose or mirrors path-derived structure. Structural fields (part, chapter, chapter_id, chapter_title, timeline_position) are rejected here; use list_chapters plus assign_scene_to_chapter, move_scene, rename_chapter, or reorder_chapter for structure changes. Changes are immediately reflected in the index. Only available when the sync dir is writable.
+Update one or more non-structural, non-relationship metadata fields for a scene. Writes only supplied allowed fields to the .meta.yaml sidecar and preserves existing structural compatibility fields; it never modifies prose, mirrors path-derived structure, or changes scene character/place relationship authority. Structural fields (part, chapter, chapter_id, chapter_title, timeline_position) are rejected here; use list_chapters plus assign_scene_to_chapter, move_scene, rename_chapter, or reorder_chapter for structure changes. Relationship fields (characters, places) are rejected here; use discovery workflows plus connect_character_place_evidence for paired sheet-backed character/place evidence, and audit_relationship_metadata for legacy sidecar/frontmatter relationship review. Allowed changes are immediately reflected in the index. Only available when the sync dir is writable.
 
 | Parameter | Type | Required | Description |
 | --- | --- | :---: | --- |

--- a/docs/initiatives/active/relationship-metadata-boundary/architecture.md
+++ b/docs/initiatives/active/relationship-metadata-boundary/architecture.md
@@ -1,6 +1,6 @@
 # Relationship Metadata Boundary — Architecture Notes
 
-**Status:** Active — M0 selected
+**Status:** Active — M1 selected
 
 ## Context
 

--- a/docs/initiatives/active/relationship-metadata-boundary/milestones.md
+++ b/docs/initiatives/active/relationship-metadata-boundary/milestones.md
@@ -1,6 +1,6 @@
 # Relationship Metadata Boundary — Milestones
 
-**Status:** Active — M0 selected
+**Status:** Active — M1 selected
 
 Use [prd.md](prd.md) for product framing and this document for sequencing,
 review gates, and implementation readiness.
@@ -22,7 +22,7 @@ legacy compatibility and keeping the repository coherent after each slice.
 
 ## M0 — Contract Decision And Characterization
 
-Status: Implemented in branch; pending review.
+Status: Implemented on main.
 
 Goal: make the current behavior and target contract reviewable before changing
 tool behavior.
@@ -85,6 +85,8 @@ Out of scope:
 - Changing sync indexing behavior.
 
 ## M1 — Generic Metadata Relationship Guardrail
+
+Status: Selected for implementation.
 
 Goal: stop `update_scene_metadata` from silently converting sidecar-first
 character/place edits into canonical relationship authority.

--- a/docs/initiatives/active/relationship-metadata-boundary/prd.md
+++ b/docs/initiatives/active/relationship-metadata-boundary/prd.md
@@ -1,6 +1,6 @@
 # PRD: Relationship Metadata Boundary
 
-**Status:** Active — M0 selected
+**Status:** Active — M1 selected
 
 Created: 2026-05-28.
 Activated: 2026-05-29.

--- a/release-log.md
+++ b/release-log.md
@@ -6,6 +6,14 @@ This complements `CHANGELOG.md`:
 - `CHANGELOG.md` is technical and release-oriented.
 - This log is plain-language and outcome-oriented.
 
+### 2026-05-30 — Guard generic scene relationship metadata updates
+
+- What changed: `update_scene_metadata` now rejects scene `characters` and `places` fields and points callers to relationship and audit workflows instead of accepting sidecar-first relationship edits.
+- Why it matters: Authors and AI agents get a clearer boundary between editorial scene metadata and SQLite-canonical relationship evidence, reducing accidental relationship changes from generic metadata patches.
+- Who is affected: Authors, maintainers, and AI agents that previously sent character or place lists through `update_scene_metadata`.
+- Action needed: Use `find_scenes`, `list_characters`, and `list_places` to identify stable IDs, then use `connect_character_place_evidence` for paired sheet-backed evidence or `audit_relationship_metadata` for legacy sidecar/frontmatter review.
+- PR: TBD
+
 ### 2026-05-28 — Document sidecar compatibility and migration posture
 
 - What changed: Added sidecar compatibility and migration guidance, updated setup, product, architecture, and agent docs, and added workflow discovery guidance for projects or prompts that still treat `.meta.yaml` files as mutation surfaces.

--- a/release-log.md
+++ b/release-log.md
@@ -12,7 +12,7 @@ This complements `CHANGELOG.md`:
 - Why it matters: Authors and AI agents get a clearer boundary between editorial scene metadata and SQLite-canonical relationship evidence, reducing accidental relationship changes from generic metadata patches.
 - Who is affected: Authors, maintainers, and AI agents that previously sent character or place lists through `update_scene_metadata`.
 - Action needed: Use `find_scenes`, `list_characters`, and `list_places` to identify stable IDs, then use `connect_character_place_evidence` for paired sheet-backed evidence or `audit_relationship_metadata` for legacy sidecar/frontmatter review.
-- PR: TBD
+- PR: [#230](https://github.com/hannasdev/mcp-writing/pull/230)
 
 ### 2026-05-28 — Document sidecar compatibility and migration posture
 

--- a/src/test/integration/metadata.test.mjs
+++ b/src/test/integration/metadata.test.mjs
@@ -145,7 +145,7 @@ describe("update_scene_metadata tool", () => {
     assert.notEqual(sidecar.chapter_title, "Chapter 8");
   });
 
-  test("characterizes current characters and places updates as independent sidecar-first index mutations", async () => {
+  test("rejects characters and places updates before sidecar writes or relationship reindexing", async () => {
     const sceneDir = path.join(writeSyncDir, "projects", "test-novel", "scenes");
     fs.mkdirSync(sceneDir, { recursive: true });
     const scenePath = path.join(sceneDir, "sc-m0-relationship-characterization.md");
@@ -165,29 +165,47 @@ describe("update_scene_metadata tool", () => {
     );
 
     await callWriteTool("sync");
+    const sidecarBefore = fs.existsSync(sidecarFile) ? fs.readFileSync(sidecarFile, "utf8") : null;
 
     const updateText = await callWriteTool("update_scene_metadata", {
       scene_id: "sc-m0-relationship-characterization",
       project_id: "test-novel",
       fields: {
-        characters: ["marcus"],
-        places: [],
+        characters: ["m1blockedcharacter"],
+        places: ["m1blockedplace"],
       },
     });
     const updateParsed = JSON.parse(updateText);
-    assert.equal(updateParsed.ok, true, updateText);
+    assert.equal(updateParsed.ok, false, updateText);
+    assert.equal(updateParsed.error.code, "VALIDATION_ERROR");
+    assert.match(updateParsed.error.message, /relationship-boundary fields/);
+    assert.deepEqual(updateParsed.error.details.blocked_fields, ["characters", "places"]);
+    assert.ok(updateParsed.error.details.relationship_tools.includes("connect_character_place_evidence"));
+    assert.ok(updateParsed.error.details.relationship_tools.includes("audit_relationship_metadata"));
+    assert.ok(updateParsed.error.details.discovery_workflows.includes("find_scenes"));
+    assert.ok(updateParsed.error.details.discovery_workflows.includes("list_characters"));
+    assert.ok(updateParsed.error.details.discovery_workflows.includes("list_places"));
+    assert.match(updateParsed.error.details.next_step, /connect_character_place_evidence/);
+    assert.match(updateParsed.error.details.next_step, /audit_relationship_metadata/);
+    assert.match(updateParsed.error.details.next_step, /paired sheet-backed character\/place evidence/);
 
-    const sidecar = yaml.load(fs.readFileSync(sidecarFile, "utf8"));
-    assert.deepEqual(sidecar.characters, ["marcus"]);
-    assert.deepEqual(sidecar.places, []);
+    const sidecarAfter = fs.existsSync(sidecarFile) ? fs.readFileSync(sidecarFile, "utf8") : null;
+    assert.equal(sidecarAfter, sidecarBefore);
 
-    const marcusScenesText = await callWriteTool("find_scenes", {
+    const elenaScenesText = await callWriteTool("find_scenes", {
       project_id: "test-novel",
-      character: "marcus",
+      character: "elena",
       page_size: 200,
     });
-    const marcusScenes = JSON.parse(marcusScenesText);
-    assert.ok(marcusScenes.results.some((row) => row.scene_id === "sc-m0-relationship-characterization"));
+    const elenaScenes = JSON.parse(elenaScenesText);
+    assert.ok(elenaScenes.results.some((row) => row.scene_id === "sc-m0-relationship-characterization"));
+
+    const blockedSearchText = await callWriteTool("search_metadata", {
+      query: "m1blockedcharacter",
+    });
+    const blockedSearch = JSON.parse(blockedSearchText);
+    assert.equal(blockedSearch.ok, false);
+    assert.equal(blockedSearch.error.code, "NO_RESULTS");
 
     await callWriteTool("sync");
 
@@ -196,6 +214,13 @@ describe("update_scene_metadata tool", () => {
     });
     const retainedPlaceSearch = JSON.parse(retainedPlaceSearchText);
     assert.ok(retainedPlaceSearch.results.some((row) => row.scene_id === "sc-m0-relationship-characterization"));
+
+    const blockedPlaceSearchText = await callWriteTool("search_metadata", {
+      query: "m1blockedplace",
+    });
+    const blockedPlaceSearch = JSON.parse(blockedPlaceSearchText);
+    assert.equal(blockedPlaceSearch.ok, false);
+    assert.equal(blockedPlaceSearch.error.code, "NO_RESULTS");
   });
 });
 

--- a/src/test/unit/metadata-tools.test.mjs
+++ b/src/test/unit/metadata-tools.test.mjs
@@ -519,7 +519,7 @@ describe("metadata update_scene_metadata relationship guardrail", () => {
         sceneId: "sc-relationship-allowed-update",
         projectId: "test-novel",
         metadata: {
-          characters: ["sidecarstalecharacter", "v7.3"],
+          characters: "sidecarstalecharacter, v7.3",
           places: ["sidecarstaleplace"],
           logline: "Original logline.",
           versions: ["v8.1"],
@@ -554,7 +554,7 @@ describe("metadata update_scene_metadata relationship guardrail", () => {
       assert.equal(sidecar.status, "revision");
       assert.deepEqual(sidecar.tags, ["relationship-boundary"]);
       assert.equal(sidecar.story_time, "Act II night");
-      assert.deepEqual(sidecar.characters, ["sidecarstalecharacter", "v7.3"]);
+      assert.equal(sidecar.characters, "sidecarstalecharacter, v7.3");
       assert.deepEqual(sidecar.places, ["sidecarstaleplace"]);
       assert.deepEqual(sidecar.versions, ["v8.1"]);
 

--- a/src/test/unit/metadata-tools.test.mjs
+++ b/src/test/unit/metadata-tools.test.mjs
@@ -511,27 +511,27 @@ describe("metadata update_scene_metadata relationship guardrail", () => {
     const db = openDb(":memory:");
     try {
       seedProject(db, "test-novel");
-      seedCharacter(db, { characterId: "char-elena", projectId: "test-novel", name: "Elena" });
-      seedCharacter(db, { characterId: "char-marcus", projectId: "test-novel", name: "Marcus" });
-      seedPlace(db, { placeId: "place-harbor", projectId: "test-novel", name: "Harbor" });
-      seedPlace(db, { placeId: "place-square", projectId: "test-novel", name: "Square" });
+      seedCharacter(db, { characterId: "sidecarstalecharacter", projectId: "test-novel", name: "Stale Sidecar Character" });
+      seedCharacter(db, { characterId: "canonicalcharacter", projectId: "test-novel", name: "Canonical Character" });
+      seedPlace(db, { placeId: "sidecarstaleplace", projectId: "test-novel", name: "Stale Sidecar Place" });
+      seedPlace(db, { placeId: "canonicalplace", projectId: "test-novel", name: "Canonical Place" });
       const scenePath = seedProjectSceneFile(db, {
         sceneId: "sc-relationship-allowed-update",
         projectId: "test-novel",
         metadata: {
-          characters: ["char-elena"],
-          places: ["place-harbor"],
+          characters: ["sidecarstalecharacter"],
+          places: ["sidecarstaleplace"],
           logline: "Original logline.",
         },
       });
       db.prepare(`
         INSERT INTO scene_characters (scene_id, project_id, character_id)
         VALUES (?, ?, ?)
-      `).run("sc-relationship-allowed-update", "test-novel", "char-marcus");
+      `).run("sc-relationship-allowed-update", "test-novel", "canonicalcharacter");
       db.prepare(`
         INSERT INTO scene_places (scene_id, project_id, place_id)
         VALUES (?, ?, ?)
-      `).run("sc-relationship-allowed-update", "test-novel", "place-square");
+      `).run("sc-relationship-allowed-update", "test-novel", "canonicalplace");
 
       const tools = makeToolHarness(db);
       const parsed = await tools.call("update_scene_metadata", {
@@ -553,8 +553,8 @@ describe("metadata update_scene_metadata relationship guardrail", () => {
       assert.equal(sidecar.status, "revision");
       assert.deepEqual(sidecar.tags, ["relationship-boundary"]);
       assert.equal(sidecar.story_time, "Act II night");
-      assert.deepEqual(sidecar.characters, ["char-elena"]);
-      assert.deepEqual(sidecar.places, ["place-harbor"]);
+      assert.deepEqual(sidecar.characters, ["sidecarstalecharacter"]);
+      assert.deepEqual(sidecar.places, ["sidecarstaleplace"]);
 
       const sceneCharacters = db.prepare(`
         SELECT character_id
@@ -569,8 +569,25 @@ describe("metadata update_scene_metadata relationship guardrail", () => {
         ORDER BY place_id
       `).all("sc-relationship-allowed-update", "test-novel").map((row) => row.place_id);
 
-      assert.deepEqual(sceneCharacters, ["char-marcus"]);
-      assert.deepEqual(scenePlaces, ["place-square"]);
+      assert.deepEqual(sceneCharacters, ["canonicalcharacter"]);
+      assert.deepEqual(scenePlaces, ["canonicalplace"]);
+
+      assert.equal(
+        db.prepare(`SELECT COUNT(*) AS count FROM scenes_fts WHERE scenes_fts MATCH ?`).get("sidecarstalecharacter").count,
+        0
+      );
+      assert.equal(
+        db.prepare(`SELECT COUNT(*) AS count FROM scenes_fts WHERE scenes_fts MATCH ?`).get("sidecarstaleplace").count,
+        0
+      );
+      assert.equal(
+        db.prepare(`SELECT COUNT(*) AS count FROM scenes_fts WHERE scenes_fts MATCH ?`).get("canonicalcharacter").count,
+        1
+      );
+      assert.equal(
+        db.prepare(`SELECT COUNT(*) AS count FROM scenes_fts WHERE scenes_fts MATCH ?`).get("canonicalplace").count,
+        1
+      );
     } finally {
       db.close();
     }

--- a/src/test/unit/metadata-tools.test.mjs
+++ b/src/test/unit/metadata-tools.test.mjs
@@ -519,9 +519,10 @@ describe("metadata update_scene_metadata relationship guardrail", () => {
         sceneId: "sc-relationship-allowed-update",
         projectId: "test-novel",
         metadata: {
-          characters: ["sidecarstalecharacter"],
+          characters: ["sidecarstalecharacter", "v7.3"],
           places: ["sidecarstaleplace"],
           logline: "Original logline.",
+          versions: ["v8.1"],
         },
       });
       db.prepare(`
@@ -553,8 +554,9 @@ describe("metadata update_scene_metadata relationship guardrail", () => {
       assert.equal(sidecar.status, "revision");
       assert.deepEqual(sidecar.tags, ["relationship-boundary"]);
       assert.equal(sidecar.story_time, "Act II night");
-      assert.deepEqual(sidecar.characters, ["sidecarstalecharacter"]);
+      assert.deepEqual(sidecar.characters, ["sidecarstalecharacter", "v7.3"]);
       assert.deepEqual(sidecar.places, ["sidecarstaleplace"]);
+      assert.deepEqual(sidecar.versions, ["v8.1"]);
 
       const sceneCharacters = db.prepare(`
         SELECT character_id
@@ -586,6 +588,14 @@ describe("metadata update_scene_metadata relationship guardrail", () => {
       );
       assert.equal(
         db.prepare(`SELECT COUNT(*) AS count FROM scenes_fts WHERE scenes_fts MATCH ?`).get("canonicalplace").count,
+        1
+      );
+      assert.equal(
+        db.prepare(`SELECT COUNT(*) AS count FROM scenes_fts WHERE scenes_fts MATCH ?`).get('"v7.3"').count,
+        1
+      );
+      assert.equal(
+        db.prepare(`SELECT COUNT(*) AS count FROM scenes_fts WHERE scenes_fts MATCH ?`).get('"v8.1"').count,
         1
       );
     } finally {

--- a/src/test/unit/metadata-tools.test.mjs
+++ b/src/test/unit/metadata-tools.test.mjs
@@ -429,8 +429,8 @@ describe("metadata upsert_reference_link tool", () => {
   });
 });
 
-describe("metadata update_scene_metadata relationship-field characterization", () => {
-  test("currently writes characters and places to the sidecar before rebuilding scene relationship indexes", async () => {
+describe("metadata update_scene_metadata relationship guardrail", () => {
+  test("rejects characters and places before writing sidecar metadata or relationship indexes", async () => {
     const db = openDb(":memory:");
     try {
       seedProject(db, "test-novel");
@@ -454,6 +454,10 @@ describe("metadata update_scene_metadata relationship-field characterization", (
         VALUES (?, ?, ?)
       `).run("sc-relationship-characterization", "test-novel", "place-harbor");
 
+      const sidecarPath = scenePath.replace(/\.md$/, ".meta.yaml");
+      const sourceBefore = fs.readFileSync(scenePath, "utf8");
+      assert.equal(fs.existsSync(sidecarPath), false);
+
       const tools = makeToolHarness(db);
       const parsed = await tools.call("update_scene_metadata", {
         scene_id: "sc-relationship-characterization",
@@ -464,12 +468,24 @@ describe("metadata update_scene_metadata relationship-field characterization", (
         },
       });
 
-      assert.equal(parsed.ok, true);
-      assert.equal(parsed.action, "updated");
-
-      const sidecar = yaml.load(fs.readFileSync(scenePath.replace(/\.md$/, ".meta.yaml"), "utf8"));
-      assert.deepEqual(sidecar.characters, ["char-marcus"]);
-      assert.deepEqual(sidecar.places, []);
+      assert.equal(parsed.ok, false);
+      assert.equal(parsed.error.code, "VALIDATION_ERROR");
+      assert.match(parsed.error.message, /relationship-boundary fields/);
+      assert.deepEqual(parsed.error.details.blocked_fields, ["characters", "places"]);
+      assert.deepEqual(parsed.error.details.relationship_tools, [
+        "connect_character_place_evidence",
+        "audit_relationship_metadata",
+      ]);
+      assert.ok(parsed.error.details.discovery_workflows.includes("find_scenes"));
+      assert.ok(parsed.error.details.discovery_workflows.includes("list_characters"));
+      assert.ok(parsed.error.details.discovery_workflows.includes("list_places"));
+      assert.match(parsed.error.details.next_step, /connect_character_place_evidence/);
+      assert.match(parsed.error.details.next_step, /audit_relationship_metadata/);
+      assert.match(parsed.error.details.next_step, /find_scenes/);
+      assert.match(parsed.error.details.next_step, /paired sheet-backed character\/place evidence/);
+      assert.match(parsed.error.details.next_step, /Character-only or place-only/);
+      assert.equal(fs.existsSync(sidecarPath), false);
+      assert.equal(fs.readFileSync(scenePath, "utf8"), sourceBefore);
 
       const sceneCharacters = db.prepare(`
         SELECT character_id
@@ -484,8 +500,77 @@ describe("metadata update_scene_metadata relationship-field characterization", (
         ORDER BY place_id
       `).all("sc-relationship-characterization", "test-novel").map((row) => row.place_id);
 
+      assert.deepEqual(sceneCharacters, ["char-elena"]);
+      assert.deepEqual(scenePlaces, ["place-harbor"]);
+    } finally {
+      db.close();
+    }
+  });
+
+  test("continues to update allowed editorial metadata without changing relationship indexes", async () => {
+    const db = openDb(":memory:");
+    try {
+      seedProject(db, "test-novel");
+      seedCharacter(db, { characterId: "char-elena", projectId: "test-novel", name: "Elena" });
+      seedCharacter(db, { characterId: "char-marcus", projectId: "test-novel", name: "Marcus" });
+      seedPlace(db, { placeId: "place-harbor", projectId: "test-novel", name: "Harbor" });
+      seedPlace(db, { placeId: "place-square", projectId: "test-novel", name: "Square" });
+      const scenePath = seedProjectSceneFile(db, {
+        sceneId: "sc-relationship-allowed-update",
+        projectId: "test-novel",
+        metadata: {
+          characters: ["char-elena"],
+          places: ["place-harbor"],
+          logline: "Original logline.",
+        },
+      });
+      db.prepare(`
+        INSERT INTO scene_characters (scene_id, project_id, character_id)
+        VALUES (?, ?, ?)
+      `).run("sc-relationship-allowed-update", "test-novel", "char-marcus");
+      db.prepare(`
+        INSERT INTO scene_places (scene_id, project_id, place_id)
+        VALUES (?, ?, ?)
+      `).run("sc-relationship-allowed-update", "test-novel", "place-square");
+
+      const tools = makeToolHarness(db);
+      const parsed = await tools.call("update_scene_metadata", {
+        scene_id: "sc-relationship-allowed-update",
+        project_id: "test-novel",
+        fields: {
+          logline: "Allowed editorial update.",
+          status: "revision",
+          tags: ["relationship-boundary"],
+          story_time: "Act II night",
+        },
+      });
+
+      assert.equal(parsed.ok, true);
+      assert.equal(parsed.action, "updated");
+
+      const sidecar = yaml.load(fs.readFileSync(scenePath.replace(/\.md$/, ".meta.yaml"), "utf8"));
+      assert.equal(sidecar.logline, "Allowed editorial update.");
+      assert.equal(sidecar.status, "revision");
+      assert.deepEqual(sidecar.tags, ["relationship-boundary"]);
+      assert.equal(sidecar.story_time, "Act II night");
+      assert.deepEqual(sidecar.characters, ["char-elena"]);
+      assert.deepEqual(sidecar.places, ["place-harbor"]);
+
+      const sceneCharacters = db.prepare(`
+        SELECT character_id
+        FROM scene_characters
+        WHERE scene_id = ? AND project_id = ?
+        ORDER BY character_id
+      `).all("sc-relationship-allowed-update", "test-novel").map((row) => row.character_id);
+      const scenePlaces = db.prepare(`
+        SELECT place_id
+        FROM scene_places
+        WHERE scene_id = ? AND project_id = ?
+        ORDER BY place_id
+      `).all("sc-relationship-allowed-update", "test-novel").map((row) => row.place_id);
+
       assert.deepEqual(sceneCharacters, ["char-marcus"]);
-      assert.deepEqual(scenePlaces, []);
+      assert.deepEqual(scenePlaces, ["place-square"]);
     } finally {
       db.close();
     }

--- a/src/tools/metadata.js
+++ b/src/tools/metadata.js
@@ -475,6 +475,28 @@ function restoreSceneRelationshipSnapshot(db, { sceneId, projectId, snapshot }) 
   }
 }
 
+function buildSceneMetadataSearchKeywords(meta, relationshipSnapshot) {
+  return [
+    ...(meta.tags ?? []),
+    ...relationshipSnapshot.characters,
+    ...relationshipSnapshot.places,
+    ...(meta.versions ?? []),
+  ]
+    .filter(Boolean)
+    .map(String)
+    .map((value) => value.trim())
+    .filter(Boolean)
+    .join(" ");
+}
+
+function restoreSceneRelationshipSearchKeywords(db, { sceneId, projectId, meta, snapshot }) {
+  db.prepare(`
+    UPDATE scenes_fts
+    SET keywords = ?
+    WHERE scene_id = ? AND project_id = ?
+  `).run(buildSceneMetadataSearchKeywords(meta, snapshot), sceneId, projectId);
+}
+
 export function registerMetadataTools(s, {
   db,
   SYNC_DIR,
@@ -2321,6 +2343,12 @@ export function registerMetadataTools(s, {
         restoreSceneRelationshipSnapshot(db, {
           sceneId: scene_id,
           projectId: project_id,
+          snapshot: relationshipSnapshot,
+        });
+        restoreSceneRelationshipSearchKeywords(db, {
+          sceneId: scene_id,
+          projectId: project_id,
+          meta: normalizedUpdated,
           snapshot: relationshipSnapshot,
         });
         const backupResult = refreshProjectScopedBackupAfterMutation(db, {

--- a/src/tools/metadata.js
+++ b/src/tools/metadata.js
@@ -34,6 +34,7 @@ import {
 } from "../structure/project-backup-refresh.js";
 
 const STRUCTURAL_SCENE_METADATA_FIELDS = ["part", "chapter", "chapter_id", "chapter_title", "timeline_position"];
+const RELATIONSHIP_SCENE_METADATA_FIELDS = ["characters", "places"];
 
 function emptyBackupMutationResult() {
   return {
@@ -106,6 +107,22 @@ function buildCompatibilityOutput({ refreshed, diagnostics = [], role = "generat
 
 function getProvidedStructuralSceneMetadataFields(fields) {
   return STRUCTURAL_SCENE_METADATA_FIELDS.filter((field) => Object.hasOwn(fields, field));
+}
+
+function getProvidedRelationshipSceneMetadataFields(fields) {
+  return RELATIONSHIP_SCENE_METADATA_FIELDS.filter((field) => Object.hasOwn(fields, field));
+}
+
+function buildRelationshipMetadataBoundaryDetails({ projectId, sceneId, blockedFields }) {
+  return {
+    project_id: projectId,
+    scene_id: sceneId,
+    blocked_fields: blockedFields,
+    boundary: "scene_relationship_metadata",
+    relationship_tools: ["connect_character_place_evidence", "audit_relationship_metadata"],
+    discovery_workflows: ["describe_workflows", "find_scenes", "list_characters", "list_places"],
+    next_step: "Use find_scenes, list_characters, and list_places to identify stable IDs. Use connect_character_place_evidence only when the scene proves paired sheet-backed character/place evidence; use audit_relationship_metadata to review legacy sidecar/frontmatter relationship fields. Character-only or place-only scene evidence is not changed through update_scene_metadata.",
+  };
 }
 
 function persistReferenceDocLink({ filePath, syncDir, targetDocId, relation }) {
@@ -435,6 +452,27 @@ function querySceneRelationshipSnapshot(db, { sceneId, projectId }) {
       ORDER BY place_id
     `).all(sceneId, projectId).map(row => row.place_id),
   };
+}
+
+function restoreSceneRelationshipSnapshot(db, { sceneId, projectId, snapshot }) {
+  db.prepare(`DELETE FROM scene_characters WHERE scene_id = ? AND project_id = ?`).run(sceneId, projectId);
+  db.prepare(`DELETE FROM scene_places WHERE scene_id = ? AND project_id = ?`).run(sceneId, projectId);
+
+  const insertCharacter = db.prepare(`
+    INSERT OR IGNORE INTO scene_characters (scene_id, project_id, character_id)
+    VALUES (?, ?, ?)
+  `);
+  for (const characterId of snapshot.characters) {
+    insertCharacter.run(sceneId, projectId, characterId);
+  }
+
+  const insertPlace = db.prepare(`
+    INSERT OR IGNORE INTO scene_places (scene_id, project_id, place_id)
+    VALUES (?, ?, ?)
+  `);
+  for (const placeId of snapshot.places) {
+    insertPlace.run(sceneId, projectId, placeId);
+  }
 }
 
 export function registerMetadataTools(s, {
@@ -2214,7 +2252,7 @@ export function registerMetadataTools(s, {
   // ---- update_scene_metadata -----------------------------------------------
   s.tool(
     "update_scene_metadata",
-    "Update one or more non-structural metadata fields for a scene. Writes only supplied non-structural fields to the .meta.yaml sidecar and preserves existing structural compatibility fields; it never modifies prose or mirrors path-derived structure. Structural fields (part, chapter, chapter_id, chapter_title, timeline_position) are rejected here; use list_chapters plus assign_scene_to_chapter, move_scene, rename_chapter, or reorder_chapter for structure changes. Changes are immediately reflected in the index. Only available when the sync dir is writable.",
+    "Update one or more non-structural, non-relationship metadata fields for a scene. Writes only supplied allowed fields to the .meta.yaml sidecar and preserves existing structural compatibility fields; it never modifies prose, mirrors path-derived structure, or changes scene character/place relationship authority. Structural fields (part, chapter, chapter_id, chapter_title, timeline_position) are rejected here; use list_chapters plus assign_scene_to_chapter, move_scene, rename_chapter, or reorder_chapter for structure changes. Relationship fields (characters, places) are rejected here; use discovery workflows plus connect_character_place_evidence for paired sheet-backed character/place evidence, and audit_relationship_metadata for legacy sidecar/frontmatter relationship review. Allowed changes are immediately reflected in the index. Only available when the sync dir is writable.",
     {
       scene_id:   z.string().describe("The scene_id to update (e.g. 'sc-011-sebastian')."),
       project_id: z.string().describe("Project the scene belongs to (e.g. 'the-lamb')."),
@@ -2231,8 +2269,8 @@ export function registerMetadataTools(s, {
         timeline_position: z.number().int().optional().describe("Rejected by update_scene_metadata. Use move_scene for ordering changes."),
         story_time:        z.string().optional(),
         tags:              z.array(z.string()).optional(),
-        characters:        z.array(z.string()).optional(),
-        places:            z.array(z.string()).optional(),
+        characters:        z.array(z.string()).optional().describe("Rejected by update_scene_metadata. Use find_scenes, list_characters, list_places, connect_character_place_evidence for paired sheet-backed evidence, and audit_relationship_metadata for compatibility review."),
+        places:            z.array(z.string()).optional().describe("Rejected by update_scene_metadata. Use find_scenes, list_characters, list_places, connect_character_place_evidence for paired sheet-backed evidence, and audit_relationship_metadata for compatibility review."),
       }).describe("Fields to update. Only supplied keys are changed."),
     },
     async ({ scene_id, project_id, fields }) => {
@@ -2243,6 +2281,18 @@ export function registerMetadataTools(s, {
         .get(scene_id, project_id);
       if (!scene) {
         return errorResponse("NOT_FOUND", `Scene '${scene_id}' not found in project '${project_id}'.`);
+      }
+      const relationshipFields = getProvidedRelationshipSceneMetadataFields(fields);
+      if (relationshipFields.length > 0) {
+        return errorResponse(
+          "VALIDATION_ERROR",
+          "update_scene_metadata cannot change relationship-boundary fields characters or places. Scene relationship metadata is sheet-backed and must use outcome-level relationship workflows, not generic sidecar metadata writes.",
+          buildRelationshipMetadataBoundaryDetails({
+            projectId: project_id,
+            sceneId: scene_id,
+            blockedFields: relationshipFields,
+          })
+        );
       }
       const structuralFields = getProvidedStructuralSceneMetadataFields(fields);
       if (structuralFields.length > 0) {
@@ -2258,6 +2308,7 @@ export function registerMetadataTools(s, {
         );
       }
       try {
+        const relationshipSnapshot = querySceneRelationshipSnapshot(db, { sceneId: scene_id, projectId: project_id });
         const { sourceMeta } = readSourceMeta(scene.file_path, SYNC_DIR, { writable: true });
         const updated = { ...sourceMeta, ...fields };
         writeMeta(scene.file_path, updated, { syncDir: SYNC_DIR });
@@ -2266,6 +2317,11 @@ export function registerMetadataTools(s, {
         const { content: prose } = matter(fs.readFileSync(scene.file_path, "utf8"));
         indexSceneFile(db, SYNC_DIR, scene.file_path, normalizedUpdated, prose, {
           managedStructure: isManagedStructureProject(db, project_id),
+        });
+        restoreSceneRelationshipSnapshot(db, {
+          sceneId: scene_id,
+          projectId: project_id,
+          snapshot: relationshipSnapshot,
         });
         const backupResult = refreshProjectScopedBackupAfterMutation(db, {
           syncDir: SYNC_DIR,

--- a/src/tools/metadata.js
+++ b/src/tools/metadata.js
@@ -480,13 +480,13 @@ function isVersionContinuityMarker(value) {
 }
 
 function buildSceneMetadataSearchKeywords(meta, relationshipSnapshot) {
-  const compatibilityVersionMarkers = (meta.characters ?? []).filter(isVersionContinuityMarker);
+  const compatibilityVersionMarkers = normalizeStringList(meta.characters).filter(isVersionContinuityMarker);
   return [
-    ...(meta.tags ?? []),
+    ...normalizeStringList(meta.tags),
     ...compatibilityVersionMarkers,
     ...relationshipSnapshot.characters,
     ...relationshipSnapshot.places,
-    ...(meta.versions ?? []),
+    ...normalizeStringList(meta.versions),
   ]
     .filter(Boolean)
     .map(String)

--- a/src/tools/metadata.js
+++ b/src/tools/metadata.js
@@ -475,9 +475,15 @@ function restoreSceneRelationshipSnapshot(db, { sceneId, projectId, snapshot }) 
   }
 }
 
+function isVersionContinuityMarker(value) {
+  return /^v\d[\d.a-z]*$/i.test(String(value).trim());
+}
+
 function buildSceneMetadataSearchKeywords(meta, relationshipSnapshot) {
+  const compatibilityVersionMarkers = (meta.characters ?? []).filter(isVersionContinuityMarker);
   return [
     ...(meta.tags ?? []),
+    ...compatibilityVersionMarkers,
     ...relationshipSnapshot.characters,
     ...relationshipSnapshot.places,
     ...(meta.versions ?? []),


### PR DESCRIPTION
## Summary

- Reject `characters` and `places` in `update_scene_metadata` as relationship-boundary fields.
- Preserve allowed editorial metadata updates while keeping canonical `scene_characters` and `scene_places` rows stable.
- Regenerate agent tool docs and advance the Relationship Metadata Boundary initiative focus to M1.

## Motivation

`update_scene_metadata` was still an older sidecar-first path for scene character/place relationship changes. That blurred the product boundary between generic editorial metadata and SQLite-canonical relationship evidence. M1 applies the strict contract selected in M0 so relationship changes move through outcome-oriented workflows instead of generic sidecar metadata patches.

## Implementation

- Added relationship-field detection for `characters` and `places` before sidecar writes or scene reindexing.
- Return a validation error with guidance for `find_scenes`, `list_characters`, `list_places`, `connect_character_place_evidence`, and `audit_relationship_metadata`.
- Snapshot and restore canonical scene character/place rows around allowed editorial metadata reindexing so stale compatibility fields do not overwrite canonical relationship indexes during generic metadata updates.
- Updated focused unit/integration coverage and regenerated `docs/agents/tools.md`.
- Added a release-log entry for the public tool contract change.

## Testing

- `npm run check:pr`
- `npm run check:docs`
- `node /Users/hanna/.codex/skills/initiative-completion/scripts/check-initiative-lifecycle.mjs --repo /Users/hanna/Code/mcp-writing --initiative docs/initiatives/active/relationship-metadata-boundary --milestone M1 --strict`

## Risks and tradeoffs

- This is a deliberate public tool contract change: clients sending `characters` or `places` through `update_scene_metadata` now receive a validation error.
- Legacy sidecar/frontmatter `characters` and `places` remain sync/import compatibility input; this PR blocks the generic metadata mutation path but does not remove compatibility indexing.
- Character-only and place-only daily-work mutation remains a future deliberately named workflow decision.

## Follow-up

- Continue with M2 compatibility sync and audit alignment.
