### PR TITLE
fix: align relationship compatibility sync and audit

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -11,7 +11,7 @@ It supports metadata-first reasoning, explicit prose editing workflows, and revi
 
 Active initiative: [Relationship Metadata Boundary](docs/initiatives/active/relationship-metadata-boundary/prd.md).
 
-Current focus: Relationship Metadata Boundary M1 applies the strict relationship guardrail to `update_scene_metadata`.
+Current focus: Relationship Metadata Boundary M2 aligns legacy sync compatibility and relationship audit diagnostics.
 
 Most recent completed initiative: [Architecture Alignment Follow-up](docs/initiatives/done/architecture-alignment-follow-up/prd.md).
 

--- a/docs/initiatives/active/relationship-metadata-boundary/architecture.md
+++ b/docs/initiatives/active/relationship-metadata-boundary/architecture.md
@@ -1,6 +1,6 @@
 # Relationship Metadata Boundary — Architecture Notes
 
-**Status:** Active — M1 selected
+**Status:** Active — M2 selected
 
 ## Context
 

--- a/docs/initiatives/active/relationship-metadata-boundary/milestones.md
+++ b/docs/initiatives/active/relationship-metadata-boundary/milestones.md
@@ -1,6 +1,6 @@
 # Relationship Metadata Boundary — Milestones
 
-**Status:** Active — M1 selected
+**Status:** Active — M2 selected
 
 Use [prd.md](prd.md) for product framing and this document for sequencing,
 review gates, and implementation readiness.
@@ -86,7 +86,7 @@ Out of scope:
 
 ## M1 — Generic Metadata Relationship Guardrail
 
-Status: Selected for implementation.
+Status: Implemented on main by PR #230.
 
 Goal: stop `update_scene_metadata` from silently converting sidecar-first
 character/place edits into canonical relationship authority.
@@ -126,6 +126,8 @@ Out of scope:
 - Bulk relationship editing.
 
 ## M2 — Compatibility Sync And Audit Alignment
+
+Status: Selected for implementation.
 
 Goal: keep legacy projects usable while making compatibility authority visible.
 

--- a/docs/initiatives/active/relationship-metadata-boundary/prd.md
+++ b/docs/initiatives/active/relationship-metadata-boundary/prd.md
@@ -1,6 +1,6 @@
 # PRD: Relationship Metadata Boundary
 
-**Status:** Active — M1 selected
+**Status:** Active — M2 selected
 
 Created: 2026-05-28.
 Activated: 2026-05-29.

--- a/release-log.md
+++ b/release-log.md
@@ -6,6 +6,14 @@ This complements `CHANGELOG.md`:
 - `CHANGELOG.md` is technical and release-oriented.
 - This log is plain-language and outcome-oriented.
 
+### 2026-05-30 — Make relationship compatibility drift visible
+
+- What changed: Ordinary sync now preserves SQLite scene character/place authority when legacy sidecar relationship fields drift, reports relationship compatibility warnings, and keeps import or repair flows as the deliberate compatibility adoption path.
+- Why it matters: Authors, maintainers, and AI agents can keep older sidecar-based projects searchable without letting stale compatibility metadata silently overwrite canonical relationship rows.
+- Who is affected: Authors, maintainers, and AI agents running sync, Scrivener import/merge, scene character enrichment, or `audit_relationship_metadata` on projects with retained sidecar/frontmatter `characters` or `places`.
+- Action needed: Use `audit_relationship_metadata` when sync reports relationship compatibility drift, then inspect stable IDs with `find_scenes`, `list_characters`, and `list_places` before applying outcome-level relationship repairs.
+- PR: TBD
+
 ### 2026-05-30 — Guard generic scene relationship metadata updates
 
 - What changed: `update_scene_metadata` now rejects scene `characters` and `places` fields and points callers to relationship and audit workflows instead of accepting sidecar-first relationship edits.

--- a/release-log.md
+++ b/release-log.md
@@ -12,7 +12,7 @@ This complements `CHANGELOG.md`:
 - Why it matters: Authors, maintainers, and AI agents can keep older sidecar-based projects searchable without letting stale compatibility metadata silently overwrite canonical relationship rows.
 - Who is affected: Authors, maintainers, and AI agents running sync, Scrivener import/merge, scene character enrichment, or `audit_relationship_metadata` on projects with retained sidecar/frontmatter `characters` or `places`.
 - Action needed: Use `audit_relationship_metadata` when sync reports relationship compatibility drift, then inspect stable IDs with `find_scenes`, `list_characters`, and `list_places` before applying outcome-level relationship repairs.
-- PR: TBD
+- PR: [#231](https://github.com/hannasdev/mcp-writing/pull/231)
 
 ### 2026-05-30 — Guard generic scene relationship metadata updates
 

--- a/src/sync/scene-character-batch.js
+++ b/src/sync/scene-character-batch.js
@@ -57,6 +57,16 @@ function resolveCharacterEntry(entry, characterRows) {
   return resolveCharacterReference(entry, characterRows);
 }
 
+function normalizeCompatibilityCharacters(value) {
+  const rawValues = Array.isArray(value)
+    ? value
+    : typeof value === "string"
+      ? value.split(",")
+      : [];
+
+  return [...new Set(rawValues.map(String).map(character => character.trim()).filter(Boolean))];
+}
+
 function pruneLessSpecificCharacters(characterIds, fullNameMatches, characterRows) {
   const kept = new Set(characterIds);
 
@@ -140,7 +150,7 @@ export async function runSceneCharacterBatch({ syncDir, args, onProgress, should
       const { content: prose } = matter(raw);
       const { sourceMeta: meta } = readSourceMeta(scene.file_path, syncDir, { writable: !dry_run });
 
-      const before_characters = [...new Set((meta.characters ?? []).map(String).filter(Boolean))];
+      const before_characters = normalizeCompatibilityCharacters(meta.characters);
       const normalized_before_characters = [...new Set(
         before_characters
           .map(character => resolveCharacterEntry(character, normalizedCharacterRows))

--- a/src/sync/sync.js
+++ b/src/sync/sync.js
@@ -1322,8 +1322,8 @@ function sameStringSet(a, b) {
   return left.length === right.length && left.every((value, index) => value === right[index]);
 }
 
-function selectRelationshipIndexValues({ sceneId, projectId, relationshipKind, existing, compatibility, compatibilityMode, hasCompatibilityField }) {
-  if (!hasCompatibilityField && existing.length > 0) {
+function selectRelationshipIndexValues({ sceneId, projectId, relationshipKind, existing, compatibility, compatibilityMode, hasCompatibilityField, hasExistingScene }) {
+  if (!hasCompatibilityField) {
     return {
       values: existing,
       diagnostic: null,
@@ -1335,7 +1335,7 @@ function selectRelationshipIndexValues({ sceneId, projectId, relationshipKind, e
       diagnostic: null,
     };
   }
-  if (existing.length > 0 && !sameStringSet(existing, compatibility)) {
+  if (hasExistingScene && !sameStringSet(existing, compatibility)) {
     return {
       values: existing,
       diagnostic: {
@@ -1362,7 +1362,7 @@ function relationshipCompatibilityFieldsFromMeta(meta = {}) {
   };
 }
 
-function buildSceneRelationshipIndexPlan(db, { meta, projectId, compatibilityMode = "preserve_existing", compatibilityFields = relationshipCompatibilityFieldsFromMeta(meta) }) {
+function buildSceneRelationshipIndexPlan(db, { meta, projectId, compatibilityMode = "preserve_existing", compatibilityFields = relationshipCompatibilityFieldsFromMeta(meta), hasExistingScene = false }) {
   const compatibilityCharacters = [];
   const compatibilityVersionMarkers = [];
   for (const value of normalizeMetadataList(meta.characters)) {
@@ -1393,6 +1393,7 @@ function buildSceneRelationshipIndexPlan(db, { meta, projectId, compatibilityMod
     compatibility: compatibilityCharacters,
     compatibilityMode,
     hasCompatibilityField: compatibilityFields.characters,
+    hasExistingScene,
   });
   const placeSelection = selectRelationshipIndexValues({
     sceneId: meta.scene_id,
@@ -1402,6 +1403,7 @@ function buildSceneRelationshipIndexPlan(db, { meta, projectId, compatibilityMod
     compatibility: compatibilityPlaces,
     compatibilityMode,
     hasCompatibilityField: compatibilityFields.places,
+    hasExistingScene,
   });
 
   return {
@@ -1553,6 +1555,7 @@ export function indexSceneFile(db, syncDir, file, meta, prose, { observedStructu
     projectId: project_id,
     compatibilityMode: relationshipCompatibilityMode,
     compatibilityFields: relationshipCompatibilityFields,
+    hasExistingScene: Boolean(existing),
   });
   const tagValues = [
     ...normalizeMetadataList(meta.tags),
@@ -1563,6 +1566,7 @@ export function indexSceneFile(db, syncDir, file, meta, prose, { observedStructu
   db.prepare(`DELETE FROM scene_characters WHERE scene_id = ? AND project_id = ?`).run(meta.scene_id, project_id);
   db.prepare(`DELETE FROM scene_places WHERE scene_id = ? AND project_id = ?`).run(meta.scene_id, project_id);
   db.prepare(`DELETE FROM scene_tags WHERE scene_id = ? AND project_id = ?`).run(meta.scene_id, project_id);
+  db.prepare(`DELETE FROM scenes_fts WHERE scene_id = ? AND project_id = ?`).run(meta.scene_id, project_id);
 
   for (const cid of relationshipIndexPlan.characters) {
     db.prepare(`INSERT OR IGNORE INTO scene_characters (scene_id, project_id, character_id) VALUES (?, ?, ?)`).run(
@@ -1591,7 +1595,7 @@ export function indexSceneFile(db, syncDir, file, meta, prose, { observedStructu
     .filter(Boolean)
     .join(" ");
 
-  db.prepare(`INSERT OR REPLACE INTO scenes_fts (scene_id, project_id, logline, title, keywords) VALUES (?, ?, ?, ?, ?)`).run(
+  db.prepare(`INSERT INTO scenes_fts (scene_id, project_id, logline, title, keywords) VALUES (?, ?, ?, ?, ?)`).run(
     meta.scene_id,
     project_id,
     meta.logline ?? meta.synopsis ?? "",

--- a/src/sync/sync.js
+++ b/src/sync/sync.js
@@ -1290,7 +1290,7 @@ export function readSceneFileForSync(syncDir, file, { writable = false } = {}) {
   };
 }
 
-function resolveSceneCharacterCompatibilityId(db, value) {
+export function resolveSceneCharacterCompatibilityId(db, value) {
   let characterId = value;
   if (!/^char-/.test(value)) {
     let row = db.prepare(`SELECT character_id FROM characters WHERE lower(name) = lower(?)`).get(value);

--- a/src/sync/sync.js
+++ b/src/sync/sync.js
@@ -299,6 +299,24 @@ export function normalizeReferenceIdList(values) {
   )];
 }
 
+function normalizeMetadataList(values) {
+  const rawValues = Array.isArray(values)
+    ? values
+    : typeof values === "string"
+      ? values.split(",")
+      : [];
+
+  return [...new Set(
+    rawValues
+      .map(value => String(value).trim())
+      .filter(Boolean)
+  )];
+}
+
+function isVersionContinuityMarker(value) {
+  return /^v\d[\d.a-z]*$/i.test(String(value).trim());
+}
+
 function normalizeReferenceRelation(value, fallbackRelation) {
   const normalized = String(value ?? fallbackRelation ?? "").trim().toLowerCase();
   if (/^[a-z][a-z0-9_-]*$/.test(normalized)) return normalized;
@@ -1272,7 +1290,129 @@ export function readSceneFileForSync(syncDir, file, { writable = false } = {}) {
   };
 }
 
-export function indexSceneFile(db, syncDir, file, meta, prose, { observedStructure, managedStructure = false } = {}) {
+function resolveSceneCharacterCompatibilityId(db, value) {
+  let characterId = value;
+  if (!/^char-/.test(value)) {
+    let row = db.prepare(`SELECT character_id FROM characters WHERE lower(name) = lower(?)`).get(value);
+    if (!row) {
+      const words = value.toLowerCase().split(/\s+/).filter(Boolean);
+      const all = db.prepare(`SELECT character_id, name FROM characters`).all();
+      const match = all.find(r =>
+        words.every(w => r.name.toLowerCase().includes(w))
+      );
+      if (match) row = match;
+    }
+    if (row) characterId = row.character_id;
+  }
+  return characterId;
+}
+
+function querySceneRelationshipIds(db, { sceneId, projectId, table, idColumn }) {
+  return db.prepare(`
+    SELECT ${idColumn} AS id
+    FROM ${table}
+    WHERE scene_id = ? AND project_id = ?
+    ORDER BY ${idColumn}
+  `).all(sceneId, projectId).map((row) => row.id);
+}
+
+function sameStringSet(a, b) {
+  const left = [...new Set(a.map(String))].sort();
+  const right = [...new Set(b.map(String))].sort();
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+function selectRelationshipIndexValues({ sceneId, projectId, relationshipKind, existing, compatibility, compatibilityMode, hasCompatibilityField }) {
+  if (!hasCompatibilityField && existing.length > 0) {
+    return {
+      values: existing,
+      diagnostic: null,
+    };
+  }
+  if (compatibilityMode === "adopt_compatibility") {
+    return {
+      values: compatibility,
+      diagnostic: null,
+    };
+  }
+  if (existing.length > 0 && !sameStringSet(existing, compatibility)) {
+    return {
+      values: existing,
+      diagnostic: {
+        type: "relationship_compatibility_drift",
+        relationship_kind: relationshipKind,
+        scene_id: sceneId,
+        project_id: projectId,
+        canonical_values: existing,
+        compatibility_values: compatibility,
+        message: `Relationship compatibility drift for scene "${sceneId}" in project "${projectId}": sidecar ${relationshipKind} differ from SQLite ${relationshipKind}; preserved SQLite relationship rows. Run audit_relationship_metadata before applying an outcome-level repair.`,
+      },
+    };
+  }
+  return {
+    values: compatibility,
+    diagnostic: null,
+  };
+}
+
+function relationshipCompatibilityFieldsFromMeta(meta = {}) {
+  return {
+    characters: Object.hasOwn(meta, "characters"),
+    places: Object.hasOwn(meta, "places"),
+  };
+}
+
+function buildSceneRelationshipIndexPlan(db, { meta, projectId, compatibilityMode = "preserve_existing", compatibilityFields = relationshipCompatibilityFieldsFromMeta(meta) }) {
+  const compatibilityCharacters = [];
+  const compatibilityVersionMarkers = [];
+  for (const value of normalizeMetadataList(meta.characters)) {
+    if (isVersionContinuityMarker(value)) {
+      compatibilityVersionMarkers.push(value);
+      continue;
+    }
+    compatibilityCharacters.push(resolveSceneCharacterCompatibilityId(db, value));
+  }
+  const compatibilityPlaces = normalizeMetadataList(meta.places);
+  const existingCharacters = querySceneRelationshipIds(db, {
+    sceneId: meta.scene_id,
+    projectId,
+    table: "scene_characters",
+    idColumn: "character_id",
+  });
+  const existingPlaces = querySceneRelationshipIds(db, {
+    sceneId: meta.scene_id,
+    projectId,
+    table: "scene_places",
+    idColumn: "place_id",
+  });
+  const characterSelection = selectRelationshipIndexValues({
+    sceneId: meta.scene_id,
+    projectId,
+    relationshipKind: "characters",
+    existing: existingCharacters,
+    compatibility: compatibilityCharacters,
+    compatibilityMode,
+    hasCompatibilityField: compatibilityFields.characters,
+  });
+  const placeSelection = selectRelationshipIndexValues({
+    sceneId: meta.scene_id,
+    projectId,
+    relationshipKind: "places",
+    existing: existingPlaces,
+    compatibility: compatibilityPlaces,
+    compatibilityMode,
+    hasCompatibilityField: compatibilityFields.places,
+  });
+
+  return {
+    characters: characterSelection.values,
+    places: placeSelection.values,
+    compatibilityVersionMarkers,
+    diagnostics: [characterSelection.diagnostic, placeSelection.diagnostic].filter(Boolean),
+  };
+}
+
+export function indexSceneFile(db, syncDir, file, meta, prose, { observedStructure, managedStructure = false, relationshipCompatibilityMode = "preserve_existing", relationshipCompatibilityFields } = {}) {
   const canonicalIndexPlan = buildCanonicalIndexPlan(db, syncDir, file, meta, observedStructure, { managedStructure });
   const { universeId: universe_id, projectId: project_id } = canonicalIndexPlan;
   const { chapterStructure } = canonicalIndexPlan.observedStructure;
@@ -1408,58 +1548,42 @@ export function indexSceneFile(db, syncDir, file, meta, prose, { observedStructu
     new Date().toISOString()
   );
 
+  const relationshipIndexPlan = buildSceneRelationshipIndexPlan(db, {
+    meta,
+    projectId: project_id,
+    compatibilityMode: relationshipCompatibilityMode,
+    compatibilityFields: relationshipCompatibilityFields,
+  });
+  const tagValues = [
+    ...normalizeMetadataList(meta.tags),
+    ...relationshipIndexPlan.compatibilityVersionMarkers,
+    ...normalizeMetadataList(meta.versions),
+  ];
+
   db.prepare(`DELETE FROM scene_characters WHERE scene_id = ? AND project_id = ?`).run(meta.scene_id, project_id);
   db.prepare(`DELETE FROM scene_places WHERE scene_id = ? AND project_id = ?`).run(meta.scene_id, project_id);
   db.prepare(`DELETE FROM scene_tags WHERE scene_id = ? AND project_id = ?`).run(meta.scene_id, project_id);
 
-  for (const c of (meta.characters ?? [])) {
-    // Version continuity markers (e.g. v7.3, v3.3b) are tracked as tags, not characters
-    if (/^v\d[\d.a-z]*$/i.test(c)) {
-      db.prepare(`INSERT OR IGNORE INTO scene_tags (scene_id, project_id, tag) VALUES (?, ?, ?)`).run(meta.scene_id, project_id, c);
-      continue;
-    }
-    let cid = c;
-    // If the value looks like a name rather than an ID, try to resolve it
-    if (!/^char-/.test(c)) {
-      // 1. Exact name match (case-insensitive)
-      let row = db.prepare(`SELECT character_id FROM characters WHERE lower(name) = lower(?)`).get(c);
-      // 2. Word-overlap: all words in the keyword appear in the stored name
-      //    Handles "Victor Sidorin" → "Victor Alexeyvich Sidorin"
-      if (!row) {
-        const words = c.toLowerCase().split(/\s+/).filter(Boolean);
-        const all = db.prepare(`SELECT character_id, name FROM characters`).all();
-        const match = all.find(r =>
-          words.every(w => r.name.toLowerCase().includes(w))
-        );
-        if (match) row = match;
-      }
-      if (row) cid = row.character_id;
-    }
+  for (const cid of relationshipIndexPlan.characters) {
     db.prepare(`INSERT OR IGNORE INTO scene_characters (scene_id, project_id, character_id) VALUES (?, ?, ?)`).run(
       meta.scene_id, project_id, cid
     );
   }
-  for (const p of (meta.places ?? [])) {
+  for (const p of relationshipIndexPlan.places) {
     db.prepare(`INSERT OR IGNORE INTO scene_places (scene_id, project_id, place_id) VALUES (?, ?, ?)`).run(
       meta.scene_id, project_id, p
     );
   }
-  for (const t of (meta.tags ?? [])) {
+  for (const t of tagValues) {
     db.prepare(`INSERT OR IGNORE INTO scene_tags (scene_id, project_id, tag) VALUES (?, ?, ?)`).run(
       meta.scene_id, project_id, t
     );
   }
-  for (const v of (meta.versions ?? [])) {
-    db.prepare(`INSERT OR IGNORE INTO scene_tags (scene_id, project_id, tag) VALUES (?, ?, ?)`).run(
-      meta.scene_id, project_id, v
-    );
-  }
 
   const keywordTokens = [
-    ...(meta.tags ?? []),
-    ...(meta.characters ?? []),
-    ...(meta.places ?? []),
-    ...(meta.versions ?? []),
+    ...tagValues,
+    ...relationshipIndexPlan.characters,
+    ...relationshipIndexPlan.places,
   ]
     .filter(Boolean)
     .map(String)
@@ -1493,7 +1617,13 @@ export function indexSceneFile(db, syncDir, file, meta, prose, { observedStructu
     relation: "informs",
   });
 
-  return { isStale, chapterId, warning: chapterWarning, canonicalIndexPlan };
+  return {
+    isStale,
+    chapterId,
+    warning: chapterWarning,
+    canonicalIndexPlan,
+    relationshipCompatibilityDiagnostics: relationshipIndexPlan.diagnostics,
+  };
 }
 
 export function isManagedStructureProject(db, projectId) {
@@ -1564,6 +1694,7 @@ const WARNING_TYPE_LABELS = {
   unobserved_canonical_scene: "Unobserved canonical scene",
   missing_canonical_chapter: "Missing canonical chapter",
   missing_canonical_epigraph: "Missing canonical epigraph",
+  relationship_compatibility_drift: "Relationship compatibility drift",
   nested_mirror: "Ignored nested mirror path",
 };
 
@@ -1578,6 +1709,7 @@ const WARNING_PATTERNS = [
   { type: "unobserved_canonical_scene", re: /^Managed sync preserved canonical scene not observed during sync scan:/ },
   { type: "missing_canonical_chapter", re: /^Managed sync preserved canonical chapter missing from filesystem:/ },
   { type: "missing_canonical_epigraph", re: /^Managed sync preserved canonical epigraph missing from filesystem:/ },
+  { type: "relationship_compatibility_drift", re: /^Relationship compatibility drift/ },
   { type: "nested_mirror",          re: /^Ignored nested mirror path:/ },
 ];
 
@@ -1598,7 +1730,7 @@ export function buildWarningSummary(warnings) {
   return summary;
 }
 
-export function syncAll(db, syncDir, { quiet = false, writable = false } = {}) {
+export function syncAll(db, syncDir, { quiet = false, writable = false, relationshipCompatibilityMode = "preserve_existing" } = {}) {
   // Reset per-run inference cache so filesystem changes between sync calls
   // (for example after imports or path repairs) are reflected immediately.
   UNIVERSE_PROJECT_ROOT_CACHE.clear();
@@ -1701,12 +1833,17 @@ export function syncAll(db, syncDir, { quiet = false, writable = false } = {}) {
       const result = indexSceneFile(db, syncDir, file, meta, prose, {
         observedStructure: structureObservation,
         managedStructure: managedProjectIds.has(project_id),
+        relationshipCompatibilityMode,
+        relationshipCompatibilityFields: relationshipCompatibilityFieldsFromMeta(sourceMeta),
       });
       const canonicalDiagnostics = result.canonicalIndexPlan?.diagnostics ?? [];
       if (canonicalDiagnostics.length) {
         for (const diagnostic of canonicalDiagnostics) warnings.push(diagnostic.message);
       } else if (result.warning) {
         warnings.push(result.warning);
+      }
+      for (const diagnostic of result.relationshipCompatibilityDiagnostics ?? []) {
+        warnings.push(diagnostic.message);
       }
       if (result.chapterId) {
         const chapterKey = `${result.chapterId}::${project_id}`;

--- a/src/test/unit/metadata-tools.test.mjs
+++ b/src/test/unit/metadata-tools.test.mjs
@@ -823,6 +823,44 @@ describe("metadata relationship outcome tools", () => {
     }
   });
 
+  test("audit_relationship_metadata resolves legacy character names before drift comparison", async () => {
+    const db = openDb(":memory:");
+    try {
+      seedProject(db, "test-novel");
+      seedCharacter(db, {
+        characterId: "char-elena-vasquez",
+        projectId: "test-novel",
+        name: "Elena Vasquez",
+      });
+      seedProjectSceneFile(db, {
+        sceneId: "sc-audit-name-compat",
+        projectId: "test-novel",
+        metadata: {
+          characters: "Elena Vasquez",
+        },
+      });
+      db.prepare(`
+        INSERT INTO scene_characters (scene_id, project_id, character_id)
+        VALUES (?, ?, ?)
+      `).run("sc-audit-name-compat", "test-novel", "char-elena-vasquez");
+
+      const tools = makeToolHarness(db);
+      const parsed = await tools.call("audit_relationship_metadata", {
+        project_id: "test-novel",
+      });
+
+      const compatibilityInput = parsed.diagnostics.find(diagnostic =>
+        diagnostic.type === "scene_relationship_compatibility_input"
+      );
+      assert.equal(parsed.ok, true);
+      assert.equal(parsed.summary.compatibility_drift_count, 0);
+      assert.deepEqual(compatibilityInput.compatibility.characters, ["char-elena-vasquez"]);
+      assert.deepEqual(compatibilityInput.canonical.characters, ["char-elena-vasquez"]);
+    } finally {
+      db.close();
+    }
+  });
+
   test("audit_relationship_metadata ignores absent compatibility relationship fields when checking drift", async () => {
     const db = openDb(":memory:");
     try {

--- a/src/test/unit/metadata-tools.test.mjs
+++ b/src/test/unit/metadata-tools.test.mjs
@@ -777,6 +777,92 @@ describe("metadata relationship outcome tools", () => {
     }
   });
 
+  test("audit_relationship_metadata reports scene relationship compatibility drift", async () => {
+    const db = openDb(":memory:");
+    try {
+      seedProject(db, "test-novel");
+      seedCharacter(db, { characterId: "canonicalcharacter", projectId: "test-novel", name: "Canonical Character" });
+      seedPlace(db, { placeId: "canonicalplace", projectId: "test-novel", name: "Canonical Place" });
+      seedProjectSceneFile(db, {
+        sceneId: "sc-audit-drift",
+        projectId: "test-novel",
+        metadata: {
+          characters: "sidecarstalecharacter, v7.3",
+          places: ["sidecarstaleplace"],
+        },
+      });
+      db.prepare(`
+        INSERT INTO scene_characters (scene_id, project_id, character_id)
+        VALUES (?, ?, ?)
+      `).run("sc-audit-drift", "test-novel", "canonicalcharacter");
+      db.prepare(`
+        INSERT INTO scene_places (scene_id, project_id, place_id)
+        VALUES (?, ?, ?)
+      `).run("sc-audit-drift", "test-novel", "canonicalplace");
+
+      const tools = makeToolHarness(db);
+      const parsed = await tools.call("audit_relationship_metadata", {
+        project_id: "test-novel",
+      });
+
+      const compatibilityInput = parsed.diagnostics.find(diagnostic =>
+        diagnostic.type === "scene_relationship_compatibility_input"
+      );
+      const drift = parsed.diagnostics.find(diagnostic =>
+        diagnostic.type === "scene_relationship_compatibility_drift"
+      );
+      assert.equal(parsed.ok, true);
+      assert.equal(parsed.summary.compatibility_drift_count, 1);
+      assert.deepEqual(compatibilityInput.compatibility.characters, ["sidecarstalecharacter"]);
+      assert.deepEqual(compatibilityInput.compatibility.places, ["sidecarstaleplace"]);
+      assert.deepEqual(drift.canonical.characters, ["canonicalcharacter"]);
+      assert.deepEqual(drift.canonical.places, ["canonicalplace"]);
+      assert.match(drift.next_step, /Treat SQLite relationship rows as canonical/);
+    } finally {
+      db.close();
+    }
+  });
+
+  test("audit_relationship_metadata ignores absent compatibility relationship fields when checking drift", async () => {
+    const db = openDb(":memory:");
+    try {
+      seedProject(db, "test-novel");
+      seedCharacter(db, { characterId: "canonicalcharacter", projectId: "test-novel", name: "Canonical Character" });
+      seedPlace(db, { placeId: "canonicalplace", projectId: "test-novel", name: "Canonical Place" });
+      seedProjectSceneFile(db, {
+        sceneId: "sc-audit-partial-fields",
+        projectId: "test-novel",
+        metadata: {
+          characters: ["canonicalcharacter"],
+        },
+      });
+      db.prepare(`
+        INSERT INTO scene_characters (scene_id, project_id, character_id)
+        VALUES (?, ?, ?)
+      `).run("sc-audit-partial-fields", "test-novel", "canonicalcharacter");
+      db.prepare(`
+        INSERT INTO scene_places (scene_id, project_id, place_id)
+        VALUES (?, ?, ?)
+      `).run("sc-audit-partial-fields", "test-novel", "canonicalplace");
+
+      const tools = makeToolHarness(db);
+      const parsed = await tools.call("audit_relationship_metadata", {
+        project_id: "test-novel",
+      });
+
+      const compatibilityInput = parsed.diagnostics.find(diagnostic =>
+        diagnostic.type === "scene_relationship_compatibility_input"
+      );
+      assert.equal(parsed.ok, true);
+      assert.equal(parsed.summary.compatibility_drift_count, 0);
+      assert.equal(compatibilityInput.compatibility.has_characters_field, true);
+      assert.equal(compatibilityInput.compatibility.has_places_field, false);
+      assert.deepEqual(compatibilityInput.canonical.places, ["canonicalplace"]);
+    } finally {
+      db.close();
+    }
+  });
+
   test("audit_relationship_metadata includes universe-scoped compatibility notes for a project", async () => {
     const db = openDb(":memory:");
     try {

--- a/src/test/unit/scene-character.test.mjs
+++ b/src/test/unit/scene-character.test.mjs
@@ -239,6 +239,30 @@ describe("runSceneCharacterBatch", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
+  test("merge mode accepts scalar legacy character compatibility metadata", async () => {
+    const { dir } = makeBatchFixture();
+    const filePath = writeBatchScene(dir, "sc-001", "No named character appears here.", "Elena Vasquez");
+
+    const result = await runSceneCharacterBatch({
+      syncDir: dir,
+      args: {
+        project_id: "test-novel",
+        dry_run: true,
+        replace_mode: "merge",
+        target_scenes: [{ scene_id: "sc-001", project_id: "test-novel", file_path: filePath }],
+        character_rows: [
+          { character_id: "char-elena-vasquez", name: "Elena Vasquez" },
+        ],
+      },
+    });
+
+    assert.equal(result.failed_scenes, 0);
+    assert.deepEqual(result.results[0].before_characters, ["Elena Vasquez"]);
+    assert.deepEqual(result.results[0].after_characters, ["char-elena-vasquez"]);
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
   test("removes a less specific existing id when a more specific full-name match is inferred", async () => {
     const { dir } = makeBatchFixture();
     const filePath = writeBatchScene(dir, "sc-001", "Victor Alexeyevich Sidorin studies the report.", ["char-victor-sidorin"]);

--- a/src/test/unit/sync.test.mjs
+++ b/src/test/unit/sync.test.mjs
@@ -2403,6 +2403,52 @@ describe("syncAll", () => {
     fs.rmSync(dir, { recursive: true });
   });
 
+  test("ordinary sync preserves intentionally empty canonical relationships on drift", () => {
+    const dir = makeTempSync();
+    const db = openDb(":memory:");
+    writeScene(dir, "sc-cleared", {
+      characters: "elena",
+      places: "harbor",
+    });
+
+    syncAll(db, dir, { quiet: true });
+    db.prepare(`
+      DELETE FROM scene_characters
+      WHERE scene_id = ? AND project_id = ?
+    `).run("sc-cleared", "test-novel");
+    db.prepare(`
+      DELETE FROM scene_places
+      WHERE scene_id = ? AND project_id = ?
+    `).run("sc-cleared", "test-novel");
+
+    const result = syncAll(db, dir, { quiet: true });
+
+    assert.equal(result.warningSummary.relationship_compatibility_drift.count, 2);
+    assert.equal(
+      db.prepare(`
+        SELECT COUNT(*) AS count
+        FROM scene_characters
+        WHERE scene_id = 'sc-cleared' AND project_id = 'test-novel'
+      `).get().count,
+      0
+    );
+    assert.equal(
+      db.prepare(`
+        SELECT COUNT(*) AS count
+        FROM scene_places
+        WHERE scene_id = 'sc-cleared' AND project_id = 'test-novel'
+      `).get().count,
+      0
+    );
+    assert.equal(
+      db.prepare(`SELECT COUNT(*) AS count FROM scenes_fts WHERE scenes_fts MATCH ?`).get("elena").count,
+      0
+    );
+
+    db.close();
+    fs.rmSync(dir, { recursive: true });
+  });
+
   test("adopt compatibility sync preserves canonical rows when compatibility fields are absent", () => {
     const dir = makeTempSync();
     const db = openDb(":memory:");

--- a/src/test/unit/sync.test.mjs
+++ b/src/test/unit/sync.test.mjs
@@ -2336,6 +2336,129 @@ describe("syncAll", () => {
     fs.rmSync(dir, { recursive: true });
   });
 
+  test("indexes legacy relationship compatibility once and preserves canonical rows on drift", () => {
+    const dir = makeTempSync();
+    const db = openDb(":memory:");
+    writeScene(dir, "sc-compat", {
+      characters: "elena, v7.3",
+      places: "harbor",
+    });
+
+    syncAll(db, dir, { quiet: true });
+
+    assert.deepEqual(
+      db.prepare(`
+        SELECT character_id
+        FROM scene_characters
+        WHERE scene_id = 'sc-compat' AND project_id = 'test-novel'
+        ORDER BY character_id
+      `).all().map((row) => row.character_id),
+      ["elena"]
+    );
+    assert.deepEqual(
+      db.prepare(`
+        SELECT place_id
+        FROM scene_places
+        WHERE scene_id = 'sc-compat' AND project_id = 'test-novel'
+        ORDER BY place_id
+      `).all().map((row) => row.place_id),
+      ["harbor"]
+    );
+    assert.equal(
+      db.prepare(`SELECT COUNT(*) AS count FROM scenes_fts WHERE scenes_fts MATCH ?`).get('"v7.3"').count,
+      1
+    );
+
+    writeScene(dir, "sc-compat", {
+      characters: "marcus",
+      places: "square",
+    });
+    const driftResult = syncAll(db, dir, { quiet: true });
+
+    assert.equal(driftResult.warningSummary.relationship_compatibility_drift.count, 2);
+    assert.deepEqual(
+      db.prepare(`
+        SELECT character_id
+        FROM scene_characters
+        WHERE scene_id = 'sc-compat' AND project_id = 'test-novel'
+        ORDER BY character_id
+      `).all().map((row) => row.character_id),
+      ["elena"]
+    );
+    assert.deepEqual(
+      db.prepare(`
+        SELECT place_id
+        FROM scene_places
+        WHERE scene_id = 'sc-compat' AND project_id = 'test-novel'
+        ORDER BY place_id
+      `).all().map((row) => row.place_id),
+      ["harbor"]
+    );
+    assert.equal(
+      db.prepare(`SELECT COUNT(*) AS count FROM scenes_fts WHERE scenes_fts MATCH ?`).get("marcus").count,
+      0
+    );
+
+    db.close();
+    fs.rmSync(dir, { recursive: true });
+  });
+
+  test("adopt compatibility sync preserves canonical rows when compatibility fields are absent", () => {
+    const dir = makeTempSync();
+    const db = openDb(":memory:");
+    const scenePath = path.join(dir, "projects", "test-novel", "scenes", "sc-no-compat.md");
+    fs.writeFileSync(
+      scenePath,
+      [
+        "---",
+        "scene_id: sc-no-compat",
+        "title: Scene without compatibility fields",
+        "part: 1",
+        "chapter: 1",
+        "---",
+        "Prose content for scene sc-no-compat.",
+      ].join("\n")
+    );
+
+    syncAll(db, dir, { quiet: true });
+    db.prepare(`
+      INSERT INTO scene_characters (scene_id, project_id, character_id)
+      VALUES (?, ?, ?)
+    `).run("sc-no-compat", "test-novel", "canonicalcharacter");
+    db.prepare(`
+      INSERT INTO scene_places (scene_id, project_id, place_id)
+      VALUES (?, ?, ?)
+    `).run("sc-no-compat", "test-novel", "canonicalplace");
+
+    const result = syncAll(db, dir, {
+      quiet: true,
+      relationshipCompatibilityMode: "adopt_compatibility",
+    });
+
+    assert.equal(result.warningSummary.relationship_compatibility_drift, undefined);
+    assert.deepEqual(
+      db.prepare(`
+        SELECT character_id
+        FROM scene_characters
+        WHERE scene_id = 'sc-no-compat' AND project_id = 'test-novel'
+        ORDER BY character_id
+      `).all().map((row) => row.character_id),
+      ["canonicalcharacter"]
+    );
+    assert.deepEqual(
+      db.prepare(`
+        SELECT place_id
+        FROM scene_places
+        WHERE scene_id = 'sc-no-compat' AND project_id = 'test-novel'
+        ORDER BY place_id
+      `).all().map((row) => row.place_id),
+      ["canonicalplace"]
+    );
+
+    db.close();
+    fs.rmSync(dir, { recursive: true });
+  });
+
   test("populates FTS table", () => {
     const dir = makeTempSync();
     const db = openDb(":memory:");

--- a/src/tools/metadata.js
+++ b/src/tools/metadata.js
@@ -454,6 +454,34 @@ function querySceneRelationshipSnapshot(db, { sceneId, projectId }) {
   };
 }
 
+function sameStringSet(a, b) {
+  const left = [...new Set(a.map(String))].sort();
+  const right = [...new Set(b.map(String))].sort();
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+function normalizeSceneRelationshipCompatibilityFields(sourceMeta) {
+  const hasCharactersField = Object.hasOwn(sourceMeta, "characters");
+  const hasPlacesField = Object.hasOwn(sourceMeta, "places");
+  return {
+    has_relationship_fields: hasCharactersField || hasPlacesField,
+    has_characters_field: hasCharactersField,
+    has_places_field: hasPlacesField,
+    characters: normalizeStringList(sourceMeta.characters).filter((value) => !isVersionContinuityMarker(value)),
+    places: normalizeStringList(sourceMeta.places),
+  };
+}
+
+function sceneRelationshipCompatibilityHasDrift(canonicalRelationships, compatibilityRelationships) {
+  return (
+    compatibilityRelationships.has_characters_field &&
+    !sameStringSet(canonicalRelationships.characters, compatibilityRelationships.characters)
+  ) || (
+    compatibilityRelationships.has_places_field &&
+    !sameStringSet(canonicalRelationships.places, compatibilityRelationships.places)
+  );
+}
+
 function restoreSceneRelationshipSnapshot(db, { sceneId, projectId, snapshot }) {
   db.prepare(`DELETE FROM scene_characters WHERE scene_id = ? AND project_id = ?`).run(sceneId, projectId);
   db.prepare(`DELETE FROM scene_places WHERE scene_id = ? AND project_id = ?`).run(sceneId, projectId);
@@ -1061,6 +1089,39 @@ export function registerMetadataTools(s, {
       }
       try {
         const { sourceMeta } = readSourceMeta(scene.file_path, SYNC_DIR, { writable: false });
+        const compatibilityRelationships = normalizeSceneRelationshipCompatibilityFields(sourceMeta);
+        if (compatibilityRelationships.has_relationship_fields) {
+          const canonicalRelationships = querySceneRelationshipSnapshot(db, {
+            sceneId: scene.scene_id,
+            projectId: scene.project_id,
+          });
+          diagnostics.push({
+            type: "scene_relationship_compatibility_input",
+            severity: "info",
+            message: `Scene '${scene.scene_id}' retains sidecar/frontmatter character/place relationship fields as compatibility input; SQLite scene relationship rows remain canonical.`,
+            scene_id: scene.scene_id,
+            project_id: scene.project_id,
+            compatibility: compatibilityRelationships,
+            canonical: canonicalRelationships,
+            authority: {
+              canonical_owner: "SQLite scene_characters/scene_places",
+              compatibility_mutation_surface: false,
+            },
+            next_step: "Use this as migration or review evidence only. Use outcome-level relationship tools for current repairs.",
+          });
+          if (sceneRelationshipCompatibilityHasDrift(canonicalRelationships, compatibilityRelationships)) {
+            diagnostics.push({
+              type: "scene_relationship_compatibility_drift",
+              severity: "warning",
+              message: `Scene '${scene.scene_id}' sidecar/frontmatter relationship fields disagree with canonical SQLite relationship rows.`,
+              scene_id: scene.scene_id,
+              project_id: scene.project_id,
+              compatibility: compatibilityRelationships,
+              canonical: canonicalRelationships,
+              next_step: "Treat SQLite relationship rows as canonical. Use find_scenes, list_characters, and list_places to inspect stable IDs; use connect_character_place_evidence for paired sheet-backed evidence or leave character-only/place-only repairs to a deliberately named future workflow.",
+            });
+          }
+        }
         if (sourceMeta.threads) {
           diagnostics.push({
             type: "sidecar_threads_compatibility_input",
@@ -1146,6 +1207,7 @@ export function registerMetadataTools(s, {
       summary: {
         diagnostics_count: diagnostics.length,
         stale_scene_count: diagnostics.filter(diagnostic => diagnostic.type === "stale_scene_relationship_index").length,
+        compatibility_drift_count: diagnostics.filter(diagnostic => diagnostic.type === "scene_relationship_compatibility_drift").length,
         compatibility_note_count: diagnostics.filter(diagnostic => diagnostic.severity === "info").length,
       },
       next_steps: [

--- a/src/tools/metadata.js
+++ b/src/tools/metadata.js
@@ -2,7 +2,7 @@ import { z } from "zod";
 import fs from "node:fs";
 import path from "node:path";
 import matter from "gray-matter";
-import { readMeta, readSourceMeta, writeMeta, indexSceneFile, isManagedStructureProject, normalizeSceneMetaForPath } from "../sync/sync.js";
+import { readMeta, readSourceMeta, writeMeta, indexSceneFile, isManagedStructureProject, normalizeSceneMetaForPath, resolveSceneCharacterCompatibilityId } from "../sync/sync.js";
 import { validateProjectId, validateUniverseId } from "../sync/importer.js";
 import { resolveValidatedChapterFilter } from "../core/chapter-resolution.js";
 import {
@@ -460,14 +460,16 @@ function sameStringSet(a, b) {
   return left.length === right.length && left.every((value, index) => value === right[index]);
 }
 
-function normalizeSceneRelationshipCompatibilityFields(sourceMeta) {
+function normalizeSceneRelationshipCompatibilityFields(db, sourceMeta) {
   const hasCharactersField = Object.hasOwn(sourceMeta, "characters");
   const hasPlacesField = Object.hasOwn(sourceMeta, "places");
   return {
     has_relationship_fields: hasCharactersField || hasPlacesField,
     has_characters_field: hasCharactersField,
     has_places_field: hasPlacesField,
-    characters: normalizeStringList(sourceMeta.characters).filter((value) => !isVersionContinuityMarker(value)),
+    characters: normalizeStringList(sourceMeta.characters)
+      .filter((value) => !isVersionContinuityMarker(value))
+      .map((value) => resolveSceneCharacterCompatibilityId(db, value)),
     places: normalizeStringList(sourceMeta.places),
   };
 }
@@ -1089,7 +1091,7 @@ export function registerMetadataTools(s, {
       }
       try {
         const { sourceMeta } = readSourceMeta(scene.file_path, SYNC_DIR, { writable: false });
-        const compatibilityRelationships = normalizeSceneRelationshipCompatibilityFields(sourceMeta);
+        const compatibilityRelationships = normalizeSceneRelationshipCompatibilityFields(db, sourceMeta);
         if (compatibilityRelationships.has_relationship_fields) {
           const canonicalRelationships = querySceneRelationshipSnapshot(db, {
             sceneId: scene.scene_id,

--- a/src/tools/sync.js
+++ b/src/tools/sync.js
@@ -470,7 +470,10 @@ export function registerSyncTools(s, {
 
       let syncResult = null;
       if (!dry_run && !preflight && auto_sync) {
-        syncResult = syncAll(db, SYNC_DIR, { writable: SYNC_DIR_WRITABLE });
+        syncResult = syncAll(db, SYNC_DIR, {
+          writable: SYNC_DIR_WRITABLE,
+          relationshipCompatibilityMode: "adopt_compatibility",
+        });
       }
 
       return jsonResponse({
@@ -572,7 +575,10 @@ export function registerSyncTools(s, {
         },
         onComplete: (completedJob) => {
           if (!auto_sync || dry_run || preflight || completedJob.status !== "completed") return;
-          const syncResult = syncAll(db, SYNC_DIR, { writable: SYNC_DIR_WRITABLE });
+          const syncResult = syncAll(db, SYNC_DIR, {
+            writable: SYNC_DIR_WRITABLE,
+            relationshipCompatibilityMode: "adopt_compatibility",
+          });
           if (completedJob.result && completedJob.result.ok) {
             completedJob.result.sync = {
               indexed: syncResult.indexed,
@@ -652,7 +658,10 @@ export function registerSyncTools(s, {
         },
         onComplete: (completedJob) => {
           if (!auto_sync || dry_run || completedJob.status !== "completed") return;
-          const syncResult = syncAll(db, SYNC_DIR, { writable: SYNC_DIR_WRITABLE });
+          const syncResult = syncAll(db, SYNC_DIR, {
+            writable: SYNC_DIR_WRITABLE,
+            relationshipCompatibilityMode: "adopt_compatibility",
+          });
           if (completedJob.result && completedJob.result.ok) {
             completedJob.result.sync = {
               indexed: syncResult.indexed,
@@ -776,7 +785,10 @@ export function registerSyncTools(s, {
         onComplete: (completedJob) => {
           if (dry_run || completedJob.status !== "completed" || !completedJob.result?.ok) return;
 
-          syncAll(db, SYNC_DIR, { writable: SYNC_DIR_WRITABLE });
+          syncAll(db, SYNC_DIR, {
+            writable: SYNC_DIR_WRITABLE,
+            relationshipCompatibilityMode: "adopt_compatibility",
+          });
 
           const changedScenes = (completedJob.result.results ?? [])
             .filter(row => row.status === "changed")
@@ -980,6 +992,7 @@ export function registerSyncTools(s, {
         writeMeta(scene.file_path, sourceUpdatedMeta, { syncDir: SYNC_DIR });
         indexSceneFile(db, SYNC_DIR, scene.file_path, updatedMeta, prose, {
           managedStructure: isManagedStructureProject(db, scene.project_id),
+          relationshipCompatibilityMode: "adopt_compatibility",
         });
         db.prepare(`UPDATE scenes SET metadata_stale = 0 WHERE scene_id = ? AND project_id = ?`)
           .run(scene.scene_id, scene.project_id);


### PR DESCRIPTION
## Summary

- Preserve SQLite scene character/place rows during ordinary sync when legacy sidecar/frontmatter relationship fields drift.
- Add relationship compatibility drift warnings to sync and audit output.
- Keep explicit import/repair flows as the deliberate compatibility adoption path.
- Add regression coverage for scalar legacy metadata, absent compatibility fields, and canonical-row preservation.

## Motivation

M2 of Relationship Metadata Boundary keeps legacy projects usable while making relationship authority visible. Existing `characters` and `places` sidecar fields still need to work as compatibility input, but ordinary sync should not silently treat stale sidecar values as canonical relationship repair.

## Implementation

- Added relationship compatibility planning in `syncAll()` / `indexSceneFile()`:
  - ordinary sync preserves existing SQLite `scene_characters` / `scene_places` rows when sidecar compatibility values disagree;
  - sync emits typed `relationship_compatibility_drift` warnings;
  - version markers from legacy `characters` remain searchable as tags.
- Added an explicit `relationshipCompatibilityMode: "adopt_compatibility"` for import/enrichment flows that intentionally apply generated compatibility output.
- Updated `audit_relationship_metadata` to distinguish retained compatibility fields from canonical SQLite rows and report drift with next-step guidance.
- Made audit drift per-field aware, so an omitted `characters` or `places` field is not treated as an asserted empty set.
- Tolerated scalar legacy `characters` metadata in the scene character batch path.
- Added a release-log entry for the sync/audit compatibility behavior change.

## Testing

- `node --experimental-sqlite --test src/test/unit/metadata-tools.test.mjs`
- `node --experimental-sqlite --test src/test/unit/sync.test.mjs`
- `node --experimental-sqlite --test src/test/unit/scene-character.test.mjs`
- `node --experimental-sqlite --test src/test/integration/sync.test.mjs`
- `node --experimental-sqlite --test src/test/integration/search.test.mjs`
- `npm run lint`
- `git diff --check`

## Risks and tradeoffs

- Ordinary sync now prefers preserved canonical relationship values over stale sidecar compatibility values for relationship keyword indexing when drift is detected.
- Generated docs/workflow guidance is intentionally deferred to M3.

## Follow-up

- M3 should update workflow and generated tool documentation for the relationship compatibility boundary.
