### PR TITLE
feat: clarify M1 workflow and relationship responses

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -9,9 +9,9 @@ It supports metadata-first reasoning, explicit prose editing workflows, and revi
 
 ## Product Status
 
-Active initiative: None currently selected.
+Active initiative: [Human Input Forgiveness](docs/initiatives/active/human-input-forgiveness/prd.md).
 
-Current focus: Consolidation after Relationship Metadata Boundary completion.
+Current focus: M1 - Response Clarity Baseline.
 
 Most recent completed initiative: [Relationship Metadata Boundary](docs/initiatives/done/relationship-metadata-boundary/prd.md).
 
@@ -51,6 +51,7 @@ For structural manuscript state, use [Managed Structure Contract](docs/foundatio
 ## For More Details
 
 - [Features](FEATURES.md) — shipped product capabilities and links to completed initiative docs
+- [Human Input Forgiveness](docs/initiatives/active/human-input-forgiveness/prd.md) — active initiative for forgiving request-boundary resolution and compact response guidance while preserving stable canonical IDs
 - [Backlog](BACKLOG.md) — deferred product work that is not currently active
 - [Relationship Metadata Boundary](docs/initiatives/done/relationship-metadata-boundary/prd.md) — completed initiative closing the remaining sidecar-first scene character/place relationship mutation path
 - [Architecture Alignment Follow-up](docs/initiatives/done/architecture-alignment-follow-up/prd.md) — completed initiative documenting sidecar compatibility, migration, deprecation expectations, and relationship workflow alignment

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Instead of feeding an entire manuscript to an AI and hoping it fits in the conte
 
 ### `describe_workflows` surface redesign
 
-`describe_workflows` now exposes an outcome-first, discovery-first workflow map. This is a breaking change if your prompts or automation depend on previous workflow IDs or ordering.
+`describe_workflows` now exposes an outcome-first, discovery-first workflow map. This was a breaking change if your prompts or automation depend on previous workflow IDs or ordering; the newer `recommended_next_actions` tier is additive and appears before the full catalogue.
 
 Update integrations using this mapping:
 
@@ -153,7 +153,7 @@ Goal: keep indexes accurate without manually re-tagging everything.
 
 1. After rewriting scenes, call `enrich_scene` to re-derive lightweight metadata from current prose.
 2. Use `update_scene_metadata` for intentional editorial fields (for example, beat, POV, status, and tags). It rejects scene `characters` and `places`; use `connect_character_place_evidence` when a scene proves paired sheet-backed character/place evidence, `connect_scene_character_evidence` for character-only evidence, and `connect_scene_place_evidence` for place-only evidence. Use `audit_relationship_metadata` for retained sidecar/frontmatter relationship fields. Use `list_chapters` plus `assign_scene_to_chapter` or `move_scene` for chapter placement and ordering.
-3. Use `search_metadata` and `find_scenes` to verify scenes are discoverable under the expected filters.
+3. Use `search_metadata` for keyword/FTS metadata searches across indexed titles, loglines, tags, characters, places, and versions, and use `find_scenes` to verify scenes are discoverable under structured filters. After identifying likely scenes, use `get_scene_prose` for prose context.
 
 Outcome: your AI assistant can reliably find the right scenes without drifting from the manuscript.
 

--- a/docs/agents/tools.md
+++ b/docs/agents/tools.md
@@ -400,7 +400,7 @@ Keyword/FTS metadata search across scene titles, loglines (synopsis/logline text
 
 | Parameter | Type | Required | Description |
 | --- | --- | :---: | --- |
-| `query` | `string` | Yes | Keyword or FTS5 search terms from indexed metadata (e.g. 'hospital' or a quoted character/place/tag phrase). |
+| `query` | `string` | Yes | Keyword search terms from indexed metadata (e.g. 'hospital' or a quoted character/place/tag phrase). FTS5 syntax supported. |
 | `page` | `integer` | No | Optional page number for paginated responses (1-based). |
 | `page_size` | `integer` | No | Optional page size for paginated responses (default: 20, max: 200). |
 

--- a/docs/agents/tools.md
+++ b/docs/agents/tools.md
@@ -396,11 +396,11 @@ Get full place details, including canonical sheet content plus retained sidecar 
 
 ## search_metadata
 
-Full-text search across scene titles, loglines (synopsis/logline text fields), and metadata keywords (tags/characters/places/versions). Use this when you don't know the exact scene_id or chapter but want to find scenes by topic, theme, or metadata keyword. Not a prose search — use get_scene_prose to read actual text. Supports pagination via page/page_size and auto-paginates large result sets with total_count.
+Keyword/FTS metadata search across scene titles, loglines (synopsis/logline text fields), and indexed metadata keywords (tags/characters/places/versions). Use this when you know likely words or exact metadata values but do not know the scene_id or chapter. This is not semantic search and does not search prose text; use find_scenes for structured filters and get_scene_prose after identifying likely scenes. Supports pagination via page/page_size and auto-paginates large result sets with total_count.
 
 | Parameter | Type | Required | Description |
 | --- | --- | :---: | --- |
-| `query` | `string` | Yes | Search terms (e.g. 'hospital' or 'Sebastian feeding'). FTS5 syntax supported. |
+| `query` | `string` | Yes | Keyword or FTS5 search terms from indexed metadata (e.g. 'hospital' or a quoted character/place/tag phrase). |
 | `page` | `integer` | No | Optional page number for paginated responses (1-based). |
 | `page_size` | `integer` | No | Optional page size for paginated responses (default: 20, max: 200). |
 

--- a/docs/initiatives/active/human-input-forgiveness/architecture.md
+++ b/docs/initiatives/active/human-input-forgiveness/architecture.md
@@ -1,0 +1,454 @@
+# Human Input Forgiveness - Architecture Notes
+
+**Status:** Active
+
+Created: 2026-06-06.
+
+## Context
+
+Writing MCP intentionally uses durable canonical IDs for structural manuscript
+state. That model is necessary because names, titles, order, folders, and source
+tool representations change over the life of a manuscript.
+
+The usability gap is at the public request boundary: callers often know the
+human-facing name or a case variant, not the exact canonical ID. The system can
+be more forgiving there without weakening canonical identity, as long as
+resolution is explicit, deterministic, scoped, and conservative.
+
+## Architecture Principle
+
+Forgiving input belongs at the tool request boundary.
+
+It must not:
+
+- change canonical IDs;
+- add name-based identity to SQLite;
+- let sidecars or generated artifacts become authority;
+- guess ambiguous targets for mutating workflows;
+- invent editorial meaning or promote prose mentions into world-model records.
+
+It may:
+
+- resolve exact stable IDs;
+- resolve unique case-insensitive names or IDs;
+- suggest candidate canonical IDs for near misses;
+- include canonical `resolved_id` details in responses;
+- help the caller continue after a failed lookup.
+
+## Resolver Boundary
+
+### Inputs
+
+Each resolver call should receive:
+
+- target kind, such as `scene`, `character`, `place`, `chapter`, `tag`, or
+  `beat`;
+- raw caller input;
+- project scope when required;
+- universe scope when the domain allows project/universe inheritance;
+- mode:
+  - `strict_id`;
+  - `case_insensitive_exact`;
+  - `suggest_only`;
+  - future `near_match_suggestions`.
+
+### Outputs
+
+Successful resolution should return:
+
+- canonical ID or canonical value;
+- target kind;
+- whether the input was already canonical;
+- `resolved_from` details when the input differed from the canonical ID;
+- optional display label.
+
+Failed resolution should return:
+
+- stable error code;
+- target kind;
+- input;
+- project/universe scope;
+- candidate matches when available;
+- next step.
+
+### Match Policy
+
+The default policy should be conservative:
+
+1. Exact stable ID match.
+2. Case-insensitive stable ID match when unique.
+3. Case-insensitive display-name match when unique.
+4. Suggestions for other near matches.
+5. Refuse ambiguity.
+
+Only steps 1-3 may automatically proceed to mutation. Step 4 is guidance only
+unless a future milestone explicitly adds an approved confirmation shape.
+Any step-4 ranking must be local, deterministic, suggestion-only, and covered
+by tests before it appears in public responses.
+
+### Error Taxonomy
+
+Resolver failures stay inside the existing JSON error envelope.
+
+- Use `AMBIGUOUS_TARGET` when more than one valid canonical target matches by
+  exact or case-insensitive ID/name/title resolution.
+- Use `NOT_FOUND` when no canonical target matches. Include fuzzy or near-match
+  suggestions when deterministic suggestions are available.
+- Use existing validation errors for malformed scope, invalid project IDs, or
+  inputs that are disallowed by a tool contract, such as numeric chapter aliases
+  in mutating chapter workflows.
+
+Both `AMBIGUOUS_TARGET` and suggestion-bearing `NOT_FOUND` responses must
+include `lookup_kind`, `input`, relevant scope fields, `candidate_matches` when
+available, and `next_step`.
+
+### Candidate And Resolution Detail Shape
+
+Candidate lists should be compact and deterministic. Default maximum:
+5 candidates, with a hard maximum of 10 if a tool explicitly opts in.
+
+Each `candidate_matches` entry should include:
+
+- `target_kind`;
+- canonical `id`;
+- `label`;
+- `matched_field`;
+- `match_type`, such as `exact_id`, `case_insensitive_id`,
+  `case_insensitive_name`, `case_insensitive_title`, or
+  `near_match_suggestion`;
+- relevant scope fields such as `project_id` and `universe_id`;
+- optional `context` with target-specific details.
+
+Candidate ordering:
+
+1. exact/case-insensitive ID matches;
+2. exact/case-insensitive display-name or title matches;
+3. deterministic near-match suggestions;
+4. within a group, sort by lowercase `label`, then canonical `id`.
+
+Successful `resolved_from` details should use the public argument name as the
+key and include:
+
+- `input`;
+- `matched_field`;
+- `match_type`;
+- canonical `id`.
+
+`resolution_hint` is a short human-readable hint only; clients should parse
+`candidate_matches` and `next_step` instead of deriving behavior from the hint.
+
+### Workflow Recommendation Shape
+
+`describe_workflows` should expose a top-level `recommended_next_actions`
+array before `workflows`. It should contain three to five entries ordered by
+likely next action priority.
+
+Each entry should include:
+
+- `id`: stable recommendation ID;
+- `label`: short human-readable action label;
+- `tool`: primary MCP tool to call next;
+- `reason`: why this action is recommended from current context;
+- `next_step`: concise instruction for the caller.
+
+Optional fields:
+
+- `workflow_id`: related workflow catalogue ID;
+- `priority`: numeric ordering value when deterministic ordering needs to be
+  asserted in tests.
+
+The full `WORKFLOW_CATALOGUE` remains the detailed navigation surface. The
+recommendation array is an additive summary and must not remove or reorder the
+full catalogue.
+
+## Target Classes
+
+### Scenes
+
+Scene resolution is project-scoped. Stable `scene_id` remains the canonical
+input. Optional title matching must be unique within the project. No other
+scene display fields are accepted as auto-resolution inputs in this initiative.
+
+Ambiguity risk:
+- scene titles are more likely to repeat or be draft placeholders.
+
+Mitigation:
+- prefer ID;
+- include chapter/timeline/title context in candidate matches;
+- never auto-resolve near matches for scene mutation.
+
+Scene candidate `context` should include `project_id`, `title`, `chapter_id`,
+`chapter_title`, and `timeline_position` when available.
+
+### Characters
+
+Character resolution must follow the existing relationship-tool ownership rule:
+for a given project, candidates may be project-owned, in the same universe as
+the project, or global records with both `project_id` and `universe_id` null.
+
+Ambiguity risk:
+- two characters can share names across projects or universes.
+
+Mitigation:
+- scope candidates by the relationship-tool project/universe/global lookup rule;
+- return role or first appearance when available.
+
+### Places
+
+Place resolution mirrors character resolution: candidates may be project-owned,
+in the same universe as the project, or global records with both `project_id`
+and `universe_id` null.
+
+Ambiguity risk:
+- locations often have aliases or generic names.
+
+Mitigation:
+- start with exact/case-insensitive matching;
+- scope candidates by the relationship-tool project/universe/global lookup rule;
+- defer alias handling unless current schema already stores aliases.
+
+### Chapters
+
+Chapter resolution is project-scoped. Canonical `chapter_id` remains the
+preferred mutating input for chapter and scene-placement workflows.
+
+Allowed request-boundary forgiveness for this initiative:
+
+- exact `chapter_id`;
+- unique case-insensitive `chapter_id`.
+
+Chapter-title resolution for mutating chapter workflows is a future expansion
+that requires a reviewed planning update before implementation.
+
+Numeric chapter aliases remain read-scoped compatibility inputs only. They may
+continue to help `find_scenes`, chapter prose retrieval, styleguide analysis,
+batch enrichment, and review-bundle planning, but they must not become mutation
+targets for creating, renaming, reordering, attaching epigraphs, moving scenes,
+or assigning scenes to chapters.
+
+Ambiguity risk:
+- chapter titles are mutable and may repeat;
+- numeric chapter labels are compatibility aliases, not identity.
+
+Mitigation:
+- prefer canonical `chapter_id`;
+- include title, sort order, and project context in candidate matches;
+- never auto-resolve numeric chapter aliases for mutating workflows;
+- fail closed on repeated titles or title/order ambiguity.
+
+### Tags, Beats, And Editorial Vocabulary
+
+These are not all canonical identity fields. Resolution should distinguish:
+
+- values with existing indexed vocabulary that can support suggestions;
+- freeform editorial values that should not become controlled lists by
+  accident.
+
+Case-insensitive matching can reduce friction, but mutation behavior should not
+silently rewrite user-chosen editorial text unless the tool already normalizes
+that field.
+
+## Response Contracts
+
+### Error Envelope
+
+The existing JSON envelope remains:
+
+```json
+{
+  "ok": false,
+  "error": {
+    "code": "NOT_FOUND",
+    "message": "...",
+    "details": {}
+  }
+}
+```
+
+This initiative should add details, not move to transport-level MCP errors.
+
+Recommended detail fields:
+
+- `lookup_kind`;
+- `input`;
+- `project_id`;
+- `universe_id`;
+- `candidate_matches`;
+- `next_step`;
+- `resolution_hint`.
+
+### Successful Mutation Responses
+
+When forgiving resolution is used, mutating tools should include:
+
+- canonical IDs in existing fields;
+- `resolved_from` details for each non-canonical input;
+- unchanged mutation-order, backup-refresh, and compatibility-output fields.
+
+Example shape:
+
+```json
+{
+  "ok": true,
+  "action": "connected",
+  "scene_id": "sc-014-argument",
+  "character_id": "char-elena-voss",
+  "resolved_from": {
+    "character_id": {
+      "input": "Elena Voss",
+      "matched_field": "name"
+    }
+  }
+}
+```
+
+Relationship evidence tools keep the existing public argument names
+(`scene_id`, `character_id`, `place_id`). Their broadened contract is:
+
+1. canonical IDs are preferred and resolved first;
+2. selected unambiguous human-shaped inputs may be accepted through the shared
+   resolver;
+3. successful responses always return canonical IDs in the existing fields and
+   place any non-canonical input details under `resolved_from`.
+
+### No-Op Responses
+
+Already-satisfied relationship evidence should not read as a new mutation.
+
+M1 must preserve the existing `action: "connected"` value and add additive
+fields:
+
+- `outcome: "no_op"`;
+- existing `already_linked: true`;
+- clear `next_step` explaining that no canonical rows changed.
+
+Changing to `action: "already_linked"` is a compatibility-sensitive follow-up,
+not part of M1.
+
+## Restore Response Compaction
+
+Restore planning has two audiences:
+
+- humans under recovery pressure who need the blocking requirement first;
+- agents/maintainers who need full plan detail for audit.
+
+The response should serve both by separating summary from detail:
+
+- `blocking_requirements` for confirmation failures;
+- `plan_summary` for counts and risk flags;
+- full `plan` retained or available on request;
+- explicit policy for unchanged rows.
+
+The first implementation should introduce additive `include_unchanged` support:
+default behavior preserves current full-plan detail, while
+`include_unchanged=false` suppresses unchanged rows. Changing the default detail
+level is a later compatibility decision that requires release notes and an
+explicit milestone or contract cleanup.
+
+## Workflow Discovery Summary
+
+`describe_workflows` already owns initial orientation and uncertainty handling.
+The compact tier should not replace the workflow catalogue. It should provide
+the first three to five likely next actions based on:
+
+- scene count;
+- setup contract status;
+- migration warnings;
+- backup or runtime warnings if already surfaced in context;
+- default manuscript-discovery workflow.
+
+The full `WORKFLOW_CATALOGUE` remains the durable map for detailed agent
+planning.
+
+## Search Boundary
+
+`search_metadata` currently uses SQLite FTS over scene titles, loglines, and
+metadata keywords. That is valuable, but it is not semantic search and does not
+read prose.
+
+This initiative may:
+
+- clarify the tool description;
+- improve no-result guidance;
+- defer any alias decision to future planning.
+
+It should not:
+
+- add embeddings;
+- add model calls;
+- index prose semantically;
+- change privacy/cost posture.
+
+Semantic search belongs to the existing Embedding-Based Search backlog item.
+
+## Migration And Compatibility
+
+This initiative should be additive where possible:
+
+- stable IDs remain valid;
+- existing tool names remain valid;
+- existing response fields remain present;
+- new resolver and summary details are added under new fields.
+
+Potential breaking changes, such as changing `action: "connected"` to
+`action: "already_linked"` or default restore plan compaction, should be called
+out in milestone acceptance criteria and release notes before implementation.
+M1 does not take that action-value change; it uses additive fields only.
+
+## Failure Modes
+
+### Ambiguous Human Name
+
+Return `AMBIGUOUS_TARGET` with candidates and next step. Do not mutate.
+
+### Near Miss With One Candidate
+
+Return suggestions only in early milestones. Do not mutate from fuzzy-only
+matches without explicit confirmation design.
+
+Near-match ranking, if exposed, must be local and deterministic. It must not
+call an external model or semantic backend as part of this initiative.
+
+### Case Variant Of Existing ID
+
+Resolve if unique and report canonical ID.
+
+### Case Variant Of Tag Or Beat
+
+For read filters, match existing vocabulary case-insensitively where possible.
+For writes, preserve field ownership rules and avoid silently changing freeform
+authorial text unless the field already normalizes.
+
+### Numeric Chapter Alias In A Mutation
+
+Reject or return a candidate list that points to canonical `chapter_id` values.
+Do not reinterpret numeric chapter aliases as mutating IDs.
+
+### Resolver Internal Error
+
+Fail closed with a normal tool error. Do not fall back to a guessed target.
+
+## Alternatives Considered
+
+### Require Callers To Use List Tools First
+
+This preserves safety but leaves the exact UX friction identified by testing.
+It should remain the fallback for ambiguity, not the only path for unambiguous
+human inputs.
+
+### Make Names Canonical
+
+Rejected. Names change and can repeat. This violates stable identity and would
+make long-form manuscript state harder to maintain.
+
+### Semantic Search Now
+
+Rejected for this initiative. The feedback exposes a naming and expectation gap
+that can be improved immediately, while semantic search requires a separate
+backend, indexing, privacy, and evaluation decision.
+
+### Transport-Level MCP Errors
+
+Rejected for this initiative. The current JSON envelope is already used by
+clients and tests. The immediate need is consistent parseable detail inside the
+envelope.

--- a/docs/initiatives/active/human-input-forgiveness/milestones.md
+++ b/docs/initiatives/active/human-input-forgiveness/milestones.md
@@ -1,0 +1,365 @@
+# Human Input Forgiveness - Milestones
+
+**Status:** Active
+
+Current implementation target: M1 - Response Clarity Baseline.
+
+Created: 2026-06-06.
+
+## Objective
+
+Ship forgiving request-boundary resolution and compact response guidance in
+small, reviewable slices without weakening Writing MCP's stable-ID,
+SQLite-canonical, explicit-mutation model.
+
+## Guardrails
+
+- Stable IDs remain canonical and continue to be accepted exactly.
+- Name, tag, beat, or case-insensitive matching is a request-boundary
+  convenience, not durable identity.
+- Mutating tools must not apply ambiguous fuzzy matches.
+- Near-match suggestions, when present, must be local, deterministic,
+  suggestion-only, and covered by tests before being exposed.
+- Response changes should be additive unless a milestone explicitly calls out a
+  breaking cleanup.
+- Every milestone that changes public tool behavior, response shape, generated
+  tool documentation, or user/maintainer guidance must include a release-log
+  entry in the same milestone PR.
+- Search wording must not promise semantic or prose search until a separate
+  semantic-search initiative implements it.
+- Restore safety requirements must not be weakened.
+
+## M1 - Response Clarity Baseline
+
+Goal: make the most confusing successful and failed responses clearer before
+changing input resolution.
+
+Deliverables:
+
+- Add explicit no-op outcome wording for already-linked one-sided relationship
+  evidence by preserving the existing `action: "connected"` value and adding
+  additive `outcome: "no_op"` plus clear next-step guidance.
+- Add `next_step` details to `NOT_FOUND` errors from relationship evidence
+  tools.
+- Add compact `recommended_next_actions` summary tier to `describe_workflows`
+  while preserving the full workflow catalogue. The field name is exactly
+  `recommended_next_actions`.
+- Clarify `search_metadata` description and no-result guidance as keyword/FTS
+  metadata search, not semantic/prose search.
+- Do not add a `search_metadata` alias in this milestone.
+- Regenerate agent tool docs if tool descriptions change.
+- Update README/user-facing docs if the changed response or search wording
+  affects app users.
+- Add a release-log entry for the public response and guidance changes.
+
+Acceptance criteria:
+
+- Calling one-sided evidence connection for an already-linked entity returns a
+  clearly recognizable no-op result via additive `outcome: "no_op"` while
+  preserving `action: "connected"` for compatibility.
+- Missing scene, character, or place in relationship evidence tools returns an
+  actionable `next_step`.
+- `describe_workflows` puts `recommended_next_actions` before long workflow
+  details, ordered by likely next action priority.
+- `search_metadata` no longer suggests it can answer semantic/prose queries by
+  name or wording.
+- No new `search_metadata` alias exists in M1.
+- Existing clients can still parse the previous core fields.
+- User-facing docs are updated if app-user behavior or guidance changes.
+- Release-log coverage exists before this milestone is PR-ready.
+
+Required validation:
+
+- Unit tests for no-op outcome construction where applicable.
+- Integration tests for relationship `NOT_FOUND` details.
+- Integration tests for `describe_workflows` summary fields.
+- Search/tool-doc assertions updated to the new keyword-search language.
+- README/user-facing documentation assertions or review notes are included when
+  behavior affects app users.
+- Release-log entry reviewed for user/client-visible behavior changes.
+
+Explicit non-goals:
+
+- No fuzzy matching or human-name resolution yet.
+- No restore plan compaction yet.
+- No semantic search implementation.
+
+## M2 - Shared Canonical Target Resolver
+
+Goal: introduce a reusable resolver that can safely convert unambiguous
+human-shaped inputs into canonical target IDs.
+
+Deliverables:
+
+- Build the shared resolver as internal infrastructure only. M2 should not
+  broaden any public tool input contract until M3 wires it into relationship
+  evidence tools.
+- Shared resolver helpers for target classes needed by the first production
+  tools:
+  - scene by `scene_id` or unique title within `project_id`;
+  - character by `character_id` or name within project/universe scope;
+  - place by `place_id` or name within project/universe scope.
+- Case-insensitive exact matching for IDs and names.
+- Candidate details for no-match and ambiguous-match outcomes.
+- Error taxonomy: ambiguous targets return `AMBIGUOUS_TARGET`; missing targets
+  return `NOT_FOUND` with suggestions when available.
+- A suggestion policy that permits exact/case-insensitive auto-resolution only;
+  any near-match ranking is local, deterministic, suggestion-only, and covered
+  by tests before public use.
+- Response details that include `resolved_from` and canonical IDs when a
+  non-canonical input succeeds.
+
+Acceptance criteria:
+
+- Exact stable IDs behave unchanged.
+- Unique case-insensitive ID/name matches resolve successfully.
+- Ambiguous name matches do not mutate state and return candidate matches.
+- Ambiguous resolution responses use `AMBIGUOUS_TARGET` in the JSON error
+  envelope.
+- Near matches are suggestions only unless a later reviewed milestone
+  explicitly accepts a confirmation shape.
+- Resolver behavior is deterministic and project-scoped.
+- Candidate responses follow the architecture cap: default maximum 5
+  candidates, hard maximum 10 only when a tool explicitly opts in.
+- No public tool accepts new human-shaped inputs before M3.
+
+Required validation:
+
+- Unit tests for resolver exact, case-insensitive, no-match, and ambiguous
+  cases.
+- Tests for project/universe scoping of character and place resolution.
+- Tests that character/place resolution follows the existing relationship-tool
+  lookup rule: project-owned records, records in the same universe as the
+  project, or global records with both `project_id` and `universe_id` null.
+- Regression tests proving stable-ID paths keep current behavior and response
+  compatibility.
+- Fixture-backed resolver contract tests cover candidate shape, ordering, and
+  count caps.
+
+Explicit non-goals:
+
+- No broad fuzzy ranking as mutation input.
+- No creation of missing scenes, characters, or places.
+- No changes to SQLite identity schema.
+
+## M3 - Forgiving Relationship Evidence Inputs
+
+Goal: apply the shared resolver to the most painful daily-work mutation path:
+scene-character/place evidence tools.
+
+Deliverables:
+
+- Allow relationship evidence tools to accept unambiguous resolved scene,
+  character, and place inputs.
+- Keep the existing public arguments (`scene_id`, `character_id`, and
+  `place_id`) and extend their descriptions/contracts: canonical IDs are the
+  preferred input, and selected unambiguous human-shaped inputs are accepted
+  only through the shared resolver.
+- Return canonical IDs and `resolved_from` details in successful responses.
+- Preserve SQLite-first mutation order, backup refresh, and generated
+  compatibility output behavior.
+- Ensure all failed resolution paths return structured candidate and next-step
+  details.
+- Add a release-log entry for accepting unambiguous human-shaped relationship
+  evidence inputs and the new resolver response details.
+- Update README/user-facing docs for the broadened relationship evidence input
+  contract if those tools are documented for app users.
+
+Acceptance criteria:
+
+- Inputs like human character/place names work when unambiguous.
+- Generated tool docs state that `*_id` parameters prefer canonical IDs and
+  accept only selected unambiguous human-shaped inputs.
+- Case variants of valid IDs work when unambiguous.
+- Ambiguous or misspelled inputs return suggestions without mutating SQLite or
+  generated compatibility output.
+- Ambiguous inputs return `AMBIGUOUS_TARGET`; missing inputs return
+  `NOT_FOUND` with suggestions when available.
+- Operation history and backup refresh record canonical IDs.
+- Release-log coverage exists before this milestone is PR-ready.
+- User-facing docs are updated when the changed input contract affects app
+  users.
+
+Required validation:
+
+- Integration tests for `connect_character_place_evidence`.
+- Integration tests for `connect_scene_character_evidence`.
+- Integration tests for `connect_scene_place_evidence`.
+- Negative tests proving ambiguous names and suggestions do not write canonical
+  rows.
+- Negative tests prove ambiguous or suggested-only matches do not refresh
+  generated compatibility output, append operation history, or refresh backup
+  artifacts.
+- Existing relationship metadata boundary tests continue to pass.
+
+Explicit non-goals:
+
+- No bulk relationship repair changes.
+- No unlink/delete relationship workflows.
+- No sheet creation from freeform prose mentions.
+
+## M4 - Restore Plan Scannability
+
+Goal: make backup restore responses easier to read under pressure while keeping
+dry-run-first and checksum-required safety intact.
+
+Deliverables:
+
+- Add compact `blocking_requirements` to confirmation-refused restore
+  responses.
+- Add `plan_summary` that highlights create/update/delete/refused/conflict/
+  unchanged counts and cross-scope/destructive counts.
+- Add additive `include_unchanged` input so callers can suppress unchanged rows
+  while the default full-plan detail remains compatible.
+- Preserve existing full plan access where callers need audit detail.
+- Add a release-log entry for restore response-shape additions.
+- Update README/user-facing recovery docs if restore response guidance or
+  parameters are documented for app users.
+
+Acceptance criteria:
+
+- `dry_run=false` without checksum leads with the checksum requirement.
+- Destructive and cross-scope confirmation requirements are visually prominent.
+- Long unchanged rows can be suppressed through documented
+  `include_unchanged=false` without changing the default response shape.
+- Full plan detail remains retrievable for review.
+- Release-log coverage exists before this milestone is PR-ready.
+- User-facing docs are updated when restore behavior or guidance visible to app
+  users changes.
+
+Required validation:
+
+- Unit tests for plan summary and unchanged compaction behavior.
+- Integration tests for checksum-required, checksum-changed, destructive, and
+  cross-scope restore refusal responses.
+- Regression tests for successful dry-run and applied restore behavior.
+
+Explicit non-goals:
+
+- No weakening of checksum, destructive, cross-scope, or transactional restore
+  requirements.
+- No change to backup snapshot authority.
+- No prose backup or restore changes.
+
+## M5 - Extended Vocabulary Resolution
+
+Goal: apply forgiving resolution to non-identity metadata values where case and
+near-match friction is common.
+
+Deliverables:
+
+- Case-insensitive matching or suggestions for tags, beats, character-backed
+  filters, and the explicitly inventoried chapter filter.
+- Field inventory for M5:
+  - `find_scenes.character` and `find_scenes.pov` may resolve character IDs by
+    the shared character resolver;
+  - `find_scenes.tag` and `find_scenes.beat` may use case-insensitive
+    read-filter matching or suggestions based on existing indexed values;
+  - `find_scenes.chapter_id` may use canonical chapter resolution;
+  - `find_scenes.chapter` remains a numeric read-scope compatibility alias;
+  - `update_scene_metadata.fields.tags` may preserve supplied casing while
+    returning suggestions for existing differently cased tags;
+  - `update_scene_metadata.fields.save_the_cat_beat` may use suggestions for
+    existing beat values but remains freeform unless a separate controlled
+    vocabulary decision is made.
+- Chapter resolution in M5 is limited to `find_scenes.chapter_id`; numeric
+  chapter aliases remain read-only compatibility filters and never mutating
+  targets. Chapter-title resolution for mutating chapter workflows is outside
+  M5 unless the initiative docs are updated and re-reviewed.
+- Candidate suggestions for `find_scenes` and `update_scene_metadata` filters
+  or fields where appropriate.
+- Clear distinction between controlled canonical IDs and freeform editorial
+  values.
+- Add a release-log entry for any public vocabulary matching or suggestion
+  behavior shipped in this milestone.
+- Update README/user-facing docs for any public vocabulary matching or
+  suggestion behavior that affects app users.
+
+Acceptance criteria:
+
+- Querying or updating with common case variants succeeds or returns useful
+  suggestions according to field ownership.
+- M5 behavior is limited to the named field inventory unless the initiative docs
+  are updated and re-reviewed.
+- `find_scenes.chapter_id` reports or filters by canonical `chapter_id`, and
+  numeric chapter aliases remain read-only.
+- Freeform fields remain freeform where no canonical vocabulary exists.
+- Metadata search and scene discovery remain metadata-first and do not read
+  prose unless the caller explicitly invokes prose tools.
+
+Required validation:
+
+- Unit tests for vocabulary normalization/suggestion helpers.
+- Integration tests for scene discovery filters and safe metadata update paths.
+- Integration tests proving numeric chapter aliases stay read-only and
+  `find_scenes.chapter_id` resolution uses canonical `chapter_id`.
+- Regression tests proving relationship and structural guardrails still reject
+  inappropriate generic metadata writes.
+- Release-log coverage exists before this milestone is PR-ready when public
+  behavior changes.
+- User-facing docs are updated before PR readiness when public vocabulary
+  behavior changes.
+
+Explicit non-goals:
+
+- No new controlled vocabulary system unless product scope is explicitly
+  expanded.
+- No numeric chapter alias mutation.
+- No semantic interpretation of prose.
+- No hidden canonical relationship mutation through tags or freeform metadata.
+
+## M6 - Documentation, Release Notes, and Feedback Replay
+
+Goal: make the new UX contract durable and verify it against the original live
+testing scenarios.
+
+Deliverables:
+
+- Update user-facing docs when behavior changes affect app users.
+- Update generated agent tool reference.
+- Audit release-log entries from M1, M3, M4, and M5; add a final release-log
+  entry only if M6 itself changes user-facing docs or rollout guidance.
+- Record manual replay results for the original temp-fixture feedback
+  scenarios.
+- Document remaining semantic search expectations as belonging to the
+  Embedding-Based Search backlog item.
+
+Acceptance criteria:
+
+- Docs explain that stable IDs remain canonical even when tools accept
+  unambiguous human-shaped inputs.
+- Release notes identify any client-facing response additions or default
+  compaction changes.
+- Manual replay confirms the original rough edges are improved or explicitly
+  deferred.
+- Open questions are either closed or moved into a follow-up backlog item.
+
+Required validation:
+
+- Full relevant unit and integration test suites pass.
+- Manual temp-fixture validation covers:
+  - human-name relationship inputs;
+  - case variants;
+  - already-linked evidence no-op;
+  - `describe_workflows` summary;
+  - restore checksum-required response;
+  - keyword metadata search wording.
+
+Explicit non-goals:
+
+- No activation of Embedding-Based Search.
+- No client UI implementation.
+- No new transport-level MCP error model.
+
+## Definition Of Done
+
+This initiative is complete when:
+
+1. Users and agents can safely use unambiguous human-shaped inputs for the
+   selected high-value tools.
+2. Ambiguous inputs return structured candidates instead of guessing.
+3. The most important next action is visible first in workflow and restore
+   responses.
+4. Keyword metadata search is named and documented honestly.
+5. Stable IDs, canonical mutation order, backup freshness, and relationship
+   boundaries remain protected by regression tests.

--- a/docs/initiatives/active/human-input-forgiveness/prd.md
+++ b/docs/initiatives/active/human-input-forgiveness/prd.md
@@ -1,0 +1,359 @@
+# PRD: Human Input Forgiveness
+
+**Status:** Active
+
+Created: 2026-06-06.
+
+Related docs:
+- [Product Overview](../../../../PRODUCT.md)
+- [Managed Structure Contract](../../../foundations/managed-structure-contract.md)
+- [MCP Tooling Usability](../../done/mcp-tooling-usability/prd.md)
+- [Relationship Metadata Boundary](../../done/relationship-metadata-boundary/prd.md)
+- [Database Backup and Recovery](../../done/database-backup-recovery/prd.md)
+- [Embedding-Based Search](../../backlog/embeddings-search/prd.md)
+
+## Goal
+
+Make Writing MCP more forgiving of human-shaped inputs and more scannable in
+stressful or ambiguous workflows, while preserving the product's canonical
+stable-ID and explicit-mutation model.
+
+The target state is:
+
+- users and agents can provide natural names or case variants when the intended
+  target is unambiguous;
+- ambiguous, missing, or near-miss targets return deterministic suggestions,
+  actionable candidates, and next steps without becoming mutation inputs;
+- high-signal workflow and recovery responses put the most important action
+  before long diagnostic or plan details;
+- keyword metadata search is described honestly, without implying semantic or
+  prose search.
+
+## Source Feedback
+
+Live user testing against `mcp-writing:3.24.1` found that the core workflows are
+solid and guarded, especially relationship metadata boundaries and backup
+restore protections.
+
+The main usability issues were:
+
+- exact IDs are required across many tools, while human names and case variants
+  often fail;
+- `search_metadata` sounds more semantic than it is;
+- some failed calls return `ok: false` in the JSON envelope rather than an
+  MCP-level error, which is workable but must remain explicit and consistent;
+- `describe_workflows` is useful but long and needs a compact "next actions"
+  tier;
+- restore confirmation failures include a large unchanged plan, making the
+  immediate diagnostic less prominent;
+- repeated one-sided evidence connections return `action: "connected"` with
+  `already_linked: true`, which reads like a mutation even when the operation is
+  effectively a no-op.
+
+## Problem
+
+Writing MCP has intentionally moved toward stable identities and explicit
+outcome workflows. That direction is correct for long-form manuscript state:
+scene IDs, character IDs, place IDs, chapter IDs, and project IDs must survive
+renames, reorderings, and source-tool changes.
+
+However, daily use still asks humans and AI agents to know and type those IDs
+too early. A caller may know "Elena Voss" but not `char-elena-voss`, or type
+`Harbor` when the indexed tag is `harbor`. When the system rejects those
+requests without candidates, the user experience feels brittle even though the
+underlying safety model is sound.
+
+The same issue appears in responses: some tools return all available detail,
+but the next action is not visually dominant. This is especially costly in
+backup restore flows where a user may already be trying to recover from a
+stressful state.
+
+## User Value
+
+- Authors can use names and story vocabulary without first doing database-like
+  lookup work.
+- AI agents can recover from near misses by following structured suggestions
+  instead of retrying blindly.
+- Maintainers keep clear canonical identity boundaries and better regression
+  coverage around response envelopes.
+- Recovery and workflow-discovery output becomes easier to scan without
+  removing detailed plan data for audits.
+
+## Design Alignment
+
+This initiative supports the product design principles:
+
+1. **Two-phase retrieval:** forgiving lookup should improve metadata-first
+   narrowing before prose is loaded.
+2. **Preserve authorship and intent:** tools should resolve explicit caller
+   intent, not silently invent relationships or editorial meaning.
+3. **Stable identities:** durable IDs remain canonical; fuzzy or
+   case-insensitive inputs are request-boundary conveniences only.
+4. **Explicit structural mutation:** resolution must happen before sanctioned
+   mutation workflows commit canonical state.
+5. **Generated transparency:** compact summaries should make generated plans
+   easier to review without hiding full details.
+6. **Outcome-oriented tools:** failures should guide users toward the next
+   writing, repair, recovery, or discovery outcome.
+
+## Scope
+
+In scope:
+
+- Shared case-insensitive exact-match and near-match suggestions for common
+  target classes:
+  - scenes;
+  - characters;
+  - places;
+  - exact and case-insensitive `chapter_id` handling where explicitly
+    inventoried, with numeric chapter aliases remaining read-scoped
+    compatibility inputs only and chapter-title resolution for mutating
+    workflows requiring later re-review;
+  - project-scoped tags and beats where tools accept vocabulary values.
+- Additive response details for `NOT_FOUND`, `NO_RESULTS`, validation, and
+  no-op outcomes where they help the caller continue.
+- Compact `describe_workflows` summary tier before the full workflow map.
+- Restore response scannability improvements, especially confirmation failures
+  and unchanged restore rows.
+- Clearer no-op outcomes for already-linked relationship evidence.
+- Search contract wording and response guidance that distinguishes keyword
+  metadata search from semantic or prose search.
+- Human-readable release-log entries in each milestone that changes public
+  tool behavior, response shape, or user/maintainer guidance.
+- Unit and integration tests that prove stable-ID behavior remains intact.
+
+Out of scope:
+
+- Replacing stable IDs with names as canonical identity.
+- Treating numeric chapter aliases as mutation targets.
+- Accepting ambiguous fuzzy matches for mutating workflows without caller
+  confirmation.
+- Creating character or place sheets from freeform prose mentions.
+- Implementing semantic embeddings search. That remains covered by the
+  separate Embedding-Based Search backlog item.
+- Redesigning MCP error transport semantics away from the existing JSON
+  envelope.
+- Changing already-linked relationship evidence from `action: "connected"` to
+  a different action value in the first milestone.
+- Building a broad UI or natural-language command parser.
+- Changing authored prose storage or backup restore authority.
+
+## Proposed Direction
+
+### 1. Shared Resolution Boundary
+
+Introduce a shared resolver for public tool inputs that need canonical targets.
+The resolver should:
+
+- accept current stable IDs exactly as the first and preferred path;
+- match case-insensitive exact names or IDs when there is exactly one candidate;
+- return near-match suggestions for misses only when the suggestion algorithm
+  is local, deterministic, suggestion-only, and covered by tests;
+- refuse ambiguous matches with candidate details instead of guessing;
+- report the final canonical ID used by successful mutating tools.
+
+The resolver should live at the request boundary. It should not change
+canonical schema, durable IDs, sync/import behavior, or backup authority.
+
+### 2. Better Failure Continuations
+
+Tool failures should keep the existing envelope shape:
+
+```json
+{
+  "ok": false,
+  "error": {
+    "code": "NOT_FOUND",
+    "message": "...",
+    "details": {
+      "next_step": "..."
+    }
+  }
+}
+```
+
+Within that envelope, add consistent details where useful:
+
+- `lookup_kind`;
+- `input`;
+- `project_id`;
+- `candidate_matches`;
+- `next_step`;
+- `resolution_hint`.
+
+Ambiguous target resolution uses `AMBIGUOUS_TARGET`. Missing targets use
+`NOT_FOUND` with candidate suggestions when available. This keeps ambiguity
+parseable without changing the JSON error envelope.
+
+This keeps clients/tests able to parse the existing envelope while making
+failures more self-recovering.
+
+### 3. Compact Workflow Discovery
+
+Add a short top-level `recommended_next_actions` summary to
+`describe_workflows`. It should appear before the full workflow catalogue in
+the JSON response and contain the first three to five likely next actions using
+the shape defined in the architecture notes.
+
+The full workflow catalogue remains present for compatibility and detailed
+agent planning.
+
+### 4. Restore Response Scannability
+
+Restore planning and confirmation failures should lead with the blocking
+requirement and compact plan summary.
+
+Preferred additive fields:
+
+- `blocking_requirements`;
+- `plan_summary`;
+- `plan_detail_policy`;
+- `include_unchanged` input, where the default preserves full unchanged rows
+  and `include_unchanged=false` suppresses unchanged rows.
+
+Do not weaken checksum, destructive, cross-scope, dry-run, or transactional
+restore protections.
+
+The first implementation should be additive: introduce `include_unchanged`
+without changing the default full-plan contract. A later breaking cleanup may
+change defaults only after documenting compatibility impact and release notes.
+
+### 5. Honest Search Language
+
+Keep `search_metadata` compatible, but clarify that it is keyword/FTS metadata
+search over titles, loglines, and metadata keywords. M1 does not add a new
+alias; it improves wording and no-result guidance only. A future planning pass
+may consider additive aliases such as `keyword_search_metadata`, but aliases
+create permanent tool surface area and are not part of the first slice.
+
+Semantic or prose search should remain a separate initiative because it implies
+new indexing, model/backend decisions, privacy/cost tradeoffs, and evaluation
+work.
+
+## Acceptance Criteria
+
+- Stable IDs continue to work exactly as before.
+- Unambiguous case-insensitive names or IDs resolve to canonical IDs for the
+  selected target classes.
+- Ambiguous fuzzy matches never trigger a mutating workflow without an explicit
+  canonical ID or follow-up confirmation.
+- Ambiguous target resolution returns `AMBIGUOUS_TARGET`; no-match resolution
+  returns `NOT_FOUND` with suggestions when available.
+- Near-match ranking, if present, is local, deterministic, suggestion-only, and
+  covered by tests before it appears in public responses.
+- Relationship evidence tools return actionable `NOT_FOUND` details for
+  missing scenes, characters, and places.
+- Already-linked one-sided evidence returns an explicit no-op outcome or next
+  step that cannot be mistaken for a fresh mutation.
+- M1 preserves `action: "connected"` for already-linked evidence and adds
+  additive `outcome: "no_op"` plus clear next-step guidance rather than changing
+  the existing action value.
+- `describe_workflows` exposes a compact recommended-action tier before the
+  full workflow list using the exact `recommended_next_actions` field.
+- Restore confirmation failures lead with blocking requirements and compact
+  summary data.
+- Restore responses expose `include_unchanged` as an additive way to suppress
+  unchanged rows before any default response-shape change is considered.
+- Search tool documentation and generated tool reference no longer imply
+  semantic/prose search.
+- Unit and integration tests cover resolver success, resolver ambiguity,
+  response envelopes, no-op evidence behavior, workflow summary fields, and
+  restore response shape.
+
+## Risks
+
+### Silent Wrong-Target Mutation
+
+Forgiving resolution could accidentally map a human name to the wrong canonical
+record.
+
+Mitigation:
+- only auto-resolve exact stable IDs and unambiguous case-insensitive exact
+  matches;
+- return candidates instead of guessing for near matches;
+- include `resolved_from` and canonical IDs in mutation responses.
+
+### Contract Churn For Existing Clients
+
+Changing response shape could break clients that assert exact payloads.
+
+Mitigation:
+- prefer additive fields;
+- keep existing envelopes and core fields;
+- update generated docs and integration tests together.
+- include release-log entries in the same milestone PR as any public behavior
+  or response-shape change.
+
+### Search Scope Creep
+
+User feedback about semantic expectations could pull this initiative into
+embedding search.
+
+Mitigation:
+- clarify naming and next-step guidance now;
+- keep semantic search in the existing Embedding-Based Search backlog item.
+
+### Overlong Guidance
+
+Adding more suggestions can make responses longer instead of clearer.
+
+Mitigation:
+- lead with compact summaries and place detailed candidates/plans under
+  structured detail fields;
+- test response shape for common stressful recovery paths.
+
+## Test Strategy
+
+Unit tests:
+
+- resolver exact stable-ID behavior;
+- case-insensitive unique match behavior;
+- ambiguity and no-match candidate details;
+- candidate ranking boundaries;
+- local deterministic suggestion-only behavior;
+- restore plan compaction helpers;
+- response envelope helpers where shared.
+
+Integration tests:
+
+- relationship evidence tools with human names, case variants, and bad inputs;
+- ambiguity paths returning `AMBIGUOUS_TARGET` without mutation;
+- `describe_workflows` compact summary plus full workflow catalogue;
+- restore dry-run and confirmation-required responses with compact details;
+- `search_metadata` no-result guidance and documentation contract;
+- regression coverage proving canonical mutation order and backup refresh remain
+  unchanged.
+
+Manual validation:
+
+- repeat the live temp-fixture feedback scenarios;
+- verify that successful mutations report canonical IDs;
+- verify that no-op relationship evidence reads clearly as no-op;
+- inspect generated tool docs for search and workflow language.
+- confirm release-log coverage for every public response or tool-contract
+  change before a milestone PR is considered ready.
+
+## Settled Planning Decisions
+
+- Relationship evidence tools are the first production slice for forgiving
+  mutating inputs; broader mutating-tool rollout should follow only after those
+  tests prove the resolver boundary.
+- Early resolver milestones may auto-resolve exact stable IDs and unique
+  case-insensitive exact ID/name matches. Near matches are suggestions only.
+- Ambiguous target resolution uses `AMBIGUOUS_TARGET`; no-match resolution uses
+  `NOT_FOUND` with suggestions when available.
+- M1 no-op relationship evidence preserves the existing action value and adds
+  additive `outcome: "no_op"` plus next-step guidance.
+- Restore scannability starts with additive `include_unchanged` support while
+  preserving current default full-plan detail; `include_unchanged=false`
+  suppresses unchanged rows.
+- M5 chapter handling is limited to `find_scenes.chapter_id` canonical
+  resolution and preserving `find_scenes.chapter` as a read-only compatibility
+  alias. Chapter-title resolution for mutating chapter workflows requires a
+  later reviewed planning update.
+
+- M1 improves `search_metadata` wording and no-result guidance only; it does
+  not add a new alias.
+- Existing relationship evidence `*_id` arguments remain the public parameters;
+  M3 extends their contract so they accept canonical IDs first and selected
+  unambiguous human-shaped inputs second.

--- a/release-log.md
+++ b/release-log.md
@@ -6,6 +6,13 @@ This complements `CHANGELOG.md`:
 - `CHANGELOG.md` is technical and release-oriented.
 - This log is plain-language and outcome-oriented.
 
+### 2026-06-06 — Clarify next actions and relationship no-op responses
+
+- What changed: Added compact `recommended_next_actions` to `describe_workflows`, added actionable `next_step` details to relationship evidence `NOT_FOUND` responses, marked repeated one-sided scene evidence links with additive `outcome: "no_op"`, and clarified `search_metadata` as keyword/FTS metadata search rather than semantic or prose search.
+- Why it matters: Authors and AI agents get a shorter first action, clearer failed-lookup recovery, and less confusing already-linked responses without weakening stable ID or SQLite-canonical relationship boundaries.
+- Who is affected: Authors, maintainers, and AI agents using workflow discovery, relationship evidence tools, or metadata search.
+- Action needed: Read `recommended_next_actions` before scanning the full workflow catalogue, follow relationship error `next_step` guidance to discover stable IDs, and use `get_scene_prose` after metadata search identifies likely scenes.
+
 ### 2026-06-06 — Add one-sided scene evidence workflows
 
 - What changed: Added `connect_scene_character_evidence` and `connect_scene_place_evidence` so character-only and place-only scene evidence can be recorded through SQLite-first outcome workflows without fabricating paired character/place associations.

--- a/release-log.md
+++ b/release-log.md
@@ -12,6 +12,7 @@ This complements `CHANGELOG.md`:
 - Why it matters: Authors and AI agents get a shorter first action, clearer failed-lookup recovery, and less confusing already-linked responses without weakening stable ID or SQLite-canonical relationship boundaries.
 - Who is affected: Authors, maintainers, and AI agents using workflow discovery, relationship evidence tools, or metadata search.
 - Action needed: Read `recommended_next_actions` before scanning the full workflow catalogue, follow relationship error `next_step` guidance to discover stable IDs, and use `get_scene_prose` after metadata search identifies likely scenes.
+- PR: [#235](https://github.com/hannasdev/mcp-writing/pull/235)
 
 ### 2026-06-06 — Add one-sided scene evidence workflows
 

--- a/src/index.js
+++ b/src/index.js
@@ -327,6 +327,100 @@ function maxScenesNextStep(matchedCount) {
   return `Re-run with max_scenes set to at least ${matchedCount}.`;
 }
 
+function buildRecommendedNextActions({
+  sceneCount,
+  setupContract,
+  dbMigrationWarnings,
+}) {
+  const recommendations = [];
+
+  if (dbMigrationWarnings.length > 0) {
+    recommendations.push({
+      id: "refresh_index_after_migration_warning",
+      label: "Refresh indexed state",
+      tool: "sync",
+      workflow_id: "parity_recovery",
+      priority: 10,
+      reason: "Database migration warnings are present, so indexed metadata may need a sync before other work.",
+      next_step: "Call sync, then re-run describe_workflows before mutating project state.",
+    });
+  }
+
+  if (sceneCount === 0) {
+    recommendations.push({
+      id: "index_project_content",
+      label: "Index project content",
+      tool: "sync",
+      workflow_id: "first_time_setup",
+      priority: 20,
+      reason: "No scenes are indexed yet, so discovery and scene-reading tools have no project content to inspect.",
+      next_step: "Call sync to index the configured writing folder, then use find_scenes without filters to confirm project_ids.",
+    });
+    recommendations.push({
+      id: "inspect_runtime_configuration",
+      label: "Inspect runtime configuration",
+      tool: "get_runtime_config",
+      workflow_id: "first_time_setup",
+      priority: 30,
+      reason: "Runtime paths and writable state determine whether sync can index the intended manuscript folder.",
+      next_step: "Call get_runtime_config if sync still indexes no scenes or the configured writing folder looks wrong.",
+    });
+    recommendations.push({
+      id: "diagnose_empty_index",
+      label: "Diagnose indexed structure",
+      tool: "diagnose_structure",
+      workflow_id: "parity_recovery",
+      priority: 35,
+      reason: "If sync does not discover scenes, structure diagnostics can explain missing or ambiguous manuscript representations.",
+      next_step: "Call diagnose_structure after sync if the index is still empty or project structure looks unexpected.",
+    });
+  } else {
+    recommendations.push({
+      id: "discover_indexed_scenes",
+      label: "Discover indexed scenes",
+      tool: "find_scenes",
+      workflow_id: "question_driven_discovery",
+      priority: 20,
+      reason: "Scenes are indexed; metadata-first discovery is the safest starting point for most manuscript questions.",
+      next_step: "Call find_scenes with project_id or lightweight filters before loading prose.",
+    });
+    recommendations.push({
+      id: "keyword_metadata_search",
+      label: "Search metadata keywords",
+      tool: "search_metadata",
+      workflow_id: "question_driven_discovery",
+      priority: 30,
+      reason: "Use keyword/FTS metadata search when you know likely titles, logline words, tags, characters, places, or versions.",
+      next_step: "Search exact metadata keywords, then open likely scenes with get_scene_prose if prose context is needed.",
+    });
+    recommendations.push({
+      id: "read_likely_scene",
+      label: "Read a likely scene",
+      tool: "get_scene_prose",
+      workflow_id: "targeted_scene_reading",
+      priority: 35,
+      reason: "Prose should be loaded only after metadata has identified a likely scene.",
+      next_step: "Call get_scene_prose with a specific scene_id and project_id once discovery has narrowed the target.",
+    });
+  }
+
+  if (setupContract?.setup_recommended) {
+    recommendations.push({
+      id: "review_styleguide_setup",
+      label: "Review styleguide setup",
+      tool: "setup_prose_styleguide_config",
+      workflow_id: "styleguide_setup_new",
+      priority: 40,
+      reason: `Styleguide setup status is ${setupContract.styleguide_setup_status}.`,
+      next_step: "Follow context.setup_contract.plan_preview before running styleguide drift checks or enforcement workflows.",
+    });
+  }
+
+  return recommendations
+    .sort((a, b) => a.priority - b.priority)
+    .slice(0, 5);
+}
+
 // ---------------------------------------------------------------------------
 // MCP server factory
 // ---------------------------------------------------------------------------
@@ -444,6 +538,11 @@ function createMcpServer() {
           pending_proposals: pendingProposals.size,
           db_migration_warnings: DB_STARTUP_WARNINGS,
         },
+        recommended_next_actions: buildRecommendedNextActions({
+          sceneCount: scene_count,
+          setupContract: setupContractContextCheck.value,
+          dbMigrationWarnings: DB_STARTUP_WARNINGS,
+        }),
         workflows: WORKFLOW_CATALOGUE,
         notes: [
           "Never write JavaScript or shell scripts to invoke tools. Call them directly.",

--- a/src/test/integration/metadata.test.mjs
+++ b/src/test/integration/metadata.test.mjs
@@ -297,6 +297,47 @@ describe("one-sided scene evidence tools", () => {
     const harborSearch = JSON.parse(harborSearchText);
     assert.ok(harborSearch.results.some((row) => row.scene_id === "sc-m4-place-only"));
   });
+
+  test("relationship evidence NOT_FOUND responses include actionable next steps", async () => {
+    const missingSceneText = await callWriteTool("connect_scene_character_evidence", {
+      project_id: "test-novel",
+      scene_id: "sc-missing-relationship-evidence",
+      character_id: "elena",
+    });
+    const missingScene = JSON.parse(missingSceneText);
+    assert.equal(missingScene.ok, false);
+    assert.equal(missingScene.error.code, "NOT_FOUND");
+    assert.equal(missingScene.error.details.lookup_kind, "scene");
+    assert.equal(missingScene.error.details.input, "sc-missing-relationship-evidence");
+    assert.match(missingScene.error.details.next_step, /find_scenes/);
+
+    const missingCharacterText = await callWriteTool("connect_character_place_evidence", {
+      project_id: "test-novel",
+      scene_id: "sc-001",
+      character_id: "Elena Voss",
+      place_id: "harbor-district",
+    });
+    const missingCharacter = JSON.parse(missingCharacterText);
+    assert.equal(missingCharacter.ok, false);
+    assert.equal(missingCharacter.error.code, "NOT_FOUND");
+    assert.equal(missingCharacter.error.details.lookup_kind, "character");
+    assert.equal(missingCharacter.error.details.input, "Elena Voss");
+    assert.equal(missingCharacter.error.details.scene_id, "sc-001");
+    assert.match(missingCharacter.error.details.next_step, /list_characters/);
+
+    const missingPlaceText = await callWriteTool("connect_scene_place_evidence", {
+      project_id: "test-novel",
+      scene_id: "sc-001",
+      place_id: "The Harbor District",
+    });
+    const missingPlace = JSON.parse(missingPlaceText);
+    assert.equal(missingPlace.ok, false);
+    assert.equal(missingPlace.error.code, "NOT_FOUND");
+    assert.equal(missingPlace.error.details.lookup_kind, "place");
+    assert.equal(missingPlace.error.details.input, "The Harbor District");
+    assert.equal(missingPlace.error.details.scene_id, "sc-001");
+    assert.match(missingPlace.error.details.next_step, /list_places/);
+  });
 });
 
 describe("relationship metadata boundary M5 regression", () => {

--- a/src/test/integration/runtime.test.mjs
+++ b/src/test/integration/runtime.test.mjs
@@ -342,6 +342,21 @@ describe("describe_workflows tool", () => {
     assert.equal(parsed.context.setup_contract.plan_preview.flow_id, "styleguide_setup_v1");
     assert.ok(Array.isArray(parsed.context.setup_contract.plan_preview.actions));
     assert.ok(Array.isArray(parsed.context.db_migration_warnings));
+    assert.ok(Array.isArray(parsed.recommended_next_actions));
+    assert.ok(parsed.recommended_next_actions.length >= 3);
+    assert.ok(parsed.recommended_next_actions.length <= 5);
+    assert.ok(text.indexOf('"recommended_next_actions"') < text.indexOf('"workflows"'));
+    assert.equal(
+      parsed.recommended_next_actions.some((action) => action.tool === "describe_workflows"),
+      false
+    );
+    for (const action of parsed.recommended_next_actions) {
+      assert.ok(typeof action.id === "string" && action.id.length > 0);
+      assert.ok(typeof action.label === "string" && action.label.length > 0);
+      assert.ok(typeof action.tool === "string" && action.tool.length > 0);
+      assert.ok(typeof action.reason === "string" && action.reason.length > 0);
+      assert.ok(typeof action.next_step === "string" && action.next_step.length > 0);
+    }
     assert.ok(Array.isArray(parsed.workflows));
     assert.ok(parsed.workflows.length > 0);
     assert.ok(Array.isArray(parsed.notes));

--- a/src/test/integration/search.test.mjs
+++ b/src/test/integration/search.test.mjs
@@ -595,7 +595,14 @@ describe("search_metadata tool", () => {
 
   test("search with no match returns helpful message", async () => {
     const text = await callTool("search_metadata", { query: "dragons" });
-    assert.ok(text.toLowerCase().includes("no scenes"));
+    const parsed = JSON.parse(text);
+    assert.equal(parsed.ok, false);
+    assert.equal(parsed.error.code, "NO_RESULTS");
+    assert.match(parsed.error.message, /keyword metadata search/);
+    assert.equal(parsed.error.details.search_type, "keyword_metadata_fts");
+    assert.ok(parsed.error.details.searched_fields.includes("scene.title"));
+    assert.match(parsed.error.details.next_step, /exact metadata keywords/);
+    assert.match(parsed.error.details.next_step, /not semantic or prose search/);
   });
 
   test("returns INVALID_QUERY on malformed FTS syntax", async () => {

--- a/src/test/unit/metadata-tools.test.mjs
+++ b/src/test/unit/metadata-tools.test.mjs
@@ -761,6 +761,7 @@ describe("metadata relationship outcome tools", () => {
 
       assert.equal(parsed.ok, true);
       assert.equal(parsed.action, "connected");
+      assert.equal(parsed.outcome, "connected");
       assert.equal(parsed.already_linked, false);
       assert.equal(parsed.character_id, "char-mira");
       assert.equal(parsed.note, "Mira appears without a specific place beat.");
@@ -812,7 +813,11 @@ describe("metadata relationship outcome tools", () => {
         character_id: "char-mira",
       });
       assert.equal(repeated.ok, true);
+      assert.equal(repeated.action, "connected");
+      assert.equal(repeated.outcome, "no_op");
       assert.equal(repeated.already_linked, true);
+      assert.match(repeated.next_step, /already linked/);
+      assert.match(repeated.next_step, /no canonical relationship rows changed/);
       assert.equal(
         db.prepare(`
           SELECT COUNT(*) AS count
@@ -961,6 +966,9 @@ describe("metadata relationship outcome tools", () => {
       });
 
       assert.equal(parsed.ok, true);
+      assert.equal(parsed.action, "connected");
+      assert.equal(parsed.outcome, "connected");
+      assert.equal(parsed.already_linked, false);
       assert.equal(parsed.place_id, "place-harbor");
       assert.deepEqual(parsed.scene_relationships, {
         characters: ["char-elena"],
@@ -993,6 +1001,26 @@ describe("metadata relationship outcome tools", () => {
         db.prepare(`SELECT COUNT(*) AS count FROM scenes_fts WHERE scenes_fts MATCH ?`).get('"stale-sidecar-place"').count,
         0
       );
+
+      const repeated = await tools.call("connect_scene_place_evidence", {
+        project_id: "test-novel",
+        scene_id: "sc-place-only",
+        place_id: "place-harbor",
+      });
+      assert.equal(repeated.ok, true);
+      assert.equal(repeated.action, "connected");
+      assert.equal(repeated.outcome, "no_op");
+      assert.equal(repeated.already_linked, true);
+      assert.match(repeated.next_step, /already linked/);
+      assert.match(repeated.next_step, /no canonical relationship rows changed/);
+      assert.equal(
+        db.prepare(`
+          SELECT COUNT(*) AS count
+          FROM scene_places
+          WHERE scene_id = ? AND project_id = ? AND place_id = ?
+        `).get("sc-place-only", "test-novel", "place-harbor").count,
+        1
+      );
     } finally {
       db.close();
     }
@@ -1018,8 +1046,18 @@ describe("metadata relationship outcome tools", () => {
 
       assert.equal(characterResult.ok, false);
       assert.equal(characterResult.error.code, "NOT_FOUND");
+      assert.equal(characterResult.error.details.lookup_kind, "character");
+      assert.equal(characterResult.error.details.input, "Mira Nystrom");
+      assert.equal(characterResult.error.details.project_id, "test-novel");
+      assert.equal(characterResult.error.details.scene_id, "sc-freeform-rejected");
+      assert.match(characterResult.error.details.next_step, /list_characters/);
       assert.equal(placeResult.ok, false);
       assert.equal(placeResult.error.code, "NOT_FOUND");
+      assert.equal(placeResult.error.details.lookup_kind, "place");
+      assert.equal(placeResult.error.details.input, "The old harbor");
+      assert.equal(placeResult.error.details.project_id, "test-novel");
+      assert.equal(placeResult.error.details.scene_id, "sc-freeform-rejected");
+      assert.match(placeResult.error.details.next_step, /list_places/);
       assert.equal(
         db.prepare(`SELECT COUNT(*) AS count FROM scene_characters WHERE scene_id = ? AND project_id = ?`).get("sc-freeform-rejected", "test-novel").count,
         0

--- a/src/test/unit/metadata-tools.test.mjs
+++ b/src/test/unit/metadata-tools.test.mjs
@@ -818,6 +818,8 @@ describe("metadata relationship outcome tools", () => {
       assert.equal(repeated.already_linked, true);
       assert.match(repeated.next_step, /already linked/);
       assert.match(repeated.next_step, /no canonical relationship rows changed/);
+      assert.match(repeated.next_step, /scene_relationships field/);
+      assert.match(repeated.next_step, /get_scene_prose/);
       assert.equal(
         db.prepare(`
           SELECT COUNT(*) AS count
@@ -1013,6 +1015,8 @@ describe("metadata relationship outcome tools", () => {
       assert.equal(repeated.already_linked, true);
       assert.match(repeated.next_step, /already linked/);
       assert.match(repeated.next_step, /no canonical relationship rows changed/);
+      assert.match(repeated.next_step, /scene_relationships field/);
+      assert.match(repeated.next_step, /get_scene_prose/);
       assert.equal(
         db.prepare(`
           SELECT COUNT(*) AS count

--- a/src/tools/metadata.js
+++ b/src/tools/metadata.js
@@ -161,7 +161,7 @@ function relationshipEvidenceNotFoundDetails({ lookupKind, input, projectId, sce
 }
 
 function alreadyLinkedRelationshipNextStep({ entityKind }) {
-  return `This ${entityKind} was already linked to the scene, so no canonical relationship rows changed. Use get_scene_prose or relationship read tools if you need to inspect the existing evidence.`;
+  return `This ${entityKind} was already linked to the scene, so no canonical relationship rows changed. Use the scene_relationships field in this response to inspect current links; call get_scene_prose with the scene_id and project_id if prose context is needed.`;
 }
 
 function persistReferenceDocLink({ filePath, syncDir, targetDocId, relation }) {

--- a/src/tools/metadata.js
+++ b/src/tools/metadata.js
@@ -130,6 +130,40 @@ function buildRelationshipMetadataBoundaryDetails({ projectId, sceneId, blockedF
   };
 }
 
+function relationshipEvidenceNotFoundDetails({ lookupKind, input, projectId, sceneId }) {
+  const details = {
+    lookup_kind: lookupKind,
+    input,
+    project_id: projectId,
+  };
+  if (sceneId !== undefined) {
+    details.scene_id = sceneId;
+  }
+
+  if (lookupKind === "scene") {
+    return {
+      ...details,
+      next_step: "Use find_scenes with the project_id to confirm the canonical scene_id, then retry the relationship evidence tool.",
+    };
+  }
+
+  if (lookupKind === "character") {
+    return {
+      ...details,
+      next_step: "Use list_characters to find the stable character_id for this project or universe, then retry the relationship evidence tool.",
+    };
+  }
+
+  return {
+    ...details,
+    next_step: "Use list_places to find the stable place_id for this project or universe, then retry the relationship evidence tool.",
+  };
+}
+
+function alreadyLinkedRelationshipNextStep({ entityKind }) {
+  return `This ${entityKind} was already linked to the scene, so no canonical relationship rows changed. Use get_scene_prose or relationship read tools if you need to inspect the existing evidence.`;
+}
+
 function persistReferenceDocLink({ filePath, syncDir, targetDocId, relation }) {
   const syncDirAbs = path.resolve(syncDir);
   const syncDirReal = resolveBoundaryRootReal(syncDirAbs);
@@ -862,16 +896,42 @@ export function registerMetadataTools(s, {
       WHERE scene_id = ? AND project_id = ?
     `).get(scene_id, project_id);
     if (!scene) {
-      return errorResponse("NOT_FOUND", `Scene '${scene_id}' not found in project '${project_id}'.`);
+      return errorResponse(
+        "NOT_FOUND",
+        `Scene '${scene_id}' not found in project '${project_id}'.`,
+        relationshipEvidenceNotFoundDetails({
+          lookupKind: "scene",
+          input: scene_id,
+          projectId: project_id,
+        })
+      );
     }
 
     const character = resolveCharacterForProject(db, { characterId: character_id, projectId: project_id });
     if (!character) {
-      return errorResponse("NOT_FOUND", `Character '${character_id}' is not indexed for project '${project_id}' or its universe.`);
+      return errorResponse(
+        "NOT_FOUND",
+        `Character '${character_id}' is not indexed for project '${project_id}' or its universe.`,
+        relationshipEvidenceNotFoundDetails({
+          lookupKind: "character",
+          input: character_id,
+          projectId: project_id,
+          sceneId: scene_id,
+        })
+      );
     }
     const place = resolvePlaceForProject(db, { placeId: place_id, projectId: project_id });
     if (!place) {
-      return errorResponse("NOT_FOUND", `Place '${place_id}' is not indexed for project '${project_id}' or its universe.`);
+      return errorResponse(
+        "NOT_FOUND",
+        `Place '${place_id}' is not indexed for project '${project_id}' or its universe.`,
+        relationshipEvidenceNotFoundDetails({
+          lookupKind: "place",
+          input: place_id,
+          projectId: project_id,
+          sceneId: scene_id,
+        })
+      );
     }
 
     const before = querySceneRelationshipSnapshot(db, { sceneId: scene_id, projectId: project_id });
@@ -1005,12 +1065,29 @@ export function registerMetadataTools(s, {
       WHERE scene_id = ? AND project_id = ?
     `).get(scene_id, project_id);
     if (!scene) {
-      return errorResponse("NOT_FOUND", `Scene '${scene_id}' not found in project '${project_id}'.`);
+      return errorResponse(
+        "NOT_FOUND",
+        `Scene '${scene_id}' not found in project '${project_id}'.`,
+        relationshipEvidenceNotFoundDetails({
+          lookupKind: "scene",
+          input: scene_id,
+          projectId: project_id,
+        })
+      );
     }
 
     if (!resolveEntity(entity_id)) {
       const label = entityKind[0].toUpperCase() + entityKind.slice(1);
-      return errorResponse("NOT_FOUND", `${label} '${entity_id}' is not indexed for project '${project_id}' or its universe.`);
+      return errorResponse(
+        "NOT_FOUND",
+        `${label} '${entity_id}' is not indexed for project '${project_id}' or its universe.`,
+        relationshipEvidenceNotFoundDetails({
+          lookupKind: entityKind,
+          input: entity_id,
+          projectId: project_id,
+          sceneId: scene_id,
+        })
+      );
     }
 
     const before = querySceneRelationshipSnapshot(db, { sceneId: scene_id, projectId: project_id });
@@ -1095,7 +1172,11 @@ export function registerMetadataTools(s, {
     return jsonResponse({
       ok: true,
       action: "connected",
+      outcome: alreadyLinked ? "no_op" : "connected",
       already_linked: alreadyLinked,
+      ...(alreadyLinked
+        ? { next_step: alreadyLinkedRelationshipNextStep({ entityKind }) }
+        : {}),
       scene_id,
       project_id,
       [idField]: entity_id,

--- a/src/tools/search.js
+++ b/src/tools/search.js
@@ -664,7 +664,7 @@ export function registerSearchTools(s, {
     "search_metadata",
     "Keyword/FTS metadata search across scene titles, loglines (synopsis/logline text fields), and indexed metadata keywords (tags/characters/places/versions). Use this when you know likely words or exact metadata values but do not know the scene_id or chapter. This is not semantic search and does not search prose text; use find_scenes for structured filters and get_scene_prose after identifying likely scenes. Supports pagination via page/page_size and auto-paginates large result sets with total_count.",
     {
-      query: z.string().describe("Keyword or FTS5 search terms from indexed metadata (e.g. 'hospital' or a quoted character/place/tag phrase)."),
+      query: z.string().describe("Keyword search terms from indexed metadata (e.g. 'hospital' or a quoted character/place/tag phrase). FTS5 syntax supported."),
       page: z.number().int().min(1).optional().describe("Optional page number for paginated responses (1-based)."),
       page_size: z.number().int().min(1).max(200).optional().describe("Optional page size for paginated responses (default: 20, max: 200)."),
     },

--- a/src/tools/search.js
+++ b/src/tools/search.js
@@ -662,9 +662,9 @@ export function registerSearchTools(s, {
   // ---- search_metadata -----------------------------------------------------
   s.tool(
     "search_metadata",
-    "Full-text search across scene titles, loglines (synopsis/logline text fields), and metadata keywords (tags/characters/places/versions). Use this when you don't know the exact scene_id or chapter but want to find scenes by topic, theme, or metadata keyword. Not a prose search — use get_scene_prose to read actual text. Supports pagination via page/page_size and auto-paginates large result sets with total_count.",
+    "Keyword/FTS metadata search across scene titles, loglines (synopsis/logline text fields), and indexed metadata keywords (tags/characters/places/versions). Use this when you know likely words or exact metadata values but do not know the scene_id or chapter. This is not semantic search and does not search prose text; use find_scenes for structured filters and get_scene_prose after identifying likely scenes. Supports pagination via page/page_size and auto-paginates large result sets with total_count.",
     {
-      query: z.string().describe("Search terms (e.g. 'hospital' or 'Sebastian feeding'). FTS5 syntax supported."),
+      query: z.string().describe("Keyword or FTS5 search terms from indexed metadata (e.g. 'hospital' or a quoted character/place/tag phrase)."),
       page: z.number().int().min(1).optional().describe("Optional page number for paginated responses (1-based)."),
       page_size: z.number().int().min(1).max(200).optional().describe("Optional page size for paginated responses (default: 20, max: 200)."),
     },
@@ -682,7 +682,11 @@ export function registerSearchTools(s, {
       }
 
       if (totalCount === 0) {
-        return errorResponse("NO_RESULTS", "No scenes matched the search query.");
+        return errorResponse("NO_RESULTS", "No scenes matched the keyword metadata search query.", {
+          search_type: "keyword_metadata_fts",
+          searched_fields: ["scene.title", "scene.logline", "tags", "characters", "places", "versions"],
+          next_step: "Try exact metadata keywords, quoted character/place/tag names, or find_scenes structured filters. After finding likely scenes, use get_scene_prose for prose context; search_metadata is not semantic or prose search.",
+        });
       }
 
       const shouldPaginate = totalCount > DEFAULT_METADATA_PAGE_SIZE || page !== undefined || page_size !== undefined;

--- a/src/workflows/workflow-catalogue.js
+++ b/src/workflows/workflow-catalogue.js
@@ -5,7 +5,7 @@ export const WORKFLOW_CATALOGUE = [
     use_when: "Start here for most sessions: when the user has a manuscript question, you need to narrow scope, or you are not yet sure which scene matters.",
     steps: [
       { tool: "find_scenes", note: "Use structured metadata filters first when the question already suggests characters, beats, tags, parts, chapters, or POV; numeric chapter values are read-scope aliases, while structure changes require canonical chapter_id workflows." },
-      { tool: "search_metadata", note: "Use this when the question is thematic, fuzzy, or keyword-driven rather than cleanly filterable." },
+      { tool: "search_metadata", note: "Use this when likely title, logline, tag, character, place, or version keywords are known but structured filters are not cleanly available; it is not semantic or prose search." },
       { tool: "get_scene_prose", note: "Escalate to prose only after likely scenes have been identified and metadata is no longer enough." },
       { tool: "flag_scene", note: "Use only when the current task naturally leads to recording a follow-up note for later editorial attention." },
     ],


### PR DESCRIPTION
## Summary

- Add `recommended_next_actions` to `describe_workflows` before the full workflow catalogue.
- Clarify relationship evidence responses with actionable `NOT_FOUND` details and additive no-op outcomes for already-linked one-sided evidence.
- Reword `search_metadata` as keyword/FTS metadata search, not semantic or prose search.
- Add Human Input Forgiveness active initiative docs, generated tool docs, README guidance, release-log coverage, and regression tests.

## Motivation

User testing showed that the safety model is strong, but some responses are hard to act on: workflow discovery is long, relationship lookup failures lacked next steps, already-linked one-sided evidence looked like a fresh mutation, and `search_metadata` sounded more semantic than it is.

This M1 slice improves response clarity before adding any forgiving input resolution.

## Implementation

- `describe_workflows` now returns a top-level `recommended_next_actions` array before `workflows`, with concrete next tools and no self-referential `describe_workflows` recommendation.
- Relationship evidence tools now include structured `NOT_FOUND` details such as `lookup_kind`, `input`, scope, and `next_step`.
- One-sided scene evidence success responses preserve `action: "connected"` and add `outcome`, including `outcome: "no_op"` for already-linked rows.
- `search_metadata` tool text, no-result guidance, workflow copy, README, and generated tool docs now consistently describe keyword/FTS metadata search.
- Release-log and active initiative docs document the public behavior changes and M1 scope.

## Testing

- `npm run check:pr`
- `node --experimental-sqlite --test src/test/integration/runtime.test.mjs`
- `npm run lint`
- `git diff --check`
- `npm test`
- Previous focused M1 validation: `node --experimental-sqlite --test src/test/unit/metadata-tools.test.mjs src/test/integration/runtime.test.mjs src/test/integration/search.test.mjs src/test/integration/metadata.test.mjs`

## Risks and tradeoffs

- Response changes are additive; stable IDs, SQLite authority, and mutation boundaries are unchanged.
- Already-linked one-sided evidence is labeled `outcome: "no_op"`, but the existing post-commit backup/compatibility refresh path is unchanged.
- This PR intentionally does not add fuzzy matching, name resolution, restore plan compaction, or semantic search.

## Follow-up

- M2: shared canonical target resolver.
- M3: forgiving relationship evidence inputs.
- M4: restore plan scannability.
