### PR TITLE
fix: tighten MCP response contracts

### DIFF
--- a/release-log.md
+++ b/release-log.md
@@ -6,6 +6,13 @@ This complements `CHANGELOG.md`:
 - `CHANGELOG.md` is technical and release-oriented.
 - This log is plain-language and outcome-oriented.
 
+### 2026-06-11 — Tighten MCP response contract feedback
+
+- What changed: MCP tool responses now set `isError: true` whenever the JSON envelope reports `ok: false`; suggestion-bearing target misses expose `suggestions_available`; `find_scenes` returns `resolved_from` for non-canonical read filters; `sync` classifies no-`scene_id` files as ignored non-manuscript files; and `get_runtime_config` reports the active transport.
+- Why it matters: Authors and AI agents can trust the MCP error flag, distinguish hard misses from retryable suggested targets, see interpreted inputs explicitly, and avoid Docker/SSE versus stdio confusion during smoke tests.
+- Who is affected: Authors, maintainers, and AI agents using MCP clients, forgiving lookup paths, sync summaries, `find_scenes`, or runtime diagnostics.
+- Action needed: Treat `isError` as authoritative for `ok: false` tool envelopes, inspect `suggestions_available` before retrying with a canonical ID, and use `get_runtime_config.transport` to confirm the connected server mode.
+
 ### 2026-06-07 — Document Human Input Forgiveness replay and rollout
 
 - What changed: Added a user-facing canonical ID and forgiving-input contract note, audited generated tool reference coverage, and recorded temp-fixture replay evidence for the original Human Input Forgiveness feedback scenarios.

--- a/release-log.md
+++ b/release-log.md
@@ -12,6 +12,7 @@ This complements `CHANGELOG.md`:
 - Why it matters: Authors and AI agents can trust the MCP error flag, distinguish hard misses from retryable suggested targets, see interpreted inputs explicitly, and avoid Docker/SSE versus stdio confusion during smoke tests.
 - Who is affected: Authors, maintainers, and AI agents using MCP clients, forgiving lookup paths, sync summaries, `find_scenes`, or runtime diagnostics.
 - Action needed: Treat `isError` as authoritative for `ok: false` tool envelopes, inspect `suggestions_available` before retrying with a canonical ID, and use `get_runtime_config.transport` to confirm the connected server mode.
+- PR: [#242](https://github.com/hannasdev/mcp-writing/pull/242)
 
 ### 2026-06-07 — Document Human Input Forgiveness replay and rollout
 

--- a/src/core/canonical-target-resolution.js
+++ b/src/core/canonical-target-resolution.js
@@ -114,6 +114,7 @@ function buildResolutionFailure({ targetKind, input, projectId, universeId, cand
     input,
     project_id: projectId,
     ...(universeId !== undefined ? { universe_id: universeId } : {}),
+    suggestions_available: cappedCandidates.length > 0,
     candidate_matches: cappedCandidates,
     next_step: nextStepForTargetKind(targetKind),
   };

--- a/src/index.js
+++ b/src/index.js
@@ -134,7 +134,10 @@ function paginateRows(rows, { page, pageSize, forcePagination = false }) {
 }
 
 function jsonResponse(payload) {
-  return { content: [{ type: "text", text: JSON.stringify(payload, null, 2) }] };
+  return {
+    content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
+    ...(payload?.ok === false ? { isError: true } : {}),
+  };
 }
 
 function errorResponse(code, message, details) {
@@ -612,6 +615,7 @@ function createMcpServer() {
     async () => {
       return jsonResponse({
         server_version: MCP_SERVER_VERSION,
+        transport: MCP_TRANSPORT === "stdio" ? "stdio" : "http",
         sync_dir: SYNC_DIR_ABS,
         db_path: DB_PATH_DISPLAY,
         db_migration_warnings: DB_STARTUP_WARNINGS,

--- a/src/sync/sync.js
+++ b/src/sync/sync.js
@@ -1688,7 +1688,7 @@ export function observeOrphanedSidecars(syncDir, { indexedSceneIds = new Set() }
 }
 
 const WARNING_TYPE_LABELS = {
-  no_scene_id: "Skipped (no scene_id)",
+  no_scene_id: "Ignored non-manuscript files",
   duplicate_scene_id: "Duplicate scene_id",
   path_metadata_mismatch: "Path/metadata mismatch",
   chapter_structure: "Chapter structure",
@@ -1703,7 +1703,7 @@ const WARNING_TYPE_LABELS = {
 };
 
 const WARNING_PATTERNS = [
-  { type: "no_scene_id",            re: /^Skipped \(no scene_id\):/  },
+  { type: "no_scene_id",            re: /^Ignored non-manuscript file \(no scene_id\):/  },
   { type: "duplicate_scene_id",     re: /^Duplicate scene_id/        },
   { type: "path_metadata_mismatch", re: /^Path\/metadata mismatch/   },
   { type: "chapter_structure",      re: /^(Chapter structure warning|Epigraph requires explicit chapter linkage|Epigraph references unknown chapter_id|Scene references unknown chapter_id|Ambiguous chapter linkage|Epigraph identity conflict|Managed structure sync ignored|Managed structure sync preserved canonical epigraph)/ },
@@ -1718,6 +1718,7 @@ const WARNING_PATTERNS = [
 ];
 
 const MAX_WARNING_EXAMPLES = 5;
+const INFO_WARNING_TYPES = new Set(["no_scene_id"]);
 
 export function buildWarningSummary(warnings) {
   const summary = {};
@@ -1725,7 +1726,14 @@ export function buildWarningSummary(warnings) {
     const firstLine = w.split("\n")[0];
     const match = WARNING_PATTERNS.find(p => p.re.test(firstLine));
     const type = match?.type ?? "other";
-    if (!summary[type]) summary[type] = { count: 0, examples: [] };
+    if (!summary[type]) {
+      summary[type] = {
+        count: 0,
+        examples: [],
+        severity: INFO_WARNING_TYPES.has(type) ? "info" : "warning",
+        label: WARNING_TYPE_LABELS[type] ?? type,
+      };
+    }
     summary[type].count++;
     if (summary[type].examples.length < MAX_WARNING_EXAMPLES) {
       summary[type].examples.push(firstLine);
@@ -1799,7 +1807,7 @@ export function syncAll(db, syncDir, { quiet = false, writable = false, relation
 
       if (!meta.scene_id && !chapterStructure.isEpigraph) {
         skipped++;
-        if (!quiet) warnings.push(`Skipped (no scene_id): ${structureObservation.relativePath}`);
+        if (!quiet) warnings.push(`Ignored non-manuscript file (no scene_id): ${structureObservation.relativePath}`);
         continue;
       }
 
@@ -1921,12 +1929,13 @@ export function syncAll(db, syncDir, { quiet = false, writable = false, relation
       `[mcp-writing] Sync complete: ${indexed} scenes indexed, ${staleMarked} scenes marked stale` +
       (epigraphsIndexed ? `, ${epigraphsIndexed} epigraphs indexed, ${epigraphsStaleMarked} epigraphs marked stale` : "") +
       (sidecarsMigrated ? `, ${sidecarsMigrated} sidecars auto-generated` : "") +
-      (skipped ? `, ${skipped} files skipped` : "") + "\n"
+      (skipped ? `, ${skipped} non-manuscript file(s) ignored` : "") + "\n"
     );
     for (const [type, entry] of Object.entries(warningSummary)) {
       const count = entry.count;
       const label = WARNING_TYPE_LABELS[type] ?? type;
-      process.stderr.write(`[mcp-writing] WARNING: ${label}: ${count} file(s). First example: ${entry.examples[0]}\n`);
+      const level = entry.severity === "info" ? "INFO" : "WARNING";
+      process.stderr.write(`[mcp-writing] ${level}: ${label}: ${count} file(s). First example: ${entry.examples[0]}\n`);
     }
   }
   return {

--- a/src/test/integration/metadata.test.mjs
+++ b/src/test/integration/metadata.test.mjs
@@ -422,6 +422,7 @@ describe("one-sided scene evidence tools", () => {
     assert.equal(missingCharacter.error.details.lookup_kind, "character");
     assert.equal(missingCharacter.error.details.input, "Elena Vosz");
     assert.equal(missingCharacter.error.details.scene_id, "sc-001");
+    assert.equal(missingCharacter.error.details.suggestions_available, true);
     assert.ok(missingCharacter.error.details.candidate_matches.some(candidate => candidate.id === "elena"));
     assert.match(missingCharacter.error.details.next_step, /list_characters/);
 
@@ -436,6 +437,7 @@ describe("one-sided scene evidence tools", () => {
     assert.equal(missingPlace.error.details.lookup_kind, "place");
     assert.equal(missingPlace.error.details.input, "The Harbor Distrikt");
     assert.equal(missingPlace.error.details.scene_id, "sc-001");
+    assert.equal(missingPlace.error.details.suggestions_available, true);
     assert.ok(missingPlace.error.details.candidate_matches.some(candidate => candidate.id === "harbor-district"));
     assert.match(missingPlace.error.details.next_step, /list_places/);
   });

--- a/src/test/integration/runtime.test.mjs
+++ b/src/test/integration/runtime.test.mjs
@@ -40,6 +40,7 @@ describe("get_runtime_config tool", () => {
     assert.equal(parsed.sync_dir, readSyncDir);
     assert.equal(parsed.db_path, ":memory:");
     assert.equal(parsed.http_port, READ_PORT);
+    assert.equal(parsed.transport, "http");
 
     assert.equal(typeof parsed.sync_dir_writable, "boolean");
     assert.equal(typeof parsed.git_available, "boolean");
@@ -313,6 +314,15 @@ describe("error envelope consistency", () => {
       assert.equal(typeof parsed.error.message, "string");
       assert.ok(parsed.error.message.length > 0);
     }
+  });
+
+  test("sets MCP isError when JSON payload reports ok false", async () => {
+    const result = await ctx.callToolResult("get_scene_prose", { scene_id: "sc-999" });
+    const parsed = JSON.parse(result.content?.[0]?.text ?? "{}");
+
+    assert.equal(result.isError, true);
+    assert.equal(parsed.ok, false);
+    assert.equal(parsed.error.code, "NOT_FOUND");
   });
 });
 

--- a/src/test/integration/search.test.mjs
+++ b/src/test/integration/search.test.mjs
@@ -59,6 +59,12 @@ describe("search tools integration suite", { concurrency: 1 }, () => {
       match_type: "case_insensitive_name",
       id: "elena",
     });
+    assert.deepEqual(characterParsed.resolved_from.character, {
+      input: "Elena Voss",
+      matched_field: "name",
+      match_type: "case_insensitive_name",
+      id: "elena",
+    });
 
     const povText = await callWriteTool("find_scenes", {
       project_id: "test-novel",
@@ -223,6 +229,16 @@ describe("search tools integration suite", { concurrency: 1 }, () => {
     assert.equal(missingPov.error.details.argument, "pov");
     assert.equal(missingPov.error.details.project_id, "test-novel");
     assert.match(missingPov.error.details.next_step, /list_characters/);
+
+    const suggestedCharacterText = await callWriteTool("find_scenes", {
+      project_id: "test-novel",
+      character: "Elena Vosz",
+    });
+    const suggestedCharacter = JSON.parse(suggestedCharacterText);
+    assert.equal(suggestedCharacter.ok, false);
+    assert.equal(suggestedCharacter.error.code, "NOT_FOUND");
+    assert.equal(suggestedCharacter.error.details.suggestions_available, true);
+    assert.ok(suggestedCharacter.error.details.candidate_matches.some(candidate => candidate.id === "elena"));
   });
 
   test("filters by character: marcus appears in 2 scenes", async () => {

--- a/src/test/integration/stdio-cli.test.mjs
+++ b/src/test/integration/stdio-cli.test.mjs
@@ -39,6 +39,7 @@ test("CLI wrapper serves MCP over stdio by default", async () => {
 
     assert.equal(payload.sync_dir, syncDir, `CLI wrapper should initialize successfully. stderr:\n${stderr}`);
     assert.equal(payload.db_path, ":memory:");
+    assert.equal(payload.transport, "stdio");
   } finally {
     await client.close().catch(() => {});
     fs.rmSync(syncDir, { recursive: true, force: true });

--- a/src/test/integration/sync.test.mjs
+++ b/src/test/integration/sync.test.mjs
@@ -1601,9 +1601,9 @@ describe("sync warning_summary", () => {
     const text = await callWriteTool("sync");
 
     assert.match(text, /Warning summary:/);
-    assert.match(text, /missing_canonical_scene: 1/);
-    assert.match(text, /missing_canonical_chapter: 1/);
-    assert.match(text, /missing_canonical_epigraph: 1/);
+    assert.match(text, /Missing canonical scene: 1/);
+    assert.match(text, /Missing canonical chapter: 1/);
+    assert.match(text, /Missing canonical epigraph: 1/);
   });
 });
 

--- a/src/test/unit/sync.test.mjs
+++ b/src/test/unit/sync.test.mjs
@@ -799,14 +799,20 @@ describe("warning summary", () => {
       nested_mirror: {
         count: 1,
         examples: ["Ignored nested mirror path: projects/test-novel/scenes/projects/test-novel/scenes/sc-001.md"],
+        severity: "warning",
+        label: "Ignored nested mirror path",
       },
       chapter_structure: {
         count: 1,
         examples: ["Scene references unknown chapter_id 'ch-99-missing': projects/test-novel/scenes/sc-001.md"],
+        severity: "warning",
+        label: "Chapter structure",
       },
       other: {
         count: 1,
         examples: ["Something uncategorized happened"],
+        severity: "warning",
+        label: "other",
       },
     });
   });
@@ -2252,7 +2258,7 @@ describe("syncAll", () => {
     fs.rmSync(dir, { recursive: true });
   });
 
-  test("skips files without scene_id", () => {
+  test("classifies files without scene_id as ignored non-manuscript files", () => {
     const dir = makeTempSync();
     const db = openDb(":memory:");
     // A file with no scene_id in frontmatter
@@ -2260,8 +2266,15 @@ describe("syncAll", () => {
       path.join(dir, "projects", "test-novel", "scenes", "notes.md"),
       "---\ntitle: Just a note\n---\nSome text."
     );
-    const result = syncAll(db, dir, { quiet: true });
+    const result = syncAll(db, dir, { quiet: false });
     assert.equal(result.indexed, 0);
+    assert.equal(result.skipped, 1);
+    assert.equal(result.warningSummary.no_scene_id.severity, "info");
+    assert.equal(result.warningSummary.no_scene_id.label, "Ignored non-manuscript files");
+    assert.equal(
+      result.warningSummary.no_scene_id.examples[0],
+      "Ignored non-manuscript file (no scene_id): projects/test-novel/scenes/notes.md"
+    );
 
     db.close();
     fs.rmSync(dir, { recursive: true });

--- a/src/tools/search.js
+++ b/src/tools/search.js
@@ -485,13 +485,15 @@ export function registerSearchTools(s, {
         pageSize: page_size,
         forcePagination: rows.length > DEFAULT_METADATA_PAGE_SIZE,
       });
+      const resolvedFrom = mergeResolvedFilters(resolvedFilters);
 
       const payload = paged.paginated
         ? {
             results: paged.rows,
             ...paged.meta,
             warning,
-            resolved_filters: mergeResolvedFilters(resolvedFilters),
+            resolved_filters: resolvedFrom,
+            resolved_from: resolvedFrom,
             next_step: staleCount > 0
               ? "Touch stale scenes as you work and run enrich_scene(scene_id, project_id) to recover metadata parity incrementally."
               : undefined,
@@ -500,7 +502,8 @@ export function registerSearchTools(s, {
             results: rows,
             total_count: rows.length,
             warning,
-            resolved_filters: mergeResolvedFilters(resolvedFilters),
+            resolved_filters: resolvedFrom,
+            resolved_from: resolvedFrom,
             next_step: staleCount > 0
               ? "Touch stale scenes as you work and run enrich_scene(scene_id, project_id) to recover metadata parity incrementally."
               : undefined,

--- a/src/tools/sync.js
+++ b/src/tools/sync.js
@@ -60,14 +60,22 @@ export function registerSyncTools(s, {
     }
     if (result.sidecarsMigrated) parts.push(`${result.sidecarsMigrated} sidecar(s) auto-generated from frontmatter.`);
     if (result.skipped) {
-      parts.push(`${result.skipped} file(s) skipped (no scene_id).`);
-      parts.push(`Tip: for raw Scrivener Draft exports, run src/scripts/import.js first, then run sync again.`);
+      parts.push(`${result.skipped} non-manuscript file(s) ignored because they did not declare scene_id.`);
+      parts.push(`Tip: if these are raw Scrivener Draft scene exports, run src/scripts/import.js first, then run sync again.`);
     }
     const summary = result.warningSummary;
     const summaryEntries = Object.entries(summary);
     if (summaryEntries.length) {
-      const lines = summaryEntries.map(([type, entry]) => `- ${type}: ${entry.count} (e.g. ${entry.examples[0]})`);
-      parts.push(`\n⚠️ Warning summary:\n` + lines.join("\n"));
+      const infoEntries = summaryEntries.filter(([, entry]) => entry.severity === "info");
+      const warningEntries = summaryEntries.filter(([, entry]) => entry.severity !== "info");
+      if (infoEntries.length) {
+        const lines = infoEntries.map(([type, entry]) => `- ${entry.label ?? type}: ${entry.count} (e.g. ${entry.examples[0]})`);
+        parts.push(`\nIgnored file summary:\n` + lines.join("\n"));
+      }
+      if (warningEntries.length) {
+        const lines = warningEntries.map(([type, entry]) => `- ${entry.label ?? type}: ${entry.count} (e.g. ${entry.examples[0]})`);
+        parts.push(`\nWarning summary:\n` + lines.join("\n"));
+      }
     }
     return { content: [{ type: "text", text: parts.join(" ") }] };
   });


### PR DESCRIPTION
## Summary

- Set MCP `isError: true` whenever a JSON tool envelope reports `ok: false`.
- Add response transparency for forgiving resolution paths: `suggestions_available`, `resolved_from`, and runtime `transport`.
- Reclassify sync files without `scene_id` as ignored non-manuscript files instead of warnings.

## Motivation

Smoke testing showed that the resolver behavior was useful, but some response contracts were easy for MCP clients and agents to misread. In particular, callers had to inspect JSON bodies instead of trusting `isError`, sync summaries sounded more alarming than intended, and resolved or suggested inputs were not always visible enough.

## Implementation

- Updated shared JSON response handling so structured `ok: false` payloads set MCP `isError`.
- Kept suggestion-bearing misses as `NOT_FOUND`, but added `suggestions_available` for cleaner client handling.
- Added `resolved_from` alongside existing `resolved_filters` in `find_scenes`; this is additive and does not replace `resolved_filters`.
- Added `transport` to `get_runtime_config`; `transport: "http"` covers the HTTP/SSE server path.
- Adjusted sync warning summaries so no-`scene_id` files are info-level ignored non-manuscript files.
- Added a release-log entry for the behavior change.

## Testing

- `npm run check:pr`

## Risks and tradeoffs

- Suggested misses still use `NOT_FOUND`; clients should use `suggestions_available` to distinguish retryable suggested targets.
- `transport: "http"` is intentionally the runtime mode label for HTTP/SSE connections, not the literal string `"sse"`.
- `resolved_from` duplicates some `resolved_filters` content for read-filter transparency.

## Follow-up

- Consider README or generated docs wording for these response-contract fields if client authors need a durable reference beyond the release log.
