### PR TITLE
ci: skip PR template check for Dependabot

### DIFF
--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -20,6 +20,13 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
+            const prAuthor = context.payload.pull_request.user?.login;
+
+            if (prAuthor === "dependabot[bot]") {
+              core.notice("Skipping PR template validation for Dependabot-generated dependency update.");
+              return;
+            }
+
             const body = context.payload.pull_request.body || "";
             const requiredSections = [
               "## Summary",


### PR DESCRIPTION
## Summary

- Skip PR template validation for PRs authored by `dependabot[bot]`.
- Keep the existing required-section and testing-evidence checks for all other PR authors.

## Motivation

Dependabot dependency PRs use generated descriptions that do not follow the repository's human PR template. This caused repeated noisy `PR Template Check` failures even when the actual CI checks passed.

## Implementation

- Added an early author check in the `PR Template Check` GitHub Script.
- Emits a workflow notice when skipping Dependabot-generated dependency PRs.
- Leaves the existing validation path unchanged for human-authored PRs.

## Testing

- `git diff --check`
- `node --input-type=module -e '...'` validating:
  - Dependabot PR body skips without failure
  - Valid human PR body passes
  - Incomplete human PR body fails
- Not run: full `npm run check:pr`; this change only affects a GitHub Actions workflow script.

## Risks and tradeoffs

All PRs authored by `dependabot[bot]` intentionally bypass this human-description gate. CI, security, and other required checks still run separately.

## Follow-up

None