### PR TITLE
feat: add canonical target resolver

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -11,7 +11,7 @@ It supports metadata-first reasoning, explicit prose editing workflows, and revi
 
 Active initiative: [Human Input Forgiveness](docs/initiatives/active/human-input-forgiveness/prd.md).
 
-Current focus: M1 - Response Clarity Baseline.
+Current focus: M2 - Shared Canonical Target Resolver.
 
 Most recent completed initiative: [Relationship Metadata Boundary](docs/initiatives/done/relationship-metadata-boundary/prd.md).
 

--- a/docs/initiatives/active/human-input-forgiveness/milestones.md
+++ b/docs/initiatives/active/human-input-forgiveness/milestones.md
@@ -2,7 +2,7 @@
 
 **Status:** Active
 
-Current implementation target: M1 - Response Clarity Baseline.
+Current implementation target: M2 - Shared Canonical Target Resolver.
 
 Created: 2026-06-06.
 

--- a/src/core/canonical-target-resolution.js
+++ b/src/core/canonical-target-resolution.js
@@ -1,0 +1,405 @@
+const DEFAULT_CANDIDATE_LIMIT = 5;
+const HARD_CANDIDATE_LIMIT = 10;
+
+const MATCH_GROUP_ORDER = new Map([
+  ["exact_id", 0],
+  ["case_insensitive_id", 1],
+  ["case_insensitive_name", 2],
+  ["case_insensitive_title", 2],
+  ["near_match_suggestion", 3],
+]);
+
+function normalizeValue(value) {
+  return String(value ?? "").trim().toLowerCase();
+}
+
+function clampCandidateLimit(candidateLimit) {
+  if (!Number.isInteger(candidateLimit) || candidateLimit <= 0) {
+    return DEFAULT_CANDIDATE_LIMIT;
+  }
+  return Math.min(candidateLimit, HARD_CANDIDATE_LIMIT);
+}
+
+function getProjectUniverseId(db, projectId) {
+  return db.prepare(`SELECT universe_id FROM projects WHERE project_id = ?`).get(projectId)?.universe_id ?? null;
+}
+
+function levenshteinDistance(left, right) {
+  if (left === right) return 0;
+  if (left.length === 0) return right.length;
+  if (right.length === 0) return left.length;
+
+  const previous = Array.from({ length: right.length + 1 }, (_, index) => index);
+  const current = Array.from({ length: right.length + 1 }, () => 0);
+
+  for (let leftIndex = 1; leftIndex <= left.length; leftIndex += 1) {
+    current[0] = leftIndex;
+    for (let rightIndex = 1; rightIndex <= right.length; rightIndex += 1) {
+      const cost = left[leftIndex - 1] === right[rightIndex - 1] ? 0 : 1;
+      current[rightIndex] = Math.min(
+        current[rightIndex - 1] + 1,
+        previous[rightIndex] + 1,
+        previous[rightIndex - 1] + cost
+      );
+    }
+    for (let index = 0; index < previous.length; index += 1) {
+      previous[index] = current[index];
+    }
+  }
+
+  return previous[right.length];
+}
+
+function isNearMatch(input, value) {
+  const normalizedInput = normalizeValue(input);
+  const normalizedValue = normalizeValue(value);
+  if (!normalizedInput || !normalizedValue) return false;
+  if (normalizedInput.length < 3 || normalizedValue.length < 3) return false;
+  if (normalizedValue.includes(normalizedInput) || normalizedInput.includes(normalizedValue)) return true;
+
+  const distance = levenshteinDistance(normalizedInput, normalizedValue);
+  const threshold = Math.max(1, Math.floor(Math.max(normalizedInput.length, normalizedValue.length) / 4));
+  return distance <= threshold;
+}
+
+function sortCandidates(candidates) {
+  return [...candidates].sort((left, right) => {
+    const groupDelta = (MATCH_GROUP_ORDER.get(left.match_type) ?? 99) - (MATCH_GROUP_ORDER.get(right.match_type) ?? 99);
+    if (groupDelta !== 0) return groupDelta;
+
+    const labelDelta = normalizeValue(left.label).localeCompare(normalizeValue(right.label));
+    if (labelDelta !== 0) return labelDelta;
+
+    return left.id.localeCompare(right.id);
+  });
+}
+
+function capCandidates(candidates, candidateLimit) {
+  return sortCandidates(candidates).slice(0, clampCandidateLimit(candidateLimit));
+}
+
+function formatSceneCandidate(row, { matchedField, matchType }) {
+  return {
+    target_kind: "scene",
+    id: row.scene_id,
+    label: row.title || row.scene_id,
+    matched_field: matchedField,
+    match_type: matchType,
+    project_id: row.project_id,
+    context: {
+      project_id: row.project_id,
+      title: row.title ?? null,
+      chapter_id: row.chapter_id ?? null,
+      chapter_title: row.chapter_title ?? null,
+      timeline_position: row.timeline_position ?? null,
+    },
+  };
+}
+
+function formatCharacterCandidate(row, { matchedField, matchType }) {
+  return {
+    target_kind: "character",
+    id: row.character_id,
+    label: row.name || row.character_id,
+    matched_field: matchedField,
+    match_type: matchType,
+    project_id: row.project_id ?? null,
+    universe_id: row.universe_id ?? null,
+    context: {
+      role: row.role ?? null,
+      first_appearance: row.first_appearance ?? null,
+    },
+  };
+}
+
+function formatPlaceCandidate(row, { matchedField, matchType }) {
+  return {
+    target_kind: "place",
+    id: row.place_id,
+    label: row.name || row.place_id,
+    matched_field: matchedField,
+    match_type: matchType,
+    project_id: row.project_id ?? null,
+    universe_id: row.universe_id ?? null,
+  };
+}
+
+function buildResolvedFrom(argumentName, input, candidate) {
+  if (candidate.match_type === "exact_id") return undefined;
+  return {
+    [argumentName]: {
+      input,
+      matched_field: candidate.matched_field,
+      match_type: candidate.match_type,
+      id: candidate.id,
+    },
+  };
+}
+
+function nextStepForTargetKind(targetKind) {
+  if (targetKind === "scene") {
+    return "Use find_scenes with project_id to identify the canonical scene_id, then retry with the stable ID.";
+  }
+  if (targetKind === "character") {
+    return "Use list_characters to inspect candidate character_id values for this project or universe, then retry with the stable ID.";
+  }
+  return "Use list_places to inspect candidate place_id values for this project or universe, then retry with the stable ID.";
+}
+
+function buildResolutionFailure({ targetKind, input, projectId, universeId, candidates, candidateLimit }) {
+  const cappedCandidates = capCandidates(candidates, candidateLimit);
+  const details = {
+    lookup_kind: targetKind,
+    target_kind: targetKind,
+    input,
+    project_id: projectId,
+    ...(universeId !== undefined ? { universe_id: universeId } : {}),
+    candidate_matches: cappedCandidates,
+    next_step: nextStepForTargetKind(targetKind),
+  };
+
+  if (candidates.some(candidate => candidate.match_type !== "near_match_suggestion")) {
+    return {
+      ok: false,
+      error: {
+        code: "AMBIGUOUS_TARGET",
+        message: `${targetKind} '${input}' resolves to multiple canonical targets. Use a stable canonical ID.`,
+        details,
+      },
+    };
+  }
+
+  return {
+    ok: false,
+    error: {
+      code: "NOT_FOUND",
+      message: `${targetKind} '${input}' was not found in the provided scope.`,
+      details,
+    },
+  };
+}
+
+function buildSuccess({ targetKind, input, argumentName, row, candidate, idField, rowField }) {
+  const resolvedFrom = buildResolvedFrom(argumentName, input, candidate);
+  return {
+    ok: true,
+    target_kind: targetKind,
+    id: candidate.id,
+    [idField]: candidate.id,
+    [rowField]: row,
+    canonical: candidate.match_type === "exact_id",
+    match: {
+      matched_field: candidate.matched_field,
+      match_type: candidate.match_type,
+      id: candidate.id,
+    },
+    ...(resolvedFrom ? { resolved_from: resolvedFrom } : {}),
+  };
+}
+
+function resolveFromRows({
+  rows,
+  input,
+  targetKind,
+  idField,
+  nameField,
+  nameMatchType,
+  argumentName,
+  projectId,
+  universeId,
+  candidateLimit,
+  formatCandidate,
+}) {
+  const normalizedInput = normalizeValue(input);
+  const exactIdRows = rows.filter(row => row[idField] === input);
+  if (exactIdRows.length === 1) {
+    const candidate = formatCandidate(exactIdRows[0], { matchedField: idField, matchType: "exact_id" });
+    return buildSuccess({
+      targetKind,
+      input,
+      argumentName,
+      row: exactIdRows[0],
+      candidate,
+      idField,
+      rowField: targetKind,
+    });
+  }
+
+  const caseInsensitiveIdRows = rows.filter(row => normalizeValue(row[idField]) === normalizedInput);
+  if (caseInsensitiveIdRows.length === 1) {
+    const candidate = formatCandidate(caseInsensitiveIdRows[0], { matchedField: idField, matchType: "case_insensitive_id" });
+    return buildSuccess({
+      targetKind,
+      input,
+      argumentName,
+      row: caseInsensitiveIdRows[0],
+      candidate,
+      idField,
+      rowField: targetKind,
+    });
+  }
+  if (caseInsensitiveIdRows.length > 1) {
+    return buildResolutionFailure({
+      targetKind,
+      input,
+      projectId,
+      universeId,
+      candidateLimit,
+      candidates: caseInsensitiveIdRows.map(row => formatCandidate(row, {
+        matchedField: idField,
+        matchType: "case_insensitive_id",
+      })),
+    });
+  }
+
+  const caseInsensitiveNameRows = rows.filter(row => normalizeValue(row[nameField]) === normalizedInput);
+  if (caseInsensitiveNameRows.length === 1) {
+    const candidate = formatCandidate(caseInsensitiveNameRows[0], { matchedField: nameField, matchType: nameMatchType });
+    return buildSuccess({
+      targetKind,
+      input,
+      argumentName,
+      row: caseInsensitiveNameRows[0],
+      candidate,
+      idField,
+      rowField: targetKind,
+    });
+  }
+  if (caseInsensitiveNameRows.length > 1) {
+    return buildResolutionFailure({
+      targetKind,
+      input,
+      projectId,
+      universeId,
+      candidateLimit,
+      candidates: caseInsensitiveNameRows.map(row => formatCandidate(row, {
+        matchedField: nameField,
+        matchType: nameMatchType,
+      })),
+    });
+  }
+
+  const suggestionsById = rows
+    .filter(row => isNearMatch(input, row[idField]))
+    .map(row => formatCandidate(row, { matchedField: idField, matchType: "near_match_suggestion" }));
+  const suggestedIds = new Set(suggestionsById.map(candidate => candidate.id));
+  const suggestionsByName = rows
+    .filter(row => !suggestedIds.has(row[idField]) && isNearMatch(input, row[nameField]))
+    .map(row => formatCandidate(row, { matchedField: nameField, matchType: "near_match_suggestion" }));
+
+  return buildResolutionFailure({
+    targetKind,
+    input,
+    projectId,
+    universeId,
+    candidateLimit,
+    candidates: [...suggestionsById, ...suggestionsByName],
+  });
+}
+
+export function resolveSceneTarget(db, {
+  projectId,
+  input,
+  argumentName = "scene_id",
+  candidateLimit = DEFAULT_CANDIDATE_LIMIT,
+} = {}) {
+  const rows = db.prepare(`
+    SELECT scene_id, project_id, title, chapter_id, chapter_title, timeline_position
+    FROM scenes
+    WHERE project_id = ?
+    ORDER BY title COLLATE NOCASE, scene_id
+  `).all(projectId);
+
+  return resolveFromRows({
+    rows,
+    input,
+    targetKind: "scene",
+    idField: "scene_id",
+    nameField: "title",
+    nameMatchType: "case_insensitive_title",
+    argumentName,
+    projectId,
+    universeId: undefined,
+    candidateLimit,
+    formatCandidate: formatSceneCandidate,
+  });
+}
+
+function selectRelationshipScopedCharacters(db, { projectId }) {
+  const universeId = getProjectUniverseId(db, projectId);
+  return {
+    universeId,
+    rows: db.prepare(`
+      SELECT character_id, project_id, universe_id, name, role, first_appearance
+      FROM characters
+      WHERE project_id = ?
+        OR (universe_id IS NOT NULL AND universe_id = ?)
+        OR (project_id IS NULL AND universe_id IS NULL)
+      ORDER BY name COLLATE NOCASE, character_id
+    `).all(projectId, universeId),
+  };
+}
+
+function selectRelationshipScopedPlaces(db, { projectId }) {
+  const universeId = getProjectUniverseId(db, projectId);
+  return {
+    universeId,
+    rows: db.prepare(`
+      SELECT place_id, project_id, universe_id, name
+      FROM places
+      WHERE project_id = ?
+        OR (universe_id IS NOT NULL AND universe_id = ?)
+        OR (project_id IS NULL AND universe_id IS NULL)
+      ORDER BY name COLLATE NOCASE, place_id
+    `).all(projectId, universeId),
+  };
+}
+
+export function resolveCharacterTargetForProject(db, {
+  projectId,
+  input,
+  argumentName = "character_id",
+  candidateLimit = DEFAULT_CANDIDATE_LIMIT,
+} = {}) {
+  const { universeId, rows } = selectRelationshipScopedCharacters(db, { projectId });
+  return resolveFromRows({
+    rows,
+    input,
+    targetKind: "character",
+    idField: "character_id",
+    nameField: "name",
+    nameMatchType: "case_insensitive_name",
+    argumentName,
+    projectId,
+    universeId,
+    candidateLimit,
+    formatCandidate: formatCharacterCandidate,
+  });
+}
+
+export function resolvePlaceTargetForProject(db, {
+  projectId,
+  input,
+  argumentName = "place_id",
+  candidateLimit = DEFAULT_CANDIDATE_LIMIT,
+} = {}) {
+  const { universeId, rows } = selectRelationshipScopedPlaces(db, { projectId });
+  return resolveFromRows({
+    rows,
+    input,
+    targetKind: "place",
+    idField: "place_id",
+    nameField: "name",
+    nameMatchType: "case_insensitive_name",
+    argumentName,
+    projectId,
+    universeId,
+    candidateLimit,
+    formatCandidate: formatPlaceCandidate,
+  });
+}
+
+export const CANONICAL_TARGET_CANDIDATE_LIMITS = {
+  default: DEFAULT_CANDIDATE_LIMIT,
+  hard: HARD_CANDIDATE_LIMIT,
+};

--- a/src/test/unit/canonical-target-resolution.test.mjs
+++ b/src/test/unit/canonical-target-resolution.test.mjs
@@ -1,0 +1,416 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { openDb } from "../../core/db.js";
+import {
+  CANONICAL_TARGET_CANDIDATE_LIMITS,
+  resolveCharacterTargetForProject,
+  resolvePlaceTargetForProject,
+  resolveSceneTarget,
+} from "../../core/canonical-target-resolution.js";
+
+function seedProject(db, projectId, { universeId = null } = {}) {
+  if (universeId) {
+    db.prepare(`INSERT OR IGNORE INTO universes (universe_id, name) VALUES (?, ?)`)
+      .run(universeId, universeId);
+  }
+  db.prepare(`INSERT INTO projects (project_id, universe_id, name) VALUES (?, ?, ?)`)
+    .run(projectId, universeId, projectId);
+}
+
+function seedScene(db, {
+  projectId = "test-novel",
+  sceneId,
+  title = sceneId,
+  chapterId = null,
+  chapterTitle = null,
+  timelinePosition = null,
+} = {}) {
+  db.prepare(`
+    INSERT INTO scenes (
+      scene_id, project_id, chapter_id, title, chapter_title, timeline_position,
+      file_path, prose_checksum, metadata_stale, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    sceneId,
+    projectId,
+    chapterId,
+    title,
+    chapterTitle,
+    timelinePosition,
+    `/tmp/${sceneId}.md`,
+    "deadbeef",
+    0,
+    new Date().toISOString()
+  );
+}
+
+function seedCharacter(db, {
+  characterId,
+  projectId = null,
+  universeId = null,
+  name = characterId,
+  role = null,
+  firstAppearance = null,
+} = {}) {
+  db.prepare(`
+    INSERT INTO characters (
+      character_id, project_id, universe_id, name, role, arc_summary, first_appearance, file_path
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(characterId, projectId, universeId, name, role, null, firstAppearance, `/tmp/${characterId}.md`);
+}
+
+function seedPlace(db, {
+  placeId,
+  projectId = null,
+  universeId = null,
+  name = placeId,
+} = {}) {
+  db.prepare(`
+    INSERT INTO places (place_id, project_id, universe_id, name, file_path)
+    VALUES (?, ?, ?, ?, ?)
+  `).run(placeId, projectId, universeId, name, `/tmp/${placeId}.md`);
+}
+
+describe("canonical target resolution", () => {
+  test("resolves exact stable scene IDs without resolved_from details", () => {
+    const db = openDb(":memory:");
+    try {
+      seedProject(db, "test-novel");
+      seedScene(db, {
+        projectId: "test-novel",
+        sceneId: "sc-arrival",
+        title: "Arrival",
+        chapterId: "ch-01-arrival",
+        chapterTitle: "Arrival Chapter",
+        timelinePosition: 10,
+      });
+
+      const result = resolveSceneTarget(db, {
+        projectId: "test-novel",
+        input: "sc-arrival",
+      });
+
+      assert.equal(result.ok, true);
+      assert.equal(result.scene_id, "sc-arrival");
+      assert.equal(result.canonical, true);
+      assert.equal(result.resolved_from, undefined);
+      assert.equal(result.match.match_type, "exact_id");
+    } finally {
+      db.close();
+    }
+  });
+
+  test("resolves unique case-insensitive scene IDs and titles with canonical details", () => {
+    const db = openDb(":memory:");
+    try {
+      seedProject(db, "test-novel");
+      seedScene(db, { projectId: "test-novel", sceneId: "sc-harbor", title: "Harbor Argument" });
+
+      const idResult = resolveSceneTarget(db, {
+        projectId: "test-novel",
+        input: "SC-HARBOR",
+      });
+      const titleResult = resolveSceneTarget(db, {
+        projectId: "test-novel",
+        input: "harbor argument",
+      });
+
+      assert.equal(idResult.ok, true);
+      assert.equal(idResult.scene_id, "sc-harbor");
+      assert.deepEqual(idResult.resolved_from.scene_id, {
+        input: "SC-HARBOR",
+        matched_field: "scene_id",
+        match_type: "case_insensitive_id",
+        id: "sc-harbor",
+      });
+      assert.equal(titleResult.ok, true);
+      assert.equal(titleResult.scene_id, "sc-harbor");
+      assert.deepEqual(titleResult.resolved_from.scene_id, {
+        input: "harbor argument",
+        matched_field: "title",
+        match_type: "case_insensitive_title",
+        id: "sc-harbor",
+      });
+    } finally {
+      db.close();
+    }
+  });
+
+  test("refuses ambiguous scene titles with deterministic candidate matches", () => {
+    const db = openDb(":memory:");
+    try {
+      seedProject(db, "test-novel");
+      seedScene(db, {
+        projectId: "test-novel",
+        sceneId: "sc-b",
+        title: "Harbor Argument",
+        chapterId: "ch-02",
+        chapterTitle: "Second",
+        timelinePosition: 2,
+      });
+      seedScene(db, {
+        projectId: "test-novel",
+        sceneId: "sc-a",
+        title: "harbor argument",
+        chapterId: "ch-01",
+        chapterTitle: "First",
+        timelinePosition: 1,
+      });
+
+      const result = resolveSceneTarget(db, {
+        projectId: "test-novel",
+        input: "HARBOR ARGUMENT",
+      });
+
+      assert.equal(result.ok, false);
+      assert.equal(result.error.code, "AMBIGUOUS_TARGET");
+      assert.equal(result.error.details.lookup_kind, "scene");
+      assert.deepEqual(
+        result.error.details.candidate_matches.map(candidate => ({
+          id: candidate.id,
+          matched_field: candidate.matched_field,
+          match_type: candidate.match_type,
+          context: candidate.context,
+        })),
+        [
+          {
+            id: "sc-a",
+            matched_field: "title",
+            match_type: "case_insensitive_title",
+            context: {
+              project_id: "test-novel",
+              title: "harbor argument",
+              chapter_id: "ch-01",
+              chapter_title: "First",
+              timeline_position: 1,
+            },
+          },
+          {
+            id: "sc-b",
+            matched_field: "title",
+            match_type: "case_insensitive_title",
+            context: {
+              project_id: "test-novel",
+              title: "Harbor Argument",
+              chapter_id: "ch-02",
+              chapter_title: "Second",
+              timeline_position: 2,
+            },
+          },
+        ]
+      );
+      assert.match(result.error.details.next_step, /find_scenes/);
+    } finally {
+      db.close();
+    }
+  });
+
+  test("resolves relationship-scoped characters by project, universe, and global records only", () => {
+    const db = openDb(":memory:");
+    try {
+      seedProject(db, "test-novel", { universeId: "shared-universe" });
+      seedProject(db, "other-novel", { universeId: "other-universe" });
+      seedCharacter(db, {
+        characterId: "char-project-elena",
+        projectId: "test-novel",
+        name: "Project Elena",
+        role: "lead",
+      });
+      seedCharacter(db, {
+        characterId: "char-shared-elena",
+        universeId: "shared-universe",
+        name: "Shared Elena",
+      });
+      seedCharacter(db, {
+        characterId: "char-global-elena",
+        name: "Global Elena",
+      });
+      seedCharacter(db, {
+        characterId: "char-other-elena",
+        projectId: "other-novel",
+        universeId: "other-universe",
+        name: "Other Elena",
+      });
+
+      const projectResult = resolveCharacterTargetForProject(db, {
+        projectId: "test-novel",
+        input: "project elena",
+      });
+      const universeResult = resolveCharacterTargetForProject(db, {
+        projectId: "test-novel",
+        input: "CHAR-SHARED-ELENA",
+      });
+      const globalResult = resolveCharacterTargetForProject(db, {
+        projectId: "test-novel",
+        input: "Global Elena",
+      });
+      const otherResult = resolveCharacterTargetForProject(db, {
+        projectId: "test-novel",
+        input: "Other Elena",
+      });
+
+      assert.equal(projectResult.ok, true);
+      assert.equal(projectResult.character_id, "char-project-elena");
+      assert.equal(projectResult.character.project_id, "test-novel");
+      assert.equal(projectResult.match.match_type, "case_insensitive_name");
+      assert.equal(universeResult.ok, true);
+      assert.equal(universeResult.character_id, "char-shared-elena");
+      assert.equal(universeResult.character.universe_id, "shared-universe");
+      assert.equal(universeResult.match.match_type, "case_insensitive_id");
+      assert.equal(globalResult.ok, true);
+      assert.equal(globalResult.character_id, "char-global-elena");
+      assert.equal(globalResult.character.project_id, null);
+      assert.equal(globalResult.character.universe_id, null);
+      assert.equal(otherResult.ok, false);
+      assert.equal(otherResult.error.code, "NOT_FOUND");
+      assert.deepEqual(otherResult.error.details.candidate_matches, []);
+    } finally {
+      db.close();
+    }
+  });
+
+  test("resolves exact stable character and place IDs without broadening caller input", () => {
+    const db = openDb(":memory:");
+    try {
+      seedProject(db, "test-novel");
+      seedCharacter(db, { characterId: "char-mira", projectId: "test-novel", name: "Mira Nystrom" });
+      seedPlace(db, { placeId: "place-harbor", projectId: "test-novel", name: "Harbor District" });
+
+      const characterResult = resolveCharacterTargetForProject(db, {
+        projectId: "test-novel",
+        input: "char-mira",
+      });
+      const placeResult = resolvePlaceTargetForProject(db, {
+        projectId: "test-novel",
+        input: "place-harbor",
+      });
+
+      assert.equal(characterResult.ok, true);
+      assert.equal(characterResult.character_id, "char-mira");
+      assert.equal(characterResult.canonical, true);
+      assert.equal(characterResult.resolved_from, undefined);
+      assert.equal(characterResult.match.match_type, "exact_id");
+      assert.equal(placeResult.ok, true);
+      assert.equal(placeResult.place_id, "place-harbor");
+      assert.equal(placeResult.canonical, true);
+      assert.equal(placeResult.resolved_from, undefined);
+      assert.equal(placeResult.match.match_type, "exact_id");
+    } finally {
+      db.close();
+    }
+  });
+
+  test("refuses ambiguous character names before mutation-oriented callers can guess", () => {
+    const db = openDb(":memory:");
+    try {
+      seedProject(db, "test-novel", { universeId: "shared-universe" });
+      seedCharacter(db, { characterId: "char-project-mira", projectId: "test-novel", name: "Mira" });
+      seedCharacter(db, { characterId: "char-shared-mira", universeId: "shared-universe", name: "mira" });
+
+      const result = resolveCharacterTargetForProject(db, {
+        projectId: "test-novel",
+        input: "MIRA",
+      });
+
+      assert.equal(result.ok, false);
+      assert.equal(result.error.code, "AMBIGUOUS_TARGET");
+      assert.deepEqual(
+        result.error.details.candidate_matches.map(candidate => [candidate.id, candidate.match_type]),
+        [
+          ["char-project-mira", "case_insensitive_name"],
+          ["char-shared-mira", "case_insensitive_name"],
+        ]
+      );
+      assert.match(result.error.details.next_step, /list_characters/);
+    } finally {
+      db.close();
+    }
+  });
+
+  test("returns suggestion-only NOT_FOUND candidates with default and hard candidate caps", () => {
+    const db = openDb(":memory:");
+    try {
+      seedProject(db, "test-novel");
+      for (let index = 1; index <= 12; index += 1) {
+        seedPlace(db, {
+          placeId: `place-harbor-${String(index).padStart(2, "0")}`,
+          projectId: "test-novel",
+          name: `Harbor Gate ${String(index).padStart(2, "0")}`,
+        });
+      }
+
+      const defaultResult = resolvePlaceTargetForProject(db, {
+        projectId: "test-novel",
+        input: "Harbor",
+      });
+      const hardCapResult = resolvePlaceTargetForProject(db, {
+        projectId: "test-novel",
+        input: "Harbor",
+        candidateLimit: 99,
+      });
+
+      assert.equal(defaultResult.ok, false);
+      assert.equal(defaultResult.error.code, "NOT_FOUND");
+      assert.equal(defaultResult.error.details.candidate_matches.length, CANONICAL_TARGET_CANDIDATE_LIMITS.default);
+      assert.ok(defaultResult.error.details.candidate_matches.every(
+        candidate => candidate.match_type === "near_match_suggestion"
+      ));
+      assert.deepEqual(
+        defaultResult.error.details.candidate_matches.map(candidate => candidate.id),
+        [
+          "place-harbor-01",
+          "place-harbor-02",
+          "place-harbor-03",
+          "place-harbor-04",
+          "place-harbor-05",
+        ]
+      );
+      assert.equal(hardCapResult.error.details.candidate_matches.length, CANONICAL_TARGET_CANDIDATE_LIMITS.hard);
+      assert.match(hardCapResult.error.details.next_step, /list_places/);
+    } finally {
+      db.close();
+    }
+  });
+
+  test("resolves places with the same relationship-tool scoping rule as characters", () => {
+    const db = openDb(":memory:");
+    try {
+      seedProject(db, "test-novel", { universeId: "shared-universe" });
+      seedProject(db, "other-novel", { universeId: "other-universe" });
+      seedPlace(db, { placeId: "place-project-harbor", projectId: "test-novel", name: "Project Harbor" });
+      seedPlace(db, { placeId: "place-shared-harbor", universeId: "shared-universe", name: "Shared Harbor" });
+      seedPlace(db, { placeId: "place-global-harbor", name: "Global Harbor" });
+      seedPlace(db, { placeId: "place-other-harbor", projectId: "other-novel", name: "Other Harbor" });
+
+      const projectResult = resolvePlaceTargetForProject(db, {
+        projectId: "test-novel",
+        input: "PROJECT HARBOR",
+      });
+      const universeResult = resolvePlaceTargetForProject(db, {
+        projectId: "test-novel",
+        input: "Shared Harbor",
+      });
+      const globalResult = resolvePlaceTargetForProject(db, {
+        projectId: "test-novel",
+        input: "PLACE-GLOBAL-HARBOR",
+      });
+      const otherResult = resolvePlaceTargetForProject(db, {
+        projectId: "test-novel",
+        input: "Other Harbor",
+      });
+
+      assert.equal(projectResult.ok, true);
+      assert.equal(projectResult.place_id, "place-project-harbor");
+      assert.equal(universeResult.ok, true);
+      assert.equal(universeResult.place_id, "place-shared-harbor");
+      assert.equal(globalResult.ok, true);
+      assert.equal(globalResult.place_id, "place-global-harbor");
+      assert.equal(globalResult.match.match_type, "case_insensitive_id");
+      assert.equal(otherResult.ok, false);
+      assert.equal(otherResult.error.code, "NOT_FOUND");
+      assert.deepEqual(otherResult.error.details.candidate_matches, []);
+    } finally {
+      db.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Add an internal canonical target resolver for scenes, characters, and places.
- Support exact stable IDs, unique case-insensitive ID/name/title matches, deterministic candidate matches, and capped suggestion-only misses.
- Update Human Input Forgiveness initiative focus from M1 to M2.

## Motivation

M2 prepares the shared request-boundary resolver needed for later human-shaped relationship evidence inputs, while keeping stable IDs canonical and avoiding public tool contract changes before M3.

## Implementation

- Added `src/core/canonical-target-resolution.js` with resolver helpers for scene, character, and place targets.
- Character/place resolution follows the existing relationship-tool scope rule: project-owned, same-universe, or global records.
- Ambiguous exact/case-insensitive matches return `AMBIGUOUS_TARGET`; misses return `NOT_FOUND` with deterministic candidate details when available.
- Public MCP tools are intentionally not wired to the resolver in this milestone.

## Testing

- `node --experimental-sqlite --test src/test/unit/canonical-target-resolution.test.mjs`
- `npm run check:pr`

## Risks and tradeoffs

- This is internal infrastructure only; users will not see forgiving relationship evidence inputs until M3 wires the resolver into public tools.
- Public tool schemas should continue to own validation for blank or malformed inputs when M3 exposes this behavior.

## Follow-up

- M3: wire relationship evidence tools to the resolver and add integration tests proving ambiguous human-shaped inputs do not mutate SQLite, compatibility output, operation history, or backups.