### PR TITLE
feat: make restore plans easier to scan

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -11,7 +11,7 @@ It supports metadata-first reasoning, explicit prose editing workflows, and revi
 
 Active initiative: [Human Input Forgiveness](docs/initiatives/active/human-input-forgiveness/prd.md).
 
-Current focus: M3 - Forgiving Relationship Evidence Inputs.
+Current focus: M4 - Restore Plan Scannability.
 
 Most recent completed initiative: [Relationship Metadata Boundary](docs/initiatives/done/relationship-metadata-boundary/prd.md).
 

--- a/docs/agents/tools.md
+++ b/docs/agents/tools.md
@@ -154,7 +154,7 @@ Explicitly restore canonical SQLite chapter, scene-placement, and epigraph struc
 
 ## restore_project_from_backup
 
-Explicitly restore a project from a trusted generated project backup bundle. Defaults to dry-run planning; dry_run=false applies canonical SQLite changes transactionally after the reviewed current snapshot checksum and required destructive or cross-scope confirmations are provided. Responses include compact plan_summary and blocking_requirements for confirmation failures; include_unchanged=false suppresses unchanged row details while preserving summary counts.
+Explicitly restore a project from a trusted generated project backup bundle. Defaults to dry-run planning; dry_run=false applies canonical SQLite changes transactionally after the reviewed current snapshot checksum and required destructive or cross-scope confirmations are provided. Restore plan and confirmation-refusal responses include compact plan_summary details; confirmation refusals include blocking_requirements. include_unchanged=false suppresses unchanged row details while preserving summary counts.
 
 | Parameter | Type | Required | Description |
 | --- | --- | :---: | --- |

--- a/docs/agents/tools.md
+++ b/docs/agents/tools.md
@@ -154,7 +154,7 @@ Explicitly restore canonical SQLite chapter, scene-placement, and epigraph struc
 
 ## restore_project_from_backup
 
-Explicitly restore a project from a trusted generated project backup bundle. Defaults to dry-run planning; dry_run=false applies canonical SQLite changes transactionally after the reviewed current snapshot checksum and required destructive or cross-scope confirmations are provided.
+Explicitly restore a project from a trusted generated project backup bundle. Defaults to dry-run planning; dry_run=false applies canonical SQLite changes transactionally after the reviewed current snapshot checksum and required destructive or cross-scope confirmations are provided. Responses include compact plan_summary and blocking_requirements for confirmation failures; include_unchanged=false suppresses unchanged row details while preserving summary counts.
 
 | Parameter | Type | Required | Description |
 | --- | --- | :---: | --- |
@@ -164,6 +164,7 @@ Explicitly restore a project from a trusted generated project backup bundle. Def
 | `confirm_destructive` | `boolean` | No | Required with dry_run=false when the restore plan includes delete candidates. |
 | `confirm_cross_scope` | `boolean` | No | Required with dry_run=false when the restore plan changes universe-scoped records. |
 | `expected_current_snapshot_checksum` | `string` | No | Required with dry_run=false; pass the current_snapshot_checksum returned by the reviewed dry-run plan to guard against state changes before apply. |
+| `include_unchanged` | `boolean` | No | If false, suppress unchanged rows from plan.changes while preserving plan_summary counts. Defaults to true for compatibility. |
 
 ---
 

--- a/docs/guides/backup-recovery.md
+++ b/docs/guides/backup-recovery.md
@@ -69,11 +69,16 @@ Start with:
 ```
 
 The dry run validates the trusted backup bundle and returns a deterministic plan plus a `current_snapshot_checksum`.
+Use `plan_summary` first for create/update/delete/unchanged counts and destructive or cross-scope risk flags, then inspect `plan.changes` for row-level detail.
+By default the full plan includes unchanged rows for audit compatibility; pass `"include_unchanged": false` to suppress unchanged row details while keeping the summary counts.
 Review the plan before applying it, especially:
 
 - `delete` changes, which remove current SQLite records absent from the backup
 - `cross_scope` changes, which affect universe-scoped records represented by the project backup
 - any `refused` or conflict diagnostics
+
+When an apply request is refused because it is missing the reviewed checksum or required confirmations, read `blocking_requirements` before the longer diagnostics or plan detail.
+It lists the checksum, destructive, and cross-scope confirmations that must be resolved before retrying.
 
 To apply a trusted plan with deletes:
 
@@ -105,6 +110,7 @@ After a successful restore, run `sync`, `diagnose_project_backups`, and `export_
 - Incompatible schema: use a compatible server version or regenerate the bundle with the current version before restoring.
 - Missing prose or reference files: restore the referenced files under `WRITING_SYNC_DIR`, then retry the dry run.
 - Read-only runtime: restore requires a writable sync/runtime configuration when `dry_run=false`.
+- Confirmation refused: run a new dry run if the checksum changed, then retry apply with the reviewed checksum and any required destructive or cross-scope confirmations.
 
 ## Docker and Homeserver Notes
 

--- a/docs/initiatives/active/human-input-forgiveness/milestones.md
+++ b/docs/initiatives/active/human-input-forgiveness/milestones.md
@@ -2,7 +2,7 @@
 
 **Status:** Active
 
-Current implementation target: M3 - Forgiving Relationship Evidence Inputs.
+Current implementation target: M4 - Restore Plan Scannability.
 
 Created: 2026-06-06.
 

--- a/release-log.md
+++ b/release-log.md
@@ -6,6 +6,14 @@ This complements `CHANGELOG.md`:
 - `CHANGELOG.md` is technical and release-oriented.
 - This log is plain-language and outcome-oriented.
 
+### 2026-06-07 — Make project restore plans easier to scan
+
+- What changed: `restore_project_from_backup` now returns compact `plan_summary` data, surfaces apply blockers in `blocking_requirements`, and accepts `include_unchanged=false` to suppress unchanged row details while preserving default full-plan output.
+- Why it matters: Authors, maintainers, and AI agents can see checksum, destructive, and cross-scope restore requirements quickly during recovery without losing audit detail when they need the full plan.
+- Who is affected: Authors, maintainers, and AI agents reviewing or applying project backup restores.
+- Action needed: Start with `plan_summary` and `blocking_requirements` during recovery; use `include_unchanged=false` for shorter dry-run plans, and omit it when full unchanged-row audit detail is needed.
+- PR: TBD
+
 ### 2026-06-06 — Accept unambiguous names in relationship evidence tools
 
 - What changed: `connect_character_place_evidence`, `connect_scene_character_evidence`, and `connect_scene_place_evidence` now resolve unambiguous scene titles, character names, place names, and case variants to canonical IDs before writing relationship evidence.

--- a/release-log.md
+++ b/release-log.md
@@ -12,7 +12,7 @@ This complements `CHANGELOG.md`:
 - Why it matters: Authors, maintainers, and AI agents can see checksum, destructive, and cross-scope restore requirements quickly during recovery without losing audit detail when they need the full plan.
 - Who is affected: Authors, maintainers, and AI agents reviewing or applying project backup restores.
 - Action needed: Start with `plan_summary` and `blocking_requirements` during recovery; use `include_unchanged=false` for shorter dry-run plans, and omit it when full unchanged-row audit detail is needed.
-- PR: TBD
+- PR: [#238](https://github.com/hannasdev/mcp-writing/pull/238)
 
 ### 2026-06-06 — Accept unambiguous names in relationship evidence tools
 

--- a/src/structure/project-backup-restore.js
+++ b/src/structure/project-backup-restore.js
@@ -873,6 +873,79 @@ function buildRestorePlan(currentSnapshot, backupSnapshot, { projectId }) {
   };
 }
 
+function buildPlanSummary(plan) {
+  return {
+    totals: { ...plan.totals },
+    by_domain: plan.by_domain,
+    destructive_change_count: plan.destructive_change_count,
+    cross_scope_change_count: plan.cross_scope_change_count,
+    has_destructive_changes: plan.destructive_change_count > 0,
+    has_cross_scope_changes: plan.cross_scope_change_count > 0,
+    requires_destructive_confirmation: plan.destructive_change_count > 0,
+    requires_cross_scope_confirmation: plan.cross_scope_change_count > 0,
+  };
+}
+
+function buildPlanDetailPolicy({ includeUnchanged, omittedUnchangedChangeCount }) {
+  return {
+    include_unchanged: includeUnchanged,
+    unchanged_rows_included: includeUnchanged,
+    omitted_unchanged_change_count: omittedUnchangedChangeCount,
+    full_plan_available: true,
+    full_plan_next_step: includeUnchanged
+      ? "This response includes unchanged rows. Pass include_unchanged=false to suppress unchanged row details while keeping plan_summary counts."
+      : "Rerun the restore plan with include_unchanged=true or omit include_unchanged to retrieve unchanged row details.",
+  };
+}
+
+function applyPlanDetailPolicy(plan, { includeUnchanged }) {
+  const omittedUnchangedChangeCount = plan.changes.filter(change => change.action === "unchanged").length;
+  if (includeUnchanged) {
+    return {
+      plan,
+      planDetailPolicy: buildPlanDetailPolicy({
+        includeUnchanged,
+        omittedUnchangedChangeCount: 0,
+      }),
+    };
+  }
+
+  return {
+    plan: {
+      ...plan,
+      changes: plan.changes.filter(change => change.action !== "unchanged"),
+    },
+    planDetailPolicy: buildPlanDetailPolicy({
+      includeUnchanged,
+      omittedUnchangedChangeCount,
+    }),
+  };
+}
+
+const BLOCKING_REQUIREMENT_PRIORITY = new Map([
+  ["project_restore_current_snapshot_confirmation_required", 0],
+  ["project_restore_current_snapshot_changed", 1],
+  ["project_restore_destructive_confirmation_required", 2],
+  ["project_restore_cross_scope_confirmation_required", 3],
+]);
+
+function buildBlockingRequirements(diagnostics) {
+  return [...diagnostics]
+    .sort((left, right) => {
+      const priorityDelta =
+        (BLOCKING_REQUIREMENT_PRIORITY.get(left.type) ?? 99) -
+        (BLOCKING_REQUIREMENT_PRIORITY.get(right.type) ?? 99);
+      if (priorityDelta !== 0) return priorityDelta;
+      return left.type.localeCompare(right.type);
+    })
+    .map(diagnostic => ({
+      type: diagnostic.type,
+      message: diagnostic.message,
+      next_step: diagnostic.next_step ?? null,
+      details: diagnostic.details,
+    }));
+}
+
 function placeholders(values) {
   return values.map(() => "?").join(",") || "NULL";
 }
@@ -1059,6 +1132,7 @@ export function restoreProjectFromBackup(db, {
   confirmDestructive = false,
   confirmCrossScope = false,
   expectedCurrentSnapshotChecksum = null,
+  includeUnchanged = true,
   applicationVersion = "0.0.0",
 } = {}) {
   const resolvedBackupDir = resolveBackupDir(backupPath ?? path.join(syncDir, "project-backups", projectId));
@@ -1150,6 +1224,10 @@ export function restoreProjectFromBackup(db, {
   }
 
   const plan = buildRestorePlan(current.snapshot, snapshot, { projectId });
+  const planSummary = buildPlanSummary(plan);
+  const { plan: responsePlan, planDetailPolicy } = applyPlanDetailPolicy(plan, {
+    includeUnchanged: includeUnchanged !== false,
+  });
   const applyDiagnostics = [];
   if (dryRun === false) {
     if (typeof expectedCurrentSnapshotChecksum !== "string" || expectedCurrentSnapshotChecksum === "") {
@@ -1222,8 +1300,11 @@ export function restoreProjectFromBackup(db, {
       dry_run: Boolean(dryRun),
       project_id: projectId,
       backup_dir: resolvedBackupDir,
+      blocking_requirements: buildBlockingRequirements(applyDiagnostics),
       diagnostics: applyDiagnostics,
-      plan,
+      plan_summary: planSummary,
+      plan_detail_policy: planDetailPolicy,
+      plan: responsePlan,
       next_step: "Resolve confirmation requirements before applying this trusted backup.",
     };
   }
@@ -1259,7 +1340,9 @@ export function restoreProjectFromBackup(db, {
           },
           { severity: "error", nextStep: "Review the database error and retry after resolving conflicts." }
         )],
-        plan,
+        plan_summary: planSummary,
+        plan_detail_policy: planDetailPolicy,
+        plan: responsePlan,
         next_step: "Resolve restore write diagnostics before retrying.",
       };
     }
@@ -1279,7 +1362,9 @@ export function restoreProjectFromBackup(db, {
     },
     current_snapshot_checksum: current.checksum,
     backup_snapshot_checksum: manifest.checksums.canonical_snapshot_sha256,
-    plan,
+    plan_summary: planSummary,
+    plan_detail_policy: planDetailPolicy,
+    plan: responsePlan,
     applied: dryRun ? null : {
       restored: true,
       destructive_confirmed: Boolean(confirmDestructive),

--- a/src/structure/project-backup-restore.js
+++ b/src/structure/project-backup-restore.js
@@ -899,7 +899,6 @@ function buildPlanDetailPolicy({ includeUnchanged, omittedUnchangedChangeCount }
 }
 
 function applyPlanDetailPolicy(plan, { includeUnchanged }) {
-  const omittedUnchangedChangeCount = plan.changes.filter(change => change.action === "unchanged").length;
   if (includeUnchanged) {
     return {
       plan,
@@ -910,10 +909,20 @@ function applyPlanDetailPolicy(plan, { includeUnchanged }) {
     };
   }
 
+  const visibleChanges = [];
+  let omittedUnchangedChangeCount = 0;
+  for (const change of plan.changes) {
+    if (change.action === "unchanged") {
+      omittedUnchangedChangeCount += 1;
+    } else {
+      visibleChanges.push(change);
+    }
+  }
+
   return {
     plan: {
       ...plan,
-      changes: plan.changes.filter(change => change.action !== "unchanged"),
+      changes: visibleChanges,
     },
     planDetailPolicy: buildPlanDetailPolicy({
       includeUnchanged,

--- a/src/test/integration/sync.test.mjs
+++ b/src/test/integration/sync.test.mjs
@@ -7,6 +7,10 @@ import yaml from "js-yaml";
 import { spawnServer, waitForServer, waitForExit, connectClient } from "../helpers/server.js";
 import { copyDirSync, createScrivenerDraftFixture, createScrivenerProjectBundleFixture } from "../helpers/fixtures.js";
 import { createTestContext } from "../helpers/server.js";
+import {
+  computeProjectBackupBundleChecksum,
+  computeProjectBackupSnapshotChecksum,
+} from "../../structure/project-backup.js";
 
 const ctx = createTestContext(3079, 3078);
 let writeSyncDir, readSyncDir;
@@ -30,6 +34,30 @@ after(async () => {
 const callTool = (n, a) => ctx.callTool(n, a);
 const callWriteTool = (n, a) => ctx.callWriteTool(n, a);
 const waitForAsyncJob = (id, t) => ctx.waitForAsyncJob(id, t);
+
+function rewriteBackupSnapshotWithValidChecksums(relativeBackupDir, snapshot) {
+  const backupDir = path.join(writeSyncDir, ...relativeBackupDir.split("/"));
+  const manifestPath = path.join(backupDir, "manifest.json");
+  const snapshotPath = path.join(backupDir, "canonical.snapshot.json");
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  const nextManifestBase = {
+    ...manifest,
+    checksums: {
+      ...manifest.checksums,
+      canonical_snapshot_sha256: computeProjectBackupSnapshotChecksum(snapshot),
+    },
+  };
+  const nextManifest = {
+    ...nextManifestBase,
+    checksums: {
+      ...nextManifestBase.checksums,
+      bundle_sha256: computeProjectBackupBundleChecksum({ manifest: nextManifestBase, snapshot }),
+    },
+  };
+  fs.writeFileSync(snapshotPath, `${JSON.stringify(snapshot, null, 2)}\n`, "utf8");
+  fs.writeFileSync(manifestPath, `${JSON.stringify(nextManifest, null, 2)}\n`, "utf8");
+}
+
 describe("sync tool", () => {
   test("returns scene indexed count after initial sync", async () => {
     const text = await callTool("sync");
@@ -251,6 +279,9 @@ describe("sync tool", () => {
     assert.equal(parsed.action, "planned");
     assert.equal(parsed.dry_run, true);
     assert.equal(parsed.plan.destructive_change_count >= 1, true);
+    assert.equal(parsed.plan_summary.destructive_change_count >= 1, true);
+    assert.equal(parsed.plan_detail_policy.include_unchanged, true);
+    assert.ok(parsed.plan.changes.some(change => change.action === "unchanged"));
     assert.ok(parsed.plan.changes.some(change => (
       change.domain === "chapters" &&
       change.action === "delete" &&
@@ -262,6 +293,141 @@ describe("sync tool", () => {
     });
     const chapters = JSON.parse(chaptersText);
     assert.ok(chapters.results.some(chapter => chapter.chapter_id === "ch-100-restore-dry-run-extra"));
+  });
+
+  test("restore_project_from_backup can suppress unchanged plan rows", async () => {
+    await callWriteTool("export_project_backup", {
+      project_id: "test-novel",
+      output_dir: "compact-restore-backups/test-novel",
+    });
+
+    await callWriteTool("create_chapter", {
+      project_id: "test-novel",
+      title: "Restore Compact Extra Chapter",
+      sort_index: 102,
+      chapter_id: "ch-102-restore-compact-extra",
+    });
+
+    const text = await callWriteTool("restore_project_from_backup", {
+      project_id: "test-novel",
+      backup_path: "compact-restore-backups/test-novel",
+      include_unchanged: false,
+    });
+    const parsed = JSON.parse(text);
+
+    assert.equal(parsed.ok, true);
+    assert.equal(parsed.plan_summary.totals.unchanged > 0, true);
+    assert.equal(parsed.plan.totals.unchanged, parsed.plan_summary.totals.unchanged);
+    assert.equal(parsed.plan.changes.some(change => change.action === "unchanged"), false);
+    assert.equal(parsed.plan_detail_policy.include_unchanged, false);
+    assert.equal(
+      parsed.plan_detail_policy.omitted_unchanged_change_count,
+      parsed.plan_summary.totals.unchanged
+    );
+    assert.ok(parsed.plan.changes.some(change => (
+      change.domain === "chapters" &&
+      change.action === "delete" &&
+      change.identity.chapter_id === "ch-102-restore-compact-extra"
+    )));
+  });
+
+  test("restore_project_from_backup surfaces checksum and destructive blockers first", async () => {
+    await callWriteTool("export_project_backup", {
+      project_id: "test-novel",
+      output_dir: "refusal-backups/test-novel",
+    });
+
+    await callWriteTool("create_chapter", {
+      project_id: "test-novel",
+      title: "Restore Refusal Extra Chapter",
+      sort_index: 103,
+      chapter_id: "ch-103-restore-refusal-extra",
+    });
+
+    const missingChecksumText = await callWriteTool("restore_project_from_backup", {
+      project_id: "test-novel",
+      backup_path: "refusal-backups/test-novel",
+      dry_run: false,
+    });
+    const missingChecksum = JSON.parse(missingChecksumText);
+
+    assert.equal(missingChecksum.ok, false);
+    assert.deepEqual(missingChecksum.blocking_requirements.map(requirement => requirement.type), [
+      "project_restore_current_snapshot_confirmation_required",
+      "project_restore_destructive_confirmation_required",
+    ]);
+    assert.equal(missingChecksum.plan_summary.requires_destructive_confirmation, true);
+    assert.equal(missingChecksum.plan_summary.destructive_change_count >= 1, true);
+
+    const reviewedText = await callWriteTool("restore_project_from_backup", {
+      project_id: "test-novel",
+      backup_path: "refusal-backups/test-novel",
+    });
+    const reviewed = JSON.parse(reviewedText);
+
+    await callWriteTool("create_chapter", {
+      project_id: "test-novel",
+      title: "Restore Refusal Changed Chapter",
+      sort_index: 104,
+      chapter_id: "ch-104-restore-refusal-changed",
+    });
+
+    const changedChecksumText = await callWriteTool("restore_project_from_backup", {
+      project_id: "test-novel",
+      backup_path: "refusal-backups/test-novel",
+      dry_run: false,
+      confirm_destructive: true,
+      expected_current_snapshot_checksum: reviewed.current_snapshot_checksum,
+    });
+    const changedChecksum = JSON.parse(changedChecksumText);
+
+    assert.equal(changedChecksum.ok, false);
+    assert.equal(changedChecksum.blocking_requirements[0].type, "project_restore_current_snapshot_changed");
+    assert.equal(
+      changedChecksum.blocking_requirements[0].details.expected_current_snapshot_checksum,
+      reviewed.current_snapshot_checksum
+    );
+  });
+
+  test("restore_project_from_backup surfaces cross-scope blockers", async () => {
+    await callWriteTool("export_project_backup", {
+      project_id: "test-novel",
+      output_dir: "cross-scope-restore-backups/test-novel",
+    });
+    const snapshotPath = path.join(writeSyncDir, "cross-scope-restore-backups", "test-novel", "canonical.snapshot.json");
+    const snapshot = JSON.parse(fs.readFileSync(snapshotPath, "utf8"));
+    rewriteBackupSnapshotWithValidChecksums("cross-scope-restore-backups/test-novel", {
+      ...snapshot,
+      project: {
+        ...snapshot.project,
+        universe_id: "shared-restore-universe",
+      },
+      universe: {
+        universe_id: "shared-restore-universe",
+        name: "Shared Restore Universe",
+      },
+    });
+
+    const reviewedText = await callWriteTool("restore_project_from_backup", {
+      project_id: "test-novel",
+      backup_path: "cross-scope-restore-backups/test-novel",
+    });
+    const reviewed = JSON.parse(reviewedText);
+
+    const text = await callWriteTool("restore_project_from_backup", {
+      project_id: "test-novel",
+      backup_path: "cross-scope-restore-backups/test-novel",
+      dry_run: false,
+      expected_current_snapshot_checksum: reviewed.current_snapshot_checksum,
+    });
+    const parsed = JSON.parse(text);
+
+    assert.equal(parsed.ok, false);
+    assert.deepEqual(parsed.blocking_requirements.map(requirement => requirement.type), [
+      "project_restore_cross_scope_confirmation_required",
+    ]);
+    assert.equal(parsed.plan_summary.requires_cross_scope_confirmation, true);
+    assert.equal(parsed.plan_summary.cross_scope_change_count >= 1, true);
   });
 
   test("restore_project_from_backup applies confirmed restore plans transactionally", async () => {
@@ -296,6 +462,7 @@ describe("sync tool", () => {
     assert.equal(parsed.action, "restored");
     assert.equal(parsed.dry_run, false);
     assert.equal(parsed.applied.restored, true);
+    assert.equal(parsed.plan_summary.destructive_change_count >= 1, true);
     assert.ok(parsed.plan.changes.some(change => (
       change.domain === "chapters" &&
       change.action === "delete" &&

--- a/src/test/unit/project-backup-restore.test.mjs
+++ b/src/test/unit/project-backup-restore.test.mjs
@@ -180,6 +180,13 @@ describe("restoreProjectFromBackup", () => {
     assert.equal(result.plan.totals.update, 0);
     assert.equal(result.plan.totals.delete, 0);
     assert.ok(result.plan.totals.unchanged > 0);
+    assert.deepEqual(result.plan_summary.totals, result.plan.totals);
+    assert.equal(result.plan_summary.has_destructive_changes, false);
+    assert.equal(result.plan_summary.has_cross_scope_changes, false);
+    assert.equal(result.plan_detail_policy.include_unchanged, true);
+    assert.equal(result.plan_detail_policy.unchanged_rows_included, true);
+    assert.equal(result.plan_detail_policy.omitted_unchanged_change_count, 0);
+    assert.ok(result.plan.changes.some(change => change.action === "unchanged"));
     assert.deepEqual(result.diagnostics, []);
     assert.deepEqual(
       built.snapshot.character_relationships.map(row => [row.from_character, row.to_character, row.scene_id, row.note]),
@@ -214,6 +221,30 @@ describe("restoreProjectFromBackup", () => {
     assert.ok(result.plan.changes.some(change => change.domain === "chapters" && change.action === "create"));
     assert.ok(result.plan.changes.some(change => change.domain === "scenes" && change.action === "update"));
     assert.ok(result.plan.changes.some(change => change.domain === "scene_tags" && change.action === "delete"));
+  }));
+
+  test("suppresses unchanged restore rows only when requested", () => withFixture(({ db, syncDir, backupDir }) => {
+    exportBackup(db, syncDir, backupDir);
+    db.prepare(`
+      UPDATE scenes
+      SET title = ?
+      WHERE project_id = ? AND scene_id = ?
+    `).run("Changed Scene", "test-novel", "sc-first");
+
+    const result = restorePlan(db, syncDir, backupDir, { includeUnchanged: false });
+
+    assert.equal(result.ok, true);
+    assert.ok(result.plan_summary.totals.unchanged > 0);
+    assert.equal(result.plan.totals.unchanged, result.plan_summary.totals.unchanged);
+    assert.equal(result.plan.changes.some(change => change.action === "unchanged"), false);
+    assert.equal(result.plan_detail_policy.include_unchanged, false);
+    assert.equal(result.plan_detail_policy.unchanged_rows_included, false);
+    assert.equal(
+      result.plan_detail_policy.omitted_unchanged_change_count,
+      result.plan_summary.totals.unchanged
+    );
+    assert.match(result.plan_detail_policy.full_plan_next_step, /include_unchanged=true/);
+    assert.ok(result.plan.changes.some(change => change.domain === "scenes" && change.action === "update"));
   }));
 
   test("plans project creation when current SQLite state is missing the project", () => withFixture(({ db, syncDir, backupDir }) => {
@@ -878,6 +909,9 @@ describe("restoreProjectFromBackup", () => {
     assert.equal(result.ok, false);
     assert.equal(result.action, "restore_refused");
     assert.deepEqual(result.diagnostics.map(diagnostic => diagnostic.type), ["project_restore_destructive_confirmation_required"]);
+    assert.deepEqual(result.blocking_requirements.map(requirement => requirement.type), ["project_restore_destructive_confirmation_required"]);
+    assert.equal(result.plan_summary.destructive_change_count, 1);
+    assert.equal(result.plan_summary.requires_destructive_confirmation, true);
     assert.equal(result.plan.destructive_change_count, 1);
     assert.equal(
       db.prepare(`SELECT COUNT(*) AS count FROM scene_tags WHERE project_id = ? AND tag = ?`).get("test-novel", "extra-current-tag").count,
@@ -893,11 +927,32 @@ describe("restoreProjectFromBackup", () => {
     assert.equal(result.ok, false);
     assert.equal(result.action, "restore_refused");
     assert.deepEqual(result.diagnostics.map(diagnostic => diagnostic.type), ["project_restore_current_snapshot_confirmation_required"]);
+    assert.deepEqual(result.blocking_requirements.map(requirement => requirement.type), ["project_restore_current_snapshot_confirmation_required"]);
+    assert.equal(result.plan_summary.requires_destructive_confirmation, false);
+    assert.equal(result.plan_summary.requires_cross_scope_confirmation, false);
     assert.equal(result.plan.totals.delete, 0);
     assert.equal(
       db.prepare(`SELECT COUNT(*) AS count FROM scenes WHERE project_id = ?`).get("test-novel").count,
       1
     );
+  }));
+
+  test("leads confirmation refusals with checksum requirement before other blockers", () => withFixture(({ db, syncDir, backupDir }) => {
+    exportBackup(db, syncDir, backupDir);
+    db.prepare(`
+      INSERT INTO scene_tags (scene_id, project_id, tag)
+      VALUES (?, ?, ?)
+    `).run("sc-first", "test-novel", "extra-current-tag");
+
+    const result = restorePlan(db, syncDir, backupDir, { dryRun: false });
+
+    assert.equal(result.ok, false);
+    assert.deepEqual(result.blocking_requirements.map(requirement => requirement.type), [
+      "project_restore_current_snapshot_confirmation_required",
+      "project_restore_destructive_confirmation_required",
+    ]);
+    assert.match(result.blocking_requirements[0].next_step, /current_snapshot_checksum/);
+    assert.equal(result.plan_summary.destructive_change_count, 1);
   }));
 
   test("refuses apply when current SQLite state changed after dry-run review", () => withFixture(({ db, syncDir, backupDir }) => {
@@ -1000,6 +1055,9 @@ describe("restoreProjectFromBackup", () => {
     assert.equal(result.ok, false);
     assert.equal(result.action, "restore_refused");
     assert.deepEqual(result.diagnostics.map(diagnostic => diagnostic.type), ["project_restore_cross_scope_confirmation_required"]);
+    assert.deepEqual(result.blocking_requirements.map(requirement => requirement.type), ["project_restore_cross_scope_confirmation_required"]);
+    assert.equal(result.plan_summary.cross_scope_change_count, 1);
+    assert.equal(result.plan_summary.requires_cross_scope_confirmation, true);
     assert.equal(result.plan.cross_scope_change_count, 1);
     assert.equal(
       db.prepare(`SELECT COUNT(*) AS count FROM universes WHERE universe_id = ?`).get("shared-universe").count,

--- a/src/tools/sync.js
+++ b/src/tools/sync.js
@@ -338,7 +338,7 @@ export function registerSyncTools(s, {
 
   s.tool(
     "restore_project_from_backup",
-    "Explicitly restore a project from a trusted generated project backup bundle. Defaults to dry-run planning; dry_run=false applies canonical SQLite changes transactionally after the reviewed current snapshot checksum and required destructive or cross-scope confirmations are provided.",
+    "Explicitly restore a project from a trusted generated project backup bundle. Defaults to dry-run planning; dry_run=false applies canonical SQLite changes transactionally after the reviewed current snapshot checksum and required destructive or cross-scope confirmations are provided. Responses include compact plan_summary and blocking_requirements for confirmation failures; include_unchanged=false suppresses unchanged row details while preserving summary counts.",
     {
       project_id: z.string().describe("Project ID to restore (e.g. 'test-novel' or 'universe-1/book-1-the-lamb')."),
       backup_path: z.string().optional().describe("Path under WRITING_SYNC_DIR to a project backup directory, manifest.json, or canonical.snapshot.json. Defaults to project-backups/<project_id>."),
@@ -346,8 +346,9 @@ export function registerSyncTools(s, {
       confirm_destructive: z.boolean().optional().describe("Required with dry_run=false when the restore plan includes delete candidates."),
       confirm_cross_scope: z.boolean().optional().describe("Required with dry_run=false when the restore plan changes universe-scoped records."),
       expected_current_snapshot_checksum: z.string().optional().describe("Required with dry_run=false; pass the current_snapshot_checksum returned by the reviewed dry-run plan to guard against state changes before apply."),
+      include_unchanged: z.boolean().optional().describe("If false, suppress unchanged rows from plan.changes while preserving plan_summary counts. Defaults to true for compatibility."),
     },
-    async ({ project_id, backup_path, dry_run = true, confirm_destructive = false, confirm_cross_scope = false, expected_current_snapshot_checksum = null } = {}) => {
+    async ({ project_id, backup_path, dry_run = true, confirm_destructive = false, confirm_cross_scope = false, expected_current_snapshot_checksum = null, include_unchanged = true } = {}) => {
       if (!SYNC_DIR_WRITABLE && dry_run === false) {
         return errorResponse("READ_ONLY", "Cannot restore project from backup: server is in read-only mode for canonical structure mutations.");
       }
@@ -374,6 +375,7 @@ export function registerSyncTools(s, {
           confirmDestructive: confirm_destructive,
           confirmCrossScope: confirm_cross_scope,
           expectedCurrentSnapshotChecksum: expected_current_snapshot_checksum,
+          includeUnchanged: include_unchanged,
           applicationVersion: MCP_SERVER_VERSION,
         }));
       } catch (error) {

--- a/src/tools/sync.js
+++ b/src/tools/sync.js
@@ -338,7 +338,7 @@ export function registerSyncTools(s, {
 
   s.tool(
     "restore_project_from_backup",
-    "Explicitly restore a project from a trusted generated project backup bundle. Defaults to dry-run planning; dry_run=false applies canonical SQLite changes transactionally after the reviewed current snapshot checksum and required destructive or cross-scope confirmations are provided. Responses include compact plan_summary and blocking_requirements for confirmation failures; include_unchanged=false suppresses unchanged row details while preserving summary counts.",
+    "Explicitly restore a project from a trusted generated project backup bundle. Defaults to dry-run planning; dry_run=false applies canonical SQLite changes transactionally after the reviewed current snapshot checksum and required destructive or cross-scope confirmations are provided. Restore plan and confirmation-refusal responses include compact plan_summary details; confirmation refusals include blocking_requirements. include_unchanged=false suppresses unchanged row details while preserving summary counts.",
     {
       project_id: z.string().describe("Project ID to restore (e.g. 'test-novel' or 'universe-1/book-1-the-lamb')."),
       backup_path: z.string().optional().describe("Path under WRITING_SYNC_DIR to a project backup directory, manifest.json, or canonical.snapshot.json. Defaults to project-backups/<project_id>."),


### PR DESCRIPTION
## Summary

- Add compact `plan_summary` and `plan_detail_policy` fields to project backup restore responses.
- Surface restore apply blockers through ordered `blocking_requirements`.
- Add `include_unchanged=false` so callers can suppress unchanged restore rows while preserving default full-plan compatibility.

## Motivation

Restore workflows can be stressful, and large unchanged plan rows made the actionable checksum, destructive, or cross-scope requirements harder to spot. This keeps the safety model intact while making recovery responses easier for authors, maintainers, and agents to scan.

## Implementation

- Builds a compact restore plan summary from the full restore plan without changing restore safety decisions.
- Filters unchanged `plan.changes` rows only when explicitly requested with `include_unchanged=false`.
- Keeps the default response compatible by including unchanged rows unless callers opt out.
- Orders confirmation blockers so checksum requirements appear before destructive and cross-scope confirmations.
- Updates generated tool docs, recovery guidance, initiative focus, and release-log coverage.

## Testing

- `node --experimental-sqlite --test src/test/unit/project-backup-restore.test.mjs`
- `node --experimental-sqlite --test --test-concurrency=1 src/test/integration/sync.test.mjs`
- `npm run lint`
- `npm test`
- `git diff --check`
- `npm run check:pr`

## Risks and tradeoffs

- Response additions are additive, but clients that snapshot full restore responses may need fixture updates.
- Default full-plan detail is preserved for compatibility; shorter plans are opt-in via `include_unchanged=false`.

## Follow-up

None.