### PR TITLE
test: add relationship boundary release readiness coverage

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -9,12 +9,13 @@ It supports metadata-first reasoning, explicit prose editing workflows, and revi
 
 ## Product Status
 
-Active initiative: [Relationship Metadata Boundary](docs/initiatives/active/relationship-metadata-boundary/prd.md).
+Active initiative: None currently selected.
 
-Current focus: Relationship Metadata Boundary M4 adds independent scene-character and scene-place evidence workflows.
+Current focus: Consolidation after Relationship Metadata Boundary completion.
 
-Most recent completed initiative: [Architecture Alignment Follow-up](docs/initiatives/done/architecture-alignment-follow-up/prd.md).
+Most recent completed initiative: [Relationship Metadata Boundary](docs/initiatives/done/relationship-metadata-boundary/prd.md).
 
+Relationship Metadata Boundary closed the sidecar-first scene relationship mutation path, preserved legacy sidecar/frontmatter compatibility, added paired and one-sided SQLite-first evidence workflows, and proved end-to-end regression coverage for relationship mutation, search/read consumers, sync compatibility, and backup freshness.
 Architecture Alignment Follow-up completed the managed sync preservation, sidecar write-boundary, outcome-oriented relationship workflow, and sidecar compatibility documentation slices that closed the known target-architecture follow-up gaps.
 Database Backup and Recovery added deterministic project backup bundles, trust/freshness diagnostics, advisory operation history, automatic backup refresh after sanctioned canonical mutations, dry-run restore planning, transactional restore application, and operational backup/restore documentation.
 Docker, CI, and Deployment Workflow made Docker a supported way to build, run, smoke-test, and deploy Writing MCP, with a documented container contract, Compose workflow, CI smoke coverage, and deployment-readiness guidance.
@@ -51,7 +52,7 @@ For structural manuscript state, use [Managed Structure Contract](docs/foundatio
 
 - [Features](FEATURES.md) — shipped product capabilities and links to completed initiative docs
 - [Backlog](BACKLOG.md) — deferred product work that is not currently active
-- [Relationship Metadata Boundary](docs/initiatives/active/relationship-metadata-boundary/prd.md) — active initiative for closing the remaining sidecar-first scene character/place relationship mutation path
+- [Relationship Metadata Boundary](docs/initiatives/done/relationship-metadata-boundary/prd.md) — completed initiative closing the remaining sidecar-first scene character/place relationship mutation path
 - [Architecture Alignment Follow-up](docs/initiatives/done/architecture-alignment-follow-up/prd.md) — completed initiative documenting sidecar compatibility, migration, deprecation expectations, and relationship workflow alignment
 - [Database Backup and Recovery](docs/initiatives/done/database-backup-recovery/prd.md) — completed initiative for Git-reviewable recovery artifacts and explicit restore workflows for SQLite-canonical state
 - [Conceptual Target Architecture](docs/foundations/target-architecture.md) — idealized architectural model for evaluating future structure, tooling, and workflow decisions

--- a/README.md
+++ b/README.md
@@ -28,9 +28,8 @@ Instead of feeding an entire manuscript to an AI and hoping it fits in the conte
 
 **Current status:**
 - **Core platform complete:** Metadata-first analysis, SQLite-canonical structural and relationship metadata, compatibility sidecar maintenance, AI-assisted prose editing with confirmation + git history, review bundles, and Scrivener Direct extraction are all implemented.
-- **Recently completed:** Database Backup and Recovery added project backup export, freshness diagnostics, advisory operation history, automatic backup refresh after sanctioned project-scoped canonical mutations, dry-run restore planning, transactional restore application, and backup/restore operations guidance.
-- **Previous milestone:** Docker, CI, and Deployment Workflow made Docker a supported way to build, run, smoke-test, and deploy Writing MCP.
-- **Active development:** Relationship Metadata Boundary M3, aligning workflow and generated documentation around SQLite-canonical relationship authority.
+- **Recently completed:** Relationship Metadata Boundary closed the sidecar-first scene relationship mutation path, added SQLite-first paired and one-sided evidence workflows, and preserved legacy sidecar/frontmatter compatibility for sync and import.
+- **Active development:** No initiative is currently selected.
 - **Deferred backlog:** OpenClaw integration, client-agnostic setup, divisions, and embeddings search.
 - **Ideas and open questions:** tracked separately so future exploration does not distort the active roadmap.
 

--- a/docs/initiatives/done/relationship-metadata-boundary/architecture.md
+++ b/docs/initiatives/done/relationship-metadata-boundary/architecture.md
@@ -1,6 +1,6 @@
 # Relationship Metadata Boundary — Architecture Notes
 
-**Status:** Active — M4 selected
+**Status:** Done
 
 ## Context
 

--- a/docs/initiatives/done/relationship-metadata-boundary/milestones.md
+++ b/docs/initiatives/done/relationship-metadata-boundary/milestones.md
@@ -1,9 +1,12 @@
 # Relationship Metadata Boundary — Milestones
 
-**Status:** Active — M4 selected
+**Status:** Done
 
 Use [prd.md](prd.md) for product framing and this document for sequencing,
 review gates, and implementation readiness.
+M0–M5 are accepted.
+
+Current focus: None — initiative closed.
 
 ## Objective
 
@@ -212,7 +215,7 @@ Out of scope:
 
 ## M4 — Independent Scene Evidence Workflows
 
-Status: Selected for implementation.
+Status: Implemented on main by PR #233.
 
 Goal: add explicit SQLite-first workflows for valid scene-character and
 scene-place links that are not paired character/place evidence.
@@ -270,6 +273,8 @@ Out of scope:
   notes.
 
 ## M5 — End-To-End Regression And Release Readiness
+
+Status: Accepted.
 
 Goal: prove the boundary holds across common writing workflows before PR
 completion.

--- a/docs/initiatives/done/relationship-metadata-boundary/prd.md
+++ b/docs/initiatives/done/relationship-metadata-boundary/prd.md
@@ -1,6 +1,8 @@
 # PRD: Relationship Metadata Boundary
 
-**Status:** Active — M4 selected
+**Status:** Done
+
+Completed: 2026-06-06.
 
 Created: 2026-05-28.
 Activated: 2026-05-29.

--- a/src/test/integration/metadata.test.mjs
+++ b/src/test/integration/metadata.test.mjs
@@ -299,6 +299,191 @@ describe("one-sided scene evidence tools", () => {
   });
 });
 
+describe("relationship metadata boundary M5 regression", () => {
+  test("paired, one-sided, blocked metadata, legacy sync, reads, bundles, and backups stay aligned", async () => {
+    const sceneDir = path.join(writeSyncDir, "projects", "test-novel", "scenes");
+    fs.mkdirSync(sceneDir, { recursive: true });
+    const scenes = {
+      paired: {
+        id: "sc-m5-relationship-paired",
+        title: "M5 Relationship Paired",
+        prose: "Elena returns to the harbor district with paired relationship evidence.",
+      },
+      characterOnly: {
+        id: "sc-m5-relationship-character-only",
+        title: "M5 Relationship Character Only",
+        prose: "Elena appears in a private beat with no place relationship evidence.",
+      },
+      placeOnly: {
+        id: "sc-m5-relationship-place-only",
+        title: "M5 Relationship Place Only",
+        prose: "The harbor district matters here with no character relationship evidence.",
+      },
+      legacy: {
+        id: "sc-m5-relationship-legacy",
+        title: "M5 Relationship Legacy",
+        prose: "Legacy sidecar compatibility still names Marcus and the harbor district.",
+      },
+    };
+
+    for (const [index, scene] of Object.values(scenes).entries()) {
+      const relationshipFields = scene.id === scenes.legacy.id
+        ? "characters:\n  - marcus\nplaces:\n  - harbor-district\n"
+        : "";
+      fs.writeFileSync(
+        path.join(sceneDir, `${scene.id}.md`),
+        `---\nscene_id: ${scene.id}\ntitle: ${scene.title}\ntimeline_position: ${90 + index}\n${relationshipFields}---\n${scene.prose}`,
+        "utf8"
+      );
+    }
+
+    await callWriteTool("sync");
+
+    const pairedText = await callWriteTool("connect_character_place_evidence", {
+      project_id: "test-novel",
+      scene_id: scenes.paired.id,
+      character_id: "elena",
+      place_id: "harbor-district",
+      note: "M5 paired regression evidence.",
+    });
+    const pairedParsed = JSON.parse(pairedText);
+    assert.equal(pairedParsed.ok, true, pairedText);
+    assert.deepEqual(pairedParsed.mutation_order, [
+      "validated_request",
+      "sqlite_commit",
+      "project_backup_refresh",
+      "compatibility_output_refresh",
+    ]);
+    assert.equal(pairedParsed.operation_history.appended, true);
+    assert.equal(pairedParsed.backup_refresh.ok, true);
+    assert.deepEqual(pairedParsed.backup_warnings, []);
+    assert.equal(pairedParsed.compatibility_output.mutation_surface, false);
+
+    const characterText = await callWriteTool("connect_scene_character_evidence", {
+      project_id: "test-novel",
+      scene_id: scenes.characterOnly.id,
+      character_id: "elena",
+      note: "M5 character-only regression evidence.",
+    });
+    const characterParsed = JSON.parse(characterText);
+    assert.equal(characterParsed.ok, true, characterText);
+    assert.deepEqual(characterParsed.scene_relationships, {
+      characters: ["elena"],
+      places: [],
+    });
+    assert.equal(characterParsed.operation_history.appended, true);
+    assert.equal(characterParsed.backup_refresh.ok, true);
+    assert.deepEqual(characterParsed.backup_warnings, []);
+
+    const placeText = await callWriteTool("connect_scene_place_evidence", {
+      project_id: "test-novel",
+      scene_id: scenes.placeOnly.id,
+      place_id: "harbor-district",
+      note: "M5 place-only regression evidence.",
+    });
+    const placeParsed = JSON.parse(placeText);
+    assert.equal(placeParsed.ok, true, placeText);
+    assert.deepEqual(placeParsed.scene_relationships, {
+      characters: [],
+      places: ["harbor-district"],
+    });
+    assert.equal(placeParsed.operation_history.appended, true);
+    assert.equal(placeParsed.backup_refresh.ok, true);
+    assert.deepEqual(placeParsed.backup_warnings, []);
+
+    const characterSidecarPath = path.join(sceneDir, `${scenes.characterOnly.id}.meta.yaml`);
+    const characterSidecarBefore = fs.readFileSync(characterSidecarPath, "utf8");
+    const blockedText = await callWriteTool("update_scene_metadata", {
+      project_id: "test-novel",
+      scene_id: scenes.characterOnly.id,
+      fields: {
+        characters: ["marcus"],
+        places: ["harbor-district"],
+      },
+    });
+    const blockedParsed = JSON.parse(blockedText);
+    assert.equal(blockedParsed.ok, false, blockedText);
+    assert.equal(blockedParsed.error.code, "VALIDATION_ERROR");
+    assert.deepEqual(blockedParsed.error.details.blocked_fields, ["characters", "places"]);
+    assert.equal(fs.readFileSync(characterSidecarPath, "utf8"), characterSidecarBefore);
+
+    const backupDiagnosticText = await callWriteTool("diagnose_project_backups", {
+      project_id: "test-novel",
+    });
+    const backupDiagnosticParsed = JSON.parse(backupDiagnosticText);
+    assert.equal(backupDiagnosticParsed.ok, true, backupDiagnosticText);
+    assert.equal(backupDiagnosticParsed.trust.status, "current");
+
+    await callWriteTool("sync");
+
+    const elenaArcText = await callWriteTool("get_arc", {
+      project_id: "test-novel",
+      character_id: "elena",
+      page_size: 200,
+    });
+    const elenaArc = JSON.parse(elenaArcText);
+    assert.ok(elenaArc.results.some((row) => row.scene_id === scenes.paired.id));
+    assert.ok(elenaArc.results.some((row) => row.scene_id === scenes.characterOnly.id));
+
+    const marcusArcText = await callWriteTool("get_arc", {
+      project_id: "test-novel",
+      character_id: "marcus",
+      page_size: 200,
+    });
+    const marcusArc = JSON.parse(marcusArcText);
+    assert.ok(marcusArc.results.some((row) => row.scene_id === scenes.legacy.id));
+    assert.equal(marcusArc.results.some((row) => row.scene_id === scenes.characterOnly.id), false);
+
+    const elenaScenesText = await callWriteTool("find_scenes", {
+      project_id: "test-novel",
+      character: "elena",
+      page_size: 200,
+    });
+    const elenaScenes = JSON.parse(elenaScenesText);
+    assert.ok(elenaScenes.results.some((row) => row.scene_id === scenes.paired.id));
+    assert.ok(elenaScenes.results.some((row) => row.scene_id === scenes.characterOnly.id));
+
+    const harborSearchText = await callWriteTool("search_metadata", {
+      query: '"harbor-district"',
+      page_size: 200,
+    });
+    const harborSearch = JSON.parse(harborSearchText);
+    assert.ok(harborSearch.results.some((row) => row.scene_id === scenes.paired.id));
+    assert.ok(harborSearch.results.some((row) => row.scene_id === scenes.placeOnly.id));
+    assert.ok(harborSearch.results.some((row) => row.scene_id === scenes.legacy.id));
+
+    const proseText = await callWriteTool("get_scene_prose", {
+      project_id: "test-novel",
+      scene_id: scenes.placeOnly.id,
+    });
+    assert.ok(proseText.includes(scenes.placeOnly.prose), `Expected place-only prose, got: ${proseText.slice(0, 300)}`);
+
+    const bundleText = await callWriteTool("preview_review_bundle", {
+      project_id: "test-novel",
+      profile: "outline_discussion",
+      scene_ids: [scenes.paired.id, scenes.characterOnly.id],
+    });
+    const bundleParsed = JSON.parse(bundleText);
+    assert.equal(bundleParsed.ok, true, bundleText);
+    assert.deepEqual(
+      bundleParsed.ordering.map((row) => row.scene_id).sort(),
+      [scenes.characterOnly.id, scenes.paired.id].sort()
+    );
+
+    const operationsPath = path.join(writeSyncDir, "project-backups", "test-novel", "operations.jsonl");
+    const operationRecords = fs.readFileSync(operationsPath, "utf8").trimEnd().split("\n").map((line) => JSON.parse(line));
+    const recentRelationshipOperations = operationRecords.slice(-3).map((record) => ({
+      operation: record.operation,
+      scenes: record.affected.scenes,
+    }));
+    assert.deepEqual(recentRelationshipOperations, [
+      { operation: "connect_character_place_evidence", scenes: [scenes.paired.id] },
+      { operation: "connect_scene_character_evidence", scenes: [scenes.characterOnly.id] },
+      { operation: "connect_scene_place_evidence", scenes: [scenes.placeOnly.id] },
+    ]);
+  });
+});
+
 describe("assign_scene_to_chapter tool", () => {
   test("assigns an unchaptered scene and reflects it in chapter-aware reads", async () => {
     const sceneDir = path.join(writeSyncDir, "projects", "test-novel", "scenes");


### PR DESCRIPTION
## Summary

- Adds an M5 regression test covering paired, character-only, place-only, blocked metadata, legacy sync, search/read, review bundle, operation history, and backup freshness paths.
- Moves Relationship Metadata Boundary from active to done and marks M5 accepted.
- Updates PRODUCT/README status text to reflect initiative completion and no currently selected active initiative.

## Motivation

M5 is the release-readiness slice for Relationship Metadata Boundary. The goal is to prove the SQLite-first relationship boundary holds across common workflows before PR completion, while closing the initiative lifecycle cleanly.

## Implementation

- Added a broad integration regression in `src/test/integration/metadata.test.mjs`.
- Verified `update_scene_metadata` cannot create hidden relationship changes through blocked `characters` / `places` writes.
- Verified legacy sidecar/frontmatter relationship compatibility remains searchable after sync.
- Moved initiative docs to `docs/initiatives/done/relationship-metadata-boundary`.
- No new release-log entry was added because this PR adds regression/lifecycle readiness; client-facing behavior was already covered by prior relationship boundary release-log entries.

## Testing

- `npm run check:pr`: passed
- `node --experimental-sqlite --test --test-concurrency=1 src/test/integration/metadata.test.mjs`: passed
- `node /Users/hanna/.codex/skills/initiative-completion/scripts/check-initiative-lifecycle.mjs --repo /Users/hanna/Code/mcp-writing --initiative docs/initiatives/done/relationship-metadata-boundary --milestone M5 --strict`: passed
- `git diff --check`: passed
- Stale active/M5-selected reference scan: no matches

## Risks and tradeoffs

- The new M5 regression is intentionally broad because it proves the release-readiness workflow end to end; reviewers may want to inspect fixture isolation.
- This PR does not introduce new runtime behavior.

## Follow-up

None.
